### PR TITLE
Change query parameter `teamId` to `teamCode` in get sessions request

### DIFF
--- a/integration_tests/mockApis/sessions.ts
+++ b/integration_tests/mockApis/sessions.ts
@@ -13,8 +13,8 @@ export default {
     sessions: ProjectAllocationsDto
   }): SuperAgentRequest => {
     const queryParameters: Record<string, unknown> = {
-      teamId: {
-        equalTo: request.teamId.toString(),
+      teamCode: {
+        equalTo: request.teamCode,
       },
       startDate: {
         equalTo: request.startDate,

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -31,7 +31,7 @@ context('Home', () => {
     cy.signIn()
 
     //  When I visit the 'find a session' page
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1', code: 'XRTC12' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
 
@@ -45,7 +45,7 @@ context('Home', () => {
     cy.signIn()
 
     //  When I visit the 'find a session' page
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
 
@@ -54,7 +54,7 @@ context('Home', () => {
 
     // And I search for sessions
     cy.task('stubGetSessions', {
-      request: { teamId: 1, startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
+      request: { teamCode: 'XRTC12', startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
       sessions: {
         allocations: [
           {
@@ -83,14 +83,14 @@ context('Home', () => {
   it('lets me view a session from the dashboard', () => {
     // Given I am logged in and on the sessions page
     cy.signIn()
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
     page.completeSearchForm()
 
     //  When I search for a session
     cy.task('stubGetSessions', {
-      request: { teamId: 1, startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
+      request: { teamCode: 'XRTC12', startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
       sessions: {
         allocations: [
           {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,6 +1,6 @@
 export interface GetSessionsRequest {
   username: string
-  teamId: number
+  teamCode: string
   startDate: string
   endDate: string
 }

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -42,7 +42,7 @@ describe('SessionsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
-        teamItems: [{ value: 1001, text: 'Team Lincoln' }],
+        teamItems: [{ value: 'XRT134', text: 'Team Lincoln' }],
       })
     })
   })
@@ -83,7 +83,7 @@ describe('SessionsController', () => {
 
       const req: DeepMocked<Request> = createMock<Request>({
         query: {
-          team: '1',
+          team: 'XR123',
         },
       })
 
@@ -92,8 +92,8 @@ describe('SessionsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
         teamItems: [
-          { value: firstTeam.id, text: firstTeam.name, selected: true },
-          { value: secondTeam.id, text: secondTeam.name, selected: false },
+          { value: firstTeam.code, text: firstTeam.name, selected: true },
+          { value: secondTeam.code, text: secondTeam.name, selected: false },
         ],
         sessionRows: [],
         startDateItems: [],
@@ -155,8 +155,8 @@ describe('SessionsController', () => {
       expect(resultTableRowsSpy).toHaveBeenCalledWith(sessions)
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
         teamItems: [
-          { value: firstTeam.id, text: firstTeam.name, selected: undefined },
-          { value: secondTeam.id, text: secondTeam.name, selected: undefined },
+          { value: firstTeam.code, text: firstTeam.name, selected: undefined },
+          { value: secondTeam.code, text: secondTeam.name, selected: undefined },
         ],
         sessionRows: formattedSessionRows,
         startDateItems: [],
@@ -183,13 +183,13 @@ describe('SessionsController', () => {
       const response = createMock<Response>()
       const requestHandler = sessionsController.search()
       const requestWithTeam = createMock<Request>({})
-      requestWithTeam.query.team = '2'
+      requestWithTeam.query.team = 'XR124'
       await requestHandler(requestWithTeam, response, next)
 
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
         teamItems: [
-          { value: firstTeam.id, text: firstTeam.name, selected: false },
-          { value: secondTeam.id, text: secondTeam.name, selected: true },
+          { value: firstTeam.code, text: firstTeam.name, selected: false },
+          { value: secondTeam.code, text: secondTeam.name, selected: true },
         ],
         sessionRows: [],
         startDateItems: [],
@@ -222,12 +222,12 @@ describe('SessionsController', () => {
           {
             selected: undefined,
             text: 'Team Lincoln',
-            value: 1,
+            value: 'XR123',
           },
           {
             selected: undefined,
             text: 'Team Grantham',
-            value: 2,
+            value: 'XR124',
           },
         ],
         sessionRows: [],
@@ -254,10 +254,19 @@ describe('SessionsController', () => {
         throw err
       })
 
+      const firstTeam = { id: 1, code: 'XR123', name: 'Team Lincoln' }
+      const secondTeam = { id: 2, code: 'XR124', name: 'Team Grantham' }
+
+      const teams = {
+        providers: [firstTeam, secondTeam],
+      }
+
+      providerService.getTeams.mockResolvedValue(teams)
+
       const response = createMock<Response>()
       const requestWithDates = createMock<Request>({})
       const query = {
-        team: '1',
+        team: 'XR123',
         'startDate-day': '07',
         'startDate-month': '07',
         'startDate-year': '2024',
@@ -274,12 +283,12 @@ describe('SessionsController', () => {
           {
             selected: true,
             text: 'Team Lincoln',
-            value: 1,
+            value: 'XR123',
           },
           {
             selected: false,
             text: 'Team Grantham',
-            value: 2,
+            value: 'XR124',
           },
         ],
         sessionRows: [],

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -25,10 +25,11 @@ export default class SessionsController {
 
       // Assigning the query object to a standard object prototype to resolve TypeError: Cannot convert object to primitive value
       const query = { ..._req.query }
+      const teamCode = query.team?.toString() ?? undefined
 
       try {
         const providerId = '1000'
-        teamItems = await this.getTeams(providerId, res, Number(query.team))
+        teamItems = await this.getTeams(providerId, res, teamCode)
       } catch {
         throw new Error('Something went wrong')
       }
@@ -42,13 +43,12 @@ export default class SessionsController {
           throw new Error('Validation error')
         }
 
-        const teamId = Number(query.team)
         const startDate = `${query['startDate-year']}-${query['startDate-month']}-${query['startDate-day']}`
         const endDate = `${query['endDate-year']}-${query['endDate-month']}-${query['endDate-day']}`
 
         const sessions = await this.sessionService.getSessions({
           username: res.locals.user.username,
-          teamId,
+          teamCode,
           startDate,
           endDate,
         })
@@ -86,14 +86,14 @@ export default class SessionsController {
     }
   }
 
-  private async getTeams(providerId: string, res: Response, teamId: number | undefined = undefined) {
+  private async getTeams(providerId: string, res: Response, teamCode: string | undefined = undefined) {
     const teams = await this.providerService.getTeams(providerId, res.locals.user.username)
 
     const teamItems = teams.providers.map(team => {
-      const selected = teamId ? team.id === teamId : undefined
+      const selected = teamCode ? team.code === teamCode : undefined
 
       return {
-        value: team.id,
+        value: team.code,
         text: team.name,
         selected,
       }

--- a/server/data/sessionClient.test.ts
+++ b/server/data/sessionClient.test.ts
@@ -22,8 +22,8 @@ describe('SessionClient', () => {
     jest.resetAllMocks()
   })
 
-  describe('getSessions', () => {
-    it('should make a GET request to the sessions path using user token and return the response body', async () => {
+  describe('find', () => {
+    it('should make a GET request to the find sessions path using user token and return the response body', async () => {
       const projectId = '1'
       const date = '2026-01-01'
       const queryString = createQueryString({ date })
@@ -61,20 +61,20 @@ describe('SessionClient', () => {
     })
   })
 
-  describe('find', () => {
+  describe('getSessions', () => {
     it('should make a GET request to the sessions path using user token and return the response body', async () => {
       const startDate = '2026-01-01'
       const endDate = '2026-05-01'
-      const teamId = 1
+      const teamCode = 'XRTC123'
 
-      const queryString = createQueryString({ startDate, endDate, teamId })
+      const queryString = createQueryString({ startDate, endDate, teamCode })
 
       const sessions = {
         allocations: [
           {
             id: 1,
             projectName: 'Community Garden Maintenance',
-            teamId,
+            teamId: 4,
             startDate,
             endDate,
             projectCode: '123',
@@ -92,7 +92,7 @@ describe('SessionClient', () => {
 
       const response = await sessionClient.getSessions({
         username: 'some-username',
-        teamId,
+        teamCode,
         startDate,
         endDate,
       })

--- a/server/data/sessionClient.ts
+++ b/server/data/sessionClient.ts
@@ -12,9 +12,9 @@ export default class SessionClient extends RestClient {
     super('sessionClient', config.apis.communityPaybackApi, logger, authenticationClient)
   }
 
-  async getSessions({ username, teamId, startDate, endDate }: GetSessionsRequest): Promise<ProjectAllocationsDto> {
+  async getSessions({ username, teamCode, startDate, endDate }: GetSessionsRequest): Promise<ProjectAllocationsDto> {
     return (await this.get(
-      { path: paths.projects.sessions({}), query: createQueryString({ startDate, endDate, teamId }) },
+      { path: paths.projects.sessions({}), query: createQueryString({ startDate, endDate, teamCode }) },
       asSystem(username),
     )) as ProjectAllocationsDto
   }

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -34,7 +34,7 @@ describe('ProviderService', () => {
 
     const result = await sessionService.getSessions({
       username: 'some-username',
-      teamId: 1,
+      teamCode: 'XRTC12',
       startDate: '2025-09-01',
       endDate: '2025-09-02',
     })

--- a/server/services/sessionService.ts
+++ b/server/services/sessionService.ts
@@ -5,8 +5,8 @@ import SessionClient from '../data/sessionClient'
 export default class SessionService {
   constructor(private readonly sessionClient: SessionClient) {}
 
-  async getSessions({ username, teamId, startDate, endDate }: GetSessionsRequest): Promise<ProjectAllocationsDto> {
-    const sessions = await this.sessionClient.getSessions({ username, teamId, startDate, endDate })
+  async getSessions({ username, teamCode, startDate, endDate }: GetSessionsRequest): Promise<ProjectAllocationsDto> {
+    const sessions = await this.sessionClient.getSessions({ username, teamCode, startDate, endDate })
 
     return sessions
   }


### PR DESCRIPTION
In https://github.com/ministryofjustice/hmpps-community-payback-api/pull/122 the API schema for a session search was updated to take a team code rather than an nDelius team ID—to decouple our implementation from nDelius data. 

This change implements that change in the UI, and fixes failing e2e test.