### PR TITLE
Set ingress host and TLS secret name in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,7 +5,8 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: community-payback-ui-dev.hmpps.service.justice.gov.uk
+    host: community-payback-dev.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-community-payback-dev-cert
 
   env:
     INGRESS_URL: "https://community-payback-ui-dev.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
We think these were set incorrectly before, causing security alerts in the browser when trying to access the service.