### PR TITLE
Pass username to API system token call

### DIFF
--- a/server/data/communityPaybackApiClient.test.ts
+++ b/server/data/communityPaybackApiClient.test.ts
@@ -27,7 +27,7 @@ describe('CommunityPaybackApiClient', () => {
         .matchHeader('authorization', 'Bearer test-system-token')
         .reply(200, { data: 'some data' })
 
-      const response = await communityPaybackApiClient.getExampleData()
+      const response = await communityPaybackApiClient.getExampleData('some-username')
 
       expect(response).toEqual({ data: 'some data' })
     })

--- a/server/data/communityPaybackApiClient.ts
+++ b/server/data/communityPaybackApiClient.ts
@@ -8,7 +8,7 @@ export default class CommunityPaybackApiClient extends RestClient {
     super('Community Payback API', config.apis.communityPaybackApi, logger, authenticationClient)
   }
 
-  getExampleData() {
-    return this.get({ path: '/example' }, asSystem())
+  getExampleData(username: string) {
+    return this.get({ path: '/example' }, asSystem(username))
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -9,7 +9,7 @@ export default function routes({ auditService, exampleService }: Services): Rout
   router.get('/', async (req, res, next) => {
     await auditService.logPageView(Page.EXAMPLE_PAGE, { who: res.locals.user.username, correlationId: req.id })
 
-    const exampleData = await exampleService.getExampleData()
+    const exampleData = await exampleService.getExampleData(res.locals.user.username)
     return res.render('pages/index', { exampleData })
   })
 

--- a/server/services/exampleService.test.ts
+++ b/server/services/exampleService.test.ts
@@ -16,7 +16,7 @@ describe('ExampleService', () => {
 
     communityPaybackApiClient.getExampleData.mockResolvedValue(expectedData)
 
-    const result = await exampleService.getExampleData()
+    const result = await exampleService.getExampleData('some-username')
 
     expect(communityPaybackApiClient.getExampleData).toHaveBeenCalledTimes(1)
     expect(result).toEqual(expectedData)

--- a/server/services/exampleService.ts
+++ b/server/services/exampleService.ts
@@ -3,7 +3,7 @@ import CommunityPaybackApiClient from '../data/communityPaybackApiClient'
 export default class ExampleService {
   constructor(private readonly communityPaybackApiClient: CommunityPaybackApiClient) {}
 
-  getExampleData() {
-    return this.communityPaybackApiClient.getExampleData()
+  getExampleData(username: string) {
+    return this.communityPaybackApiClient.getExampleData(username)
   }
 }


### PR DESCRIPTION
This will allow at API to identify who is making the request whilst still following[ the system token approach that is preferred within HMPPS](https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/4632379405/RFC+4+-+Role+Protecting+API+Endpoints).