### PR TITLE
Update content on find a session page

### DIFF
--- a/e2e-tests/tests/01_search_sessions.spec.ts
+++ b/e2e-tests/tests/01_search_sessions.spec.ts
@@ -6,6 +6,6 @@ import signIn from '../steps/signIn'
 test('Search project sessions', async ({ page, deliusUser }) => {
   await signIn(page, deliusUser)
   await expect(page.locator('h1')).toContainText('Community Payback')
-  await page.getByRole('link', { name: 'Search sessions' }).click()
-  await expect(page.locator('h1')).toContainText('Search sessions')
+  await page.getByRole('link', { name: 'Track progress on Community Payback' }).click()
+  await expect(page.locator('h1')).toContainText('Track progress on Community Payback')
 })

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -34,6 +34,7 @@ describe('SessionsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('sessions/show', {
         teamItems: [{ value: 1001, text: 'Team Lincoln' }],
+        sessions: [],
       })
     })
   })

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -1,5 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 import ProviderService from '../services/providerService'
+import { ProjectAllocationDto } from '../@types/shared'
 
 export default class SessionsController {
   constructor(private readonly providerService: ProviderService) {}
@@ -14,7 +15,9 @@ export default class SessionsController {
         text: team.name,
       }))
 
-      res.render('sessions/show', { teamItems })
+      const sessions: Array<ProjectAllocationDto> = []
+
+      res.render('sessions/show', { teamItems, sessions })
     }
   }
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -12,9 +12,9 @@
     <div class="card">
       <div class="card-body">
         <h2 class="govuk-heading-s">
-          <a class="govuk-link" href="{{ paths.sessions.show() }}">Search sessions</a>
+          <a class="govuk-link" href="{{ paths.sessions.show() }}">Track progress on Community Payback</a>
         </h2>
-        <p class="govuk-body">Search and filter project sessions by team and date</p>
+        <p class="govuk-body">Find a project session and track a person's progress</p>
       </div>
     </div>
   </div>

--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -4,22 +4,22 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = applicationName + " - Search sessions" %}
+{% set pageTitle = applicationName + " - Track progress on Community Payback" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 
-  <h1>Search sessions</h1>
+  <h1>Track progress on Community Payback</h1>
 
   <form action="" method="get" class="search-and-filter">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <h2 class="govuk-heading-m">Filters</h2>
+    <h2 class="govuk-heading-m">Find a session</h2>
 
     <div class="search-and-filter__row">
       {{ govukSelect({
           label: {
-              text: "Provider",
+              text: "Region",
               classes: "govuk-label--s"
           },
           id: "provider",
@@ -67,13 +67,15 @@
 
     {{ govukButton({
       "name": "submit",
-      "text": "Apply filters",
+      "text": "Search",
       preventDoubleClick: true
     }) }}
     </div>
 
   </form>
 
-  {% include "./_table.njk" %}
+  {% if sessions | length %}
+    {% include "./_table.njk" %}
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
There are a few content tweaks here, including labelling ‘Provider’ as ‘Region’ for users. This is at odds with its name in the rest of the UI and API codebase and something we may wish to change when we have slightly more confidence in the correct language.

I have also set the session table to conditionally render if there are session results passed into the template, to avoid confusion when the search page first loads.

<img width="1264" height="609" alt="Screenshot 2025-09-15 at 15 57 12" src="https://github.com/user-attachments/assets/b1caf6a2-ffa3-46e6-8bd6-5bd9a9551932" />
