### PR TITLE
Replace example E2E test with basic test of session search journey

### DIFF
--- a/e2e-tests/tests/01_make_a_call_to_cp_api.spec.ts
+++ b/e2e-tests/tests/01_make_a_call_to_cp_api.spec.ts
@@ -1,9 +1,0 @@
-import { expect } from '@playwright/test'
-import test from '../test'
-
-import signIn from '../steps/signIn'
-
-test('make a call to the Community Payback API', async ({ page, deliusUser }) => {
-  await signIn(page, deliusUser)
-  await expect(page.locator('p').first()).toContainText('"apiName":"hmpps-community-payback-api"')
-})

--- a/e2e-tests/tests/01_search_sessions.spec.ts
+++ b/e2e-tests/tests/01_search_sessions.spec.ts
@@ -1,0 +1,11 @@
+import { expect } from '@playwright/test'
+import test from '../test'
+
+import signIn from '../steps/signIn'
+
+test('Search project sessions', async ({ page, deliusUser }) => {
+  await signIn(page, deliusUser)
+  await expect(page.locator('h1')).toContainText('Community Payback')
+  await page.getByRole('link', { name: 'Search sessions' }).click()
+  await expect(page.locator('h1')).toContainText('Search sessions')
+})


### PR DESCRIPTION
The example journey no longer exists, so I've replaced the E2E test with a basic test of the session search journey so far.