### PR TITLE
Revert "Merge pull request #23 from ministryofjustice/renovate-slackapi-slack-github-action-2.x"

### DIFF
--- a/.github/actions/slack_failure_notification/action.yml
+++ b/.github/actions/slack_failure_notification/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+    - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
       with:
         channel-id: ${{ inputs.channel_id }}
         payload: |


### PR DESCRIPTION
This reverts commit 43c59b1ee7997c50bc204b11a9a0518341a4e5d1, reversing changes made to fe1b5f2af4b95691ea896a198e225cd014b3b7ff. The update seems to have broken Slack notifications for E2E test failures.