### PR TITLE
CPB-85: Automate API type generation in UI repository

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -1,0 +1,46 @@
+name: Generate Types
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-types:
+    runs-on: [self-hosted, hmpps-github-actions-runner]
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Generate Types
+        run: ./script/generate-types ${{ vars.API_SPEC_URL }}
+
+      # We need to use a GitHub App token rather than a Github token to ensure further workflows are triggered when opening a pull request in the next step.
+      # See: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+      - name: Generate Token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'API model updates'
+          commit-message: 'Updating community-payback-api models from OpenAPI specification'
+          body: 'Updating community-payback-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
+          delete-branch: true
+          branch: update-api-types
+          base: main


### PR DESCRIPTION
This adds a workflow to automate the generation of types from the Community Payback API Schema when changes are made (script added in #34). 

It is copied from similar workflows in the Approved Premises projects ([example](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/blob/main/.github/workflows/generate-types.yml)), with some changes:
- Remove the client id and secret set in env, these do not seem to be needed (and should be stored in secrets if they are).
- Add a permissions block for writing pull requests

Tested this workflow works correctly and triggers further runs with pull request checks by triggering #45 from this pull request (and then changing the workflow trigger back to `on: workflow_call`).

## Why a GitHub App token

We had some discussion about why we needed a GitHub App Token rather than the Github token for use with the create pull request action, and it was noted that with a Github Token further workflows will not be triggered on the opened PR. We need this in order to run checks against the newly added types. 

See details here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

Relates to [CPB-85](https://dsdmoj.atlassian.net/browse/CPB-85)

[CPB-85]: https://dsdmoj.atlassian.net/browse/CPB-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ