### PR TITLE
CPB-133: Add integration test for viewing session details

### DIFF
--- a/integration_tests/mockApis/sessions.ts
+++ b/integration_tests/mockApis/sessions.ts
@@ -1,7 +1,7 @@
 import type { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import paths from '../../server/paths/api'
-import type { ProjectAllocationsDto } from '../../server/@types/shared/models/ProjectAllocationsDto'
+import type { ProjectAllocationsDto, AppointmentsDto } from '../../server/@types/shared'
 import type { GetSessionsRequest } from '../../server/@types/user-defined'
 
 export default {
@@ -37,4 +37,49 @@ export default {
       },
     })
   },
+  stubFindSession: ({ projectId }: { projectId: string }): SuperAgentRequest => {
+    const pattern = paths.projects.sessionAppointments({ projectId })
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: pattern,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          ...appointments,
+        },
+      },
+    })
+  },
+}
+
+const appointments: AppointmentsDto = {
+  appointments: [
+    {
+      id: 1001,
+      projectName: 'Park cleaning',
+      requirementMinutes: 600,
+      completedMinutes: 500,
+      offender: {
+        forename: 'John',
+        surname: 'Smith',
+        crn: 'CRN123',
+        objectType: 'OffenderFull',
+      },
+    },
+    {
+      id: 1002,
+      projectName: 'Park cleaning',
+      requirementMinutes: 900,
+      completedMinutes: 600,
+      offender: {
+        forename: 'Roberta',
+        surname: 'John',
+        crn: 'CRN124',
+        objectType: 'OffenderFull',
+      },
+    },
+  ],
 }

--- a/integration_tests/mockApis/sessions.ts
+++ b/integration_tests/mockApis/sessions.ts
@@ -48,14 +48,14 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: {
-          ...appointments,
+          ...mockAppointments,
         },
       },
     })
   },
 }
 
-const appointments: AppointmentsDto = {
+export const mockAppointments: AppointmentsDto = {
   appointments: [
     {
       id: 1001,

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -33,6 +33,10 @@ export default class FindASessionPage extends Page {
     cy.get('button').click()
   }
 
+  clickOnASession() {
+    cy.get('a').contains('project-name').click()
+  }
+
   shouldShowSearchResults() {
     cy.get('td').eq(0).should('contain.text', 'project-name')
     cy.get('td').eq(0).should('contain.text', 'prj')

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -1,7 +1,42 @@
+import { AppointmentDto, OffenderFullDto } from '../../server/@types/shared'
+import { mockAppointments } from '../mockApis/sessions'
 import Page from './page'
 
 export default class ViewSessionPage extends Page {
   constructor() {
     super('Park cleaning')
+  }
+
+  shouldShowAppointmentsList() {
+    const { appointments } = mockAppointments
+
+    cy.get('tr')
+      .eq(1)
+      .within(() => {
+        this.shouldShowAppointmentDetails(appointments[0])
+      })
+
+    cy.get('tr')
+      .eq(2)
+      .within(() => {
+        this.shouldShowAppointmentDetails(appointments[1])
+      })
+  }
+
+  private shouldShowAppointmentDetails(appointment: AppointmentDto) {
+    const offender = appointment.offender as OffenderFullDto
+
+    cy.get('td').eq(0).should('have.text', `${offender.forename} ${offender.surname}`)
+    cy.get('td').eq(1).should('have.text', offender.crn)
+    cy.get('td')
+      .eq(2)
+      .should('have.text', appointment.requirementMinutes / 60)
+    cy.get('td')
+      .eq(3)
+      .should('have.text', appointment.completedMinutes / 60)
+    cy.get('td')
+      .eq(4)
+      .should('have.text', (appointment.requirementMinutes - appointment.completedMinutes) / 60)
+    cy.get('td').eq(5).should('have.text', 'Empty')
   }
 }

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class ViewSessionPage extends Page {
+  constructor() {
+    super('Park cleaning')
+  }
+}

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -7,9 +7,9 @@
 //      Given I am logged in
 //      When I visit the 'find a session' page
 //      Then I see the search form
-
 import FindASessionPage from '../pages/findASessionPage'
 import Page from '../pages/page'
+import ViewSessionPage from '../pages/viewSessionPage'
 
 context('Home', () => {
   beforeEach(() => {
@@ -69,5 +69,44 @@ context('Home', () => {
     //  Then I see the search results
     page.shouldShowSearchResults()
     page.shouldShowPopulatedSearchForm()
+  })
+
+  //  Scenario: viewing a session
+  it('lets me view a session from the dashboard', () => {
+    // Given I am logged in and on the sessions page
+    cy.signIn()
+    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1' }] } })
+    FindASessionPage.visit()
+    const page = Page.verifyOnPage(FindASessionPage)
+    page.completeSearchForm()
+
+    //  When I search for a session
+    cy.task('stubGetSessions', {
+      request: { teamId: 1, startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
+      sessions: {
+        allocations: [
+          {
+            id: 1001,
+            projectId: 3,
+            date: '2025-09-07',
+            projectName: 'project-name',
+            projectCode: 'prj',
+            startTime: '09:00:00',
+            endTime: '17:00:00',
+            numberOfOffendersAllocated: 5,
+            numberOfOffendersWithOutcomes: 3,
+            numberOfOffendersWithEA: 1,
+          },
+        ],
+      },
+    })
+    page.submitForm()
+
+    // And I click on a session in the results
+    cy.task('stubFindSession', { projectId: '3' })
+    page.clickOnASession()
+
+    //  Then I see the session details page
+    Page.verifyOnPage(ViewSessionPage)
   })
 })

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -107,6 +107,7 @@ context('Home', () => {
     page.clickOnASession()
 
     //  Then I see the session details page
-    Page.verifyOnPage(ViewSessionPage)
+    const sessionDetailsPage = Page.verifyOnPage(ViewSessionPage)
+    sessionDetailsPage.shouldShowAppointmentsList()
   })
 })


### PR DESCRIPTION
In #68 I added implementation for viewing a session details from a search results list. This adds an integration test for this functionality. 

