### PR TITLE
CPB 108: Add UI services for retrieving options in session update forms

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ import HmppsAuditClient from './hmppsAuditClient'
 import logger from '../../logger'
 import ProviderClient from './providerClient'
 import SessionClient from './sessionClient'
+import ReferenceDataClient from './referenceDataClient'
 
 export const dataAccess = () => {
   const hmppsAuthClient = new AuthenticationClient(
@@ -31,6 +32,7 @@ export const dataAccess = () => {
     providerClient: new ProviderClient(hmppsAuthClient),
     hmppsAuditClient: new HmppsAuditClient(config.sqs.audit),
     sessionClient: new SessionClient(hmppsAuthClient),
+    referenceDataClient: new ReferenceDataClient(hmppsAuthClient),
   }
 }
 

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -59,5 +59,24 @@ describe('ReferenceDataClient', () => {
 
       expect(response).toEqual(enforcementActions)
     })
+
+    it('should make a GET request to the contact-outcomes path using user token and return the response body', async () => {
+      const contactOutcomes = {
+        contactOutcomes: [
+          {
+            id: 1001,
+            name: 'Cleaning',
+          },
+        ],
+      }
+      nock(config.apis.communityPaybackApi.url)
+        .get(path.referenceData.contactOutcomes.pattern)
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200, contactOutcomes)
+
+      const response = await referenceDataClient.getContactOutcomes('some-username')
+
+      expect(response).toEqual(contactOutcomes)
+    })
   })
 })

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -40,5 +40,24 @@ describe('ReferenceDataClient', () => {
 
       expect(response).toEqual(projectTypes)
     })
+
+    it('should make a GET request to the enforment-actions path using user token and return the response body', async () => {
+      const enforcementActions = {
+        enforcementActions: [
+          {
+            id: 1001,
+            name: 'Cleaning',
+          },
+        ],
+      }
+      nock(config.apis.communityPaybackApi.url)
+        .get(path.referenceData.enforcementActions.pattern)
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200, enforcementActions)
+
+      const response = await referenceDataClient.getEnforcementActions('some-username')
+
+      expect(response).toEqual(enforcementActions)
+    })
   })
 })

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -1,0 +1,44 @@
+import nock from 'nock'
+import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
+import config from '../config'
+import ReferenceDataClient from './referenceDataClient'
+import path from '../paths/api'
+
+describe('ReferenceDataClient', () => {
+  let referenceDataClient: ReferenceDataClient
+  let mockAuthenticationClient: jest.Mocked<AuthenticationClient>
+
+  beforeEach(() => {
+    mockAuthenticationClient = {
+      getToken: jest.fn().mockResolvedValue('test-system-token'),
+    } as unknown as jest.Mocked<AuthenticationClient>
+
+    referenceDataClient = new ReferenceDataClient(mockAuthenticationClient)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    jest.resetAllMocks()
+  })
+
+  describe('getProjectTypes', () => {
+    it('should make a GET request to the project types path using user token and return the response body', async () => {
+      const projectTypes = {
+        projectTypes: [
+          {
+            id: 1001,
+            name: 'Cleaning',
+          },
+        ],
+      }
+      nock(config.apis.communityPaybackApi.url)
+        .get(path.referenceData.projectTypes.pattern)
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200, projectTypes)
+
+      const response = await referenceDataClient.getProjectTypes('some-username')
+
+      expect(response).toEqual(projectTypes)
+    })
+  })
+})

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,0 +1,17 @@
+import { RestClient, asSystem } from '@ministryofjustice/hmpps-rest-client'
+import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
+import config from '../config'
+import logger from '../../logger'
+import paths from '../paths/api'
+import { ProjectTypesDto } from '../@types/shared'
+
+export default class ReferenceDataClient extends RestClient {
+  constructor(authenticationClient: AuthenticationClient) {
+    super('referenceDataClient', config.apis.communityPaybackApi, logger, authenticationClient)
+  }
+
+  getProjectTypes(username: string): Promise<ProjectTypesDto> {
+    const path = paths.referenceData.projectTypes.pattern
+    return this.get({ path }, asSystem(username))
+  }
+}

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -3,7 +3,7 @@ import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients
 import config from '../config'
 import logger from '../../logger'
 import paths from '../paths/api'
-import { EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
+import { ContactOutcomesDto, EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
 
 export default class ReferenceDataClient extends RestClient {
   constructor(authenticationClient: AuthenticationClient) {
@@ -17,6 +17,11 @@ export default class ReferenceDataClient extends RestClient {
 
   getEnforcementActions(username: string): Promise<EnforcementActionsDto> {
     const path = paths.referenceData.enforcementActions.pattern
+    return this.get({ path }, asSystem(username))
+  }
+
+  getContactOutcomes(username: string): Promise<ContactOutcomesDto> {
+    const path = paths.referenceData.contactOutcomes.pattern
     return this.get({ path }, asSystem(username))
   }
 }

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -3,7 +3,7 @@ import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients
 import config from '../config'
 import logger from '../../logger'
 import paths from '../paths/api'
-import { ProjectTypesDto } from '../@types/shared'
+import { EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
 
 export default class ReferenceDataClient extends RestClient {
   constructor(authenticationClient: AuthenticationClient) {
@@ -12,6 +12,11 @@ export default class ReferenceDataClient extends RestClient {
 
   getProjectTypes(username: string): Promise<ProjectTypesDto> {
     const path = paths.referenceData.projectTypes.pattern
+    return this.get({ path }, asSystem(username))
+  }
+
+  getEnforcementActions(username: string): Promise<EnforcementActionsDto> {
+    const path = paths.referenceData.enforcementActions.pattern
     return this.get({ path }, asSystem(username))
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -14,5 +14,6 @@ export default {
   referenceData: {
     projectTypes: referenceDataPath.path('project-types'),
     enforcementActions: referenceDataPath.path('enforce-ment-actions'),
+    contactOutcomes: referenceDataPath.path('contact-outcomes'),
   },
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -13,5 +13,6 @@ export default {
   },
   referenceData: {
     projectTypes: referenceDataPath.path('project-types'),
+    enforcementActions: referenceDataPath.path('enforce-ment-actions'),
   },
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -2,6 +2,7 @@ import { path } from 'static-path'
 
 const providersPath = path('/providers')
 const projectsPath = path('/projects')
+const referenceDataPath = path('/references')
 
 export default {
   providers: {
@@ -9,5 +10,8 @@ export default {
   },
   projects: {
     sessions: projectsPath.path('allocations'),
+  },
+  referenceData: {
+    projectTypes: referenceDataPath.path('project-types'),
   },
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -2,15 +2,17 @@ import { dataAccess } from '../data'
 import AuditService from './auditService'
 import ProviderService from './providerService'
 import SessionService from './sessionService'
+import ReferenceDataService from './referenceDataService'
 
 export const services = () => {
-  const { applicationInfo, hmppsAuditClient, providerClient, sessionClient } = dataAccess()
+  const { applicationInfo, hmppsAuditClient, providerClient, sessionClient, referenceDataClient } = dataAccess()
 
   return {
     applicationInfo,
     auditService: new AuditService(hmppsAuditClient),
     providerService: new ProviderService(providerClient),
     sessionService: new SessionService(sessionClient),
+    referenceDataService: new ReferenceDataService(referenceDataClient),
   }
 }
 

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -29,4 +29,23 @@ describe('ReferenceDataService', () => {
     expect(referenceDataClient.getProjectTypes).toHaveBeenCalledTimes(1)
     expect(result).toEqual(projectTypes)
   })
+
+  it('should call getEnforcementActions on the api client and return its result', async () => {
+    const enforcementActions = {
+      enforcementActions: [
+        {
+          id: '1001',
+          name: 'Team Lincoln',
+          code: '12',
+        },
+      ],
+    }
+
+    referenceDataClient.getEnforcementActions.mockResolvedValue(enforcementActions)
+
+    const result = await referenceDataService.getEnforcementActions('some-username')
+
+    expect(referenceDataClient.getEnforcementActions).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(enforcementActions)
+  })
 })

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -1,0 +1,32 @@
+import ReferenceDataClient from '../data/referenceDataClient'
+import ReferenceDataService from './referenceDataService'
+
+jest.mock('../data/referenceDataClient')
+
+describe('ReferenceDataService', () => {
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+  let referenceDataService: ReferenceDataService
+
+  beforeEach(() => {
+    referenceDataService = new ReferenceDataService(referenceDataClient)
+  })
+
+  it('should call getProjectTypes on the api client and return its result', async () => {
+    const projectTypes = {
+      projectTypes: [
+        {
+          id: '1001',
+          name: 'Team Lincoln',
+          code: '12',
+        },
+      ],
+    }
+
+    referenceDataClient.getProjectTypes.mockResolvedValue(projectTypes)
+
+    const result = await referenceDataService.getProjectTypes('some-username')
+
+    expect(referenceDataClient.getProjectTypes).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(projectTypes)
+  })
+})

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -48,4 +48,23 @@ describe('ReferenceDataService', () => {
     expect(referenceDataClient.getEnforcementActions).toHaveBeenCalledTimes(1)
     expect(result).toEqual(enforcementActions)
   })
+
+  it('should call getContactOutcomes on the api client and return its result', async () => {
+    const contactOutcomes = {
+      contactOutcomes: [
+        {
+          id: '1001',
+          name: 'Team Lincoln',
+          code: '12',
+        },
+      ],
+    }
+
+    referenceDataClient.getContactOutcomes.mockResolvedValue(contactOutcomes)
+
+    const result = await referenceDataService.getContactOutcomes('some-username')
+
+    expect(referenceDataClient.getContactOutcomes).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(contactOutcomes)
+  })
 })

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,4 +1,4 @@
-import { ProjectTypesDto } from '../@types/shared'
+import { EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
 import ReferenceDataClient from '../data/referenceDataClient'
 
 export default class ReferenceDataService {
@@ -6,5 +6,9 @@ export default class ReferenceDataService {
 
   async getProjectTypes(userName: string): Promise<ProjectTypesDto> {
     return this.referenceDataClient.getProjectTypes(userName)
+  }
+
+  async getEnforcementActions(userName: string): Promise<EnforcementActionsDto> {
+    return this.referenceDataClient.getEnforcementActions(userName)
   }
 }

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,4 +1,4 @@
-import { EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
+import { ContactOutcomesDto, EnforcementActionsDto, ProjectTypesDto } from '../@types/shared'
 import ReferenceDataClient from '../data/referenceDataClient'
 
 export default class ReferenceDataService {
@@ -10,5 +10,9 @@ export default class ReferenceDataService {
 
   async getEnforcementActions(userName: string): Promise<EnforcementActionsDto> {
     return this.referenceDataClient.getEnforcementActions(userName)
+  }
+
+  async getContactOutcomes(userName: string): Promise<ContactOutcomesDto> {
+    return this.referenceDataClient.getContactOutcomes(userName)
   }
 }

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,0 +1,10 @@
+import { ProjectTypesDto } from '../@types/shared'
+import ReferenceDataClient from '../data/referenceDataClient'
+
+export default class ReferenceDataService {
+  constructor(private readonly referenceDataClient: ReferenceDataClient) {}
+
+  async getProjectTypes(userName: string): Promise<ProjectTypesDto> {
+    return this.referenceDataClient.getProjectTypes(userName)
+  }
+}


### PR DESCRIPTION
This implements a reference data client to fetch data from API `/references` endpoints, and a service to interact with the client. 

I have kept the service scoped to 'reference data' as well, but it could equally sit on the sessions service as it will be related to updating a session for the moment.