### PR TITLE
CPB-133: Fix back link on sessions page

### DIFF
--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -7,7 +7,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.sessions.index.pattern
+    href: paths.sessions.index()
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
We cannot use the `pattern` property on the static-path here.

This will return the user to a blank search form, not their previous search.

https://github.com/user-attachments/assets/88a74c10-6b25-44bf-baa7-beb83846b63d

