### PR TITLE
Run E2E tests on self hosted runner

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   e2e_test:
     name: Run the e2e tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, hmpps-github-actions-runner]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is necessary to run our Playwright E2E tests within HMPPS.