### PR TITLE
CPB-88: Populate sessions search form

### DIFF
--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -43,4 +43,13 @@ export default class FindASessionPage extends Page {
     cy.get('td').eq(6).should('have.text', '3')
     cy.get('td').eq(7).should('have.text', '1')
   }
+
+  shouldShowPopulatedSearchForm() {
+    cy.get('#startDate-day').should('have.value', '18')
+    cy.get('#startDate-month').should('have.value', '09')
+    cy.get('#startDate-year').should('have.value', '2025')
+    cy.get('#endDate-day').should('have.value', '20')
+    cy.get('#endDate-month').should('have.value', '09')
+    cy.get('#endDate-year').should('have.value', '2025')
+  }
 }

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -68,5 +68,6 @@ context('Home', () => {
 
     //  Then I see the search results
     page.shouldShowSearchResults()
+    page.shouldShowPopulatedSearchForm()
   })
 })

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -84,6 +84,37 @@ describe('SessionsController', () => {
       })
     })
 
+    it('should return teamItems with selected team', async () => {
+      const sessions: ProjectAllocationsDto = {
+        allocations: [],
+      }
+
+      sessionService.getSessions.mockResolvedValue(sessions)
+
+      const firstTeam = { id: 1, name: 'Team Lincoln' }
+      const secondTeam = { id: 2, name: 'Team Grantham' }
+
+      const teams = {
+        providers: [firstTeam, secondTeam],
+      }
+
+      providerService.getTeams.mockResolvedValue(teams)
+
+      const response = createMock<Response>()
+      const requestHandler = sessionsController.search()
+      const requestWithTeam = createMock<Request>({})
+      requestWithTeam.query.team = '2'
+      await requestHandler(requestWithTeam, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('sessions/show', {
+        teamItems: [
+          { value: firstTeam.id, text: firstTeam.name, selected: false },
+          { value: secondTeam.id, text: secondTeam.name, selected: true },
+        ],
+        sessionRows: [],
+      })
+    })
+
     it('should render empty results if error code returned from client', async () => {
       const requestHandler = sessionsController.search()
       const err = { data: {}, status: 404 }

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -6,10 +6,14 @@ import ProviderService from '../services/providerService'
 import SessionService from '../services/sessionService'
 import { ProjectAllocationsDto } from '../@types/shared'
 import DateFormats from '../utils/dateUtils'
+import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
+
+jest.mock('../forms/GovukFrontendDateInput')
 
 describe('SessionsController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+  const govukInputMock: jest.Mock = GovukFrontendDateInput as unknown as jest.Mock
 
   let sessionsController: SessionsController
   const providerService = createMock<ProviderService>()
@@ -17,6 +21,9 @@ describe('SessionsController', () => {
 
   beforeEach(() => {
     sessionsController = new SessionsController(providerService, sessionService)
+    govukInputMock.mockImplementation(() => {
+      return { items: [] }
+    })
   })
 
   describe('show', () => {
@@ -81,6 +88,8 @@ describe('SessionsController', () => {
             { text: allocation.numberOfOffendersWithEA },
           ],
         ],
+        startDateItems: [],
+        endDateItems: [],
       })
     })
 
@@ -112,6 +121,8 @@ describe('SessionsController', () => {
           { value: secondTeam.id, text: secondTeam.name, selected: true },
         ],
         sessionRows: [],
+        startDateItems: [],
+        endDateItems: [],
       })
     })
 
@@ -129,6 +140,46 @@ describe('SessionsController', () => {
       expect(response.render).toHaveBeenCalledWith('sessions/show', {
         teamItems: [],
         sessionRows: [],
+        startDateItems: [],
+        endDateItems: [],
+      })
+    })
+
+    it('should return the formatted date query parameters', async () => {
+      const dateParts = [
+        { name: 'day', value: '09', classes: 'classes' },
+        { name: 'month', value: '10', classes: 'classes' },
+      ]
+
+      govukInputMock.mockImplementation(() => {
+        return { items: dateParts }
+      })
+      const requestHandler = sessionsController.search()
+      const err = { data: {}, status: 404 }
+
+      sessionService.getSessions.mockImplementation(() => {
+        throw err
+      })
+
+      const response = createMock<Response>()
+      const requestWithDates = createMock<Request>({})
+      const query = {
+        'startDate-day': '07',
+        'startDate-month': '07',
+        'startDate-year': '2024',
+        'endDate-day': '08',
+        'endDate-month': '08',
+        'endDate-year': '2025',
+      }
+
+      requestWithDates.query = query
+      await requestHandler(requestWithDates, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('sessions/show', {
+        teamItems: [],
+        sessionRows: [],
+        startDateItems: dateParts,
+        endDateItems: dateParts,
       })
     })
   })

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -29,7 +29,7 @@ export default class SessionsController {
 
       try {
         const providerId = '1000'
-        const teamItems = await this.getTeams(providerId, res)
+        const teamItems = await this.getTeams(providerId, res, teamId)
 
         const sessions = await this.sessionService.getSessions({
           username: res.locals.user.username,
@@ -46,13 +46,18 @@ export default class SessionsController {
     }
   }
 
-  private async getTeams(providerId: string, res: Response) {
+  private async getTeams(providerId: string, res: Response, teamId: number | undefined = undefined) {
     const teams = await this.providerService.getTeams(providerId, res.locals.user.username)
 
-    const teamItems = teams.providers.map(team => ({
-      value: team.id,
-      text: team.name,
-    }))
+    const teamItems = teams.providers.map(team => {
+      const selected = teamId ? team.id === teamId : undefined
+
+      return {
+        value: team.id,
+        text: team.name,
+        selected,
+      }
+    })
     return teamItems
   }
 

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -3,6 +3,7 @@ import ProviderService from '../services/providerService'
 import { ProjectAllocationsDto } from '../@types/shared'
 import SessionService from '../services/sessionService'
 import DateFormats from '../utils/dateUtils'
+import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
 
 export default class SessionsController {
   constructor(
@@ -23,9 +24,17 @@ export default class SessionsController {
     return async (_req: Request, res: Response) => {
       // Assigning the query object to a standard object prototype to resolve TypeError: Cannot convert object to primitive value
       const query = { ..._req.query }
+      const startDateInput = new GovukFrontendDateInput(query, 'startDate')
+      const endDateInput = new GovukFrontendDateInput(query, 'endDate')
+
       const teamId = Number(query.team)
       const startDate = `${query['startDate-year']}-${query['startDate-month']}-${query['startDate-day']}`
       const endDate = `${query['endDate-year']}-${query['endDate-month']}-${query['endDate-day']}`
+
+      const pageSearchValues = {
+        startDateItems: startDateInput.items,
+        endDateItems: endDateInput.items,
+      }
 
       try {
         const providerId = '1000'
@@ -38,10 +47,10 @@ export default class SessionsController {
           endDate,
         })
 
-        res.render('sessions/show', { teamItems, sessionRows: this.sessionRows(sessions) })
+        res.render('sessions/show', { ...pageSearchValues, teamItems, sessionRows: this.sessionRows(sessions) })
       } catch {
         // Response error handling to be added
-        res.render('sessions/show', { teamItems: [], sessionRows: [] })
+        res.render('sessions/show', { ...pageSearchValues, teamItems: [], sessionRows: [] })
       }
     }
   }

--- a/server/forms/GovUkFrontendDateInput.test.ts
+++ b/server/forms/GovUkFrontendDateInput.test.ts
@@ -1,0 +1,60 @@
+import GovukFrontendDateInput from './GovukFrontendDateInput'
+
+describe('GovUkFrontendDateInput', () => {
+  it('has expected items if dates with key exist', () => {
+    const query = {
+      'date-day': '09',
+      'date-month': '10',
+      'date-year': '2025',
+      'another-day': '22',
+    }
+
+    const input = new GovukFrontendDateInput(query, 'date')
+
+    expect(input.items).toEqual([
+      {
+        name: 'day',
+        classes: 'govuk-input--width-2',
+        value: '09',
+      },
+      {
+        name: 'month',
+        classes: 'govuk-input--width-2',
+        value: '10',
+      },
+      {
+        name: 'year',
+        classes: 'govuk-input--width-4',
+        value: '2025',
+      },
+    ])
+  })
+
+  it('has items with empty value if date with key does not exist', () => {
+    const query = {
+      'another-day': '22',
+      'another-month': '23',
+      'another-year': '24',
+    }
+
+    const input = new GovukFrontendDateInput(query, 'date')
+
+    expect(input.items).toEqual([
+      {
+        name: 'day',
+        classes: 'govuk-input--width-2',
+        value: '',
+      },
+      {
+        name: 'month',
+        classes: 'govuk-input--width-2',
+        value: '',
+      },
+      {
+        name: 'year',
+        classes: 'govuk-input--width-4',
+        value: '',
+      },
+    ])
+  })
+})

--- a/server/forms/GovukFrontendDateInput.ts
+++ b/server/forms/GovukFrontendDateInput.ts
@@ -1,0 +1,53 @@
+import { ParsedQs } from 'qs'
+
+type GovukFrontendDateInputPartType = 'day' | 'month' | 'year'
+
+interface GovUkFrontendDateInputItem {
+  name: string
+  classes: string
+  value: string
+}
+
+export default class GovukFrontendDateInput {
+  items: GovUkFrontendDateInputItem[]
+
+  private dayValue: string
+
+  private monthValue: string
+
+  private yearValue: string
+
+  constructor(query: ParsedQs, key: string) {
+    this.dayValue = GovukFrontendDateInput.getDatePartQueryValue(query, key, 'day')
+    this.monthValue = GovukFrontendDateInput.getDatePartQueryValue(query, key, 'month')
+    this.yearValue = GovukFrontendDateInput.getDatePartQueryValue(query, key, 'year')
+
+    this.buildItems()
+  }
+
+  private buildItems(): void {
+    this.items = [
+      {
+        name: 'day',
+        classes: 'govuk-input--width-2',
+        value: this.dayValue,
+      },
+      {
+        name: 'month',
+        classes: 'govuk-input--width-2',
+        value: this.monthValue,
+      },
+      {
+        name: 'year',
+        classes: 'govuk-input--width-4',
+        value: this.yearValue,
+      },
+    ]
+  }
+
+  static getDatePartQueryValue(query: ParsedQs, key: string, type: GovukFrontendDateInputPartType): string {
+    const value = query[`${key}-${type}`]
+
+    return value === undefined ? '' : value.toString()
+  }
+}

--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -51,7 +51,8 @@
           text: "From",
           classes: "govuk-!-font-weight-bold"
         }
-      }
+      },
+      items: startDateItems
     }) }}
 
     {{ govukDateInput({
@@ -62,7 +63,8 @@
           text: "To",
           classes: "govuk-!-font-weight-bold"
         }
-      }
+      },
+      items: endDateItems
     }) }}
 
     {{ govukButton({


### PR DESCRIPTION
This ensures that the sessions search form is populated with the original search terms after a search. 

To populate the [GOV.UK Date Input component](https://design-system.service.gov.uk/components/date-input/), we need to supply a list of `items` with the given day, month and years values which are provided as separate values in the query. I have written a utility function to return this list of items given a request query object. 

Builds on implementation added in #61 

Relates to [CPB-88: Session search UI - fetch and display results](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/5660?selectedIssue=CPB-88)

## Screenshots

<img width="1388" height="956" alt="Screenshot 2025-09-24 at 15 57 05" src="https://github.com/user-attachments/assets/11981463-e669-46b2-91b1-ea18202aec5a" />
