### PR TITLE
fix API endpoint updates

### DIFF
--- a/integration_tests/mockApis/providers.ts
+++ b/integration_tests/mockApis/providers.ts
@@ -4,11 +4,11 @@ import paths from '../../server/paths/api'
 import type { ProviderTeamSummariesDto } from '../../server/@types/shared/models/ProviderTeamSummariesDto'
 
 export default {
-  stubGetTeams: (args: { providerId: string; teams: ProviderTeamSummariesDto }): SuperAgentRequest =>
+  stubGetTeams: (args: { teams: ProviderTeamSummariesDto }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: paths.providers.teams({ providerId: args.providerId }),
+        urlPattern: paths.providers.teams({ providerCode: 'ABC123' }),
       },
       response: {
         status: 200,

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -31,7 +31,7 @@ context('Home', () => {
     cy.signIn()
 
     //  When I visit the 'find a session' page
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1', code: 'XRTC12' }] } })
+    cy.task('stubGetTeams', { teams: { providers: [{ id: 1, name: 'Team 1', code: 'XRTC12' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
 
@@ -45,7 +45,7 @@ context('Home', () => {
     cy.signIn()
 
     //  When I visit the 'find a session' page
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
 
@@ -83,7 +83,7 @@ context('Home', () => {
   it('lets me view a session from the dashboard', () => {
     // Given I am logged in and on the sessions page
     cy.signIn()
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { teams: { providers: [{ id: 1, code: 'XRTC12', name: 'Team 1' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
     page.completeSearchForm()
@@ -125,7 +125,7 @@ context('Home', () => {
     cy.signIn()
 
     //  When I visit the 'find a session' page
-    cy.task('stubGetTeams', { providerId: '1000', teams: { providers: [{ id: 1, name: 'Team 1' }] } })
+    cy.task('stubGetTeams', { teams: { providers: [{ id: 1, name: 'Team 1' }] } })
     FindASessionPage.visit()
     const page = Page.verifyOnPage(FindASessionPage)
 

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -5,6 +5,8 @@ import SessionUtils from '../utils/sessionUtils'
 import TrackProgressPage, { TrackProgressPageInput } from '../pages/trackProgressPage'
 
 export default class SessionsController {
+  private readonly providerCode = 'ABC123'
+
   constructor(
     private readonly providerService: ProviderService,
     private readonly sessionService: SessionService,
@@ -12,8 +14,7 @@ export default class SessionsController {
 
   index(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const providerId = '1000'
-      const teamItems = await this.getTeams(providerId, res)
+      const teamItems = await this.getTeams(this.providerCode, res)
 
       res.render('sessions/index', { teamItems })
     }
@@ -28,8 +29,7 @@ export default class SessionsController {
       const teamCode = query.team?.toString() ?? undefined
 
       try {
-        const providerId = '1000'
-        teamItems = await this.getTeams(providerId, res, teamCode)
+        teamItems = await this.getTeams(this.providerCode, res, teamCode)
       } catch {
         throw new Error('Something went wrong')
       }
@@ -86,8 +86,8 @@ export default class SessionsController {
     }
   }
 
-  private async getTeams(providerId: string, res: Response, teamCode: string | undefined = undefined) {
-    const teams = await this.providerService.getTeams(providerId, res.locals.user.username)
+  private async getTeams(providerCode: string, res: Response, teamCode: string | undefined = undefined) {
+    const teams = await this.providerService.getTeams(providerCode, res.locals.user.username)
 
     const teamItems = teams.providers.map(team => {
       const selected = teamCode ? team.code === teamCode : undefined

--- a/server/data/providerClient.ts
+++ b/server/data/providerClient.ts
@@ -10,9 +10,9 @@ export default class ProviderClient extends RestClient {
     super('providerClient', config.apis.communityPaybackApi, logger, authenticationClient)
   }
 
-  async getTeams(providerId: string, username: string): Promise<ProviderTeamSummariesDto> {
+  async getTeams(providerCode: string, username: string): Promise<ProviderTeamSummariesDto> {
     return (await this.get(
-      { path: paths.providers.teams({ providerId }) },
+      { path: paths.providers.teams({ providerCode }) },
       asSystem(username),
     )) as ProviderTeamSummariesDto
   }

--- a/server/data/sessionClient.test.ts
+++ b/server/data/sessionClient.test.ts
@@ -86,7 +86,7 @@ describe('SessionClient', () => {
       }
 
       nock(config.apis.communityPaybackApi.url)
-        .get(`/projects/allocations?${queryString}`)
+        .get(`/projects/session-search?${queryString}`)
         .matchHeader('authorization', 'Bearer test-system-token')
         .reply(200, sessions)
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -13,7 +13,7 @@ export default {
     teams: providersPath.path(':providerId/teams'),
   },
   projects: {
-    sessions: projectsPath.path('allocations'),
+    sessions: projectsPath.path('session-search'),
     sessionAppointments: projectsPath.path(':projectId').path('appointments'),
   },
   referenceData: {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -10,7 +10,7 @@ export default {
     singleAppointment: appointmentsPath.path(':appointmentId'),
   },
   providers: {
-    teams: providersPath.path(':providerId/teams'),
+    teams: providersPath.path(':providerCode/teams'),
   },
   projects: {
     sessions: projectsPath.path('session-search'),

--- a/server/services/providerService.ts
+++ b/server/services/providerService.ts
@@ -4,8 +4,8 @@ import ProviderClient from '../data/providerClient'
 export default class ProviderService {
   constructor(private readonly providerClient: ProviderClient) {}
 
-  async getTeams(providerId: string, username: string): Promise<ProviderTeamSummariesDto> {
-    const teams = await this.providerClient.getTeams(providerId, username)
+  async getTeams(providerCode: string, username: string): Promise<ProviderTeamSummariesDto> {
+    const teams = await this.providerClient.getTeams(providerCode, username)
 
     return teams
   }


### PR DESCRIPTION
This resolves two breaking changes to the API schema:

- Endpoint to get sessions renamed to `projects/session-search`
- url parameter in endpoint to get teams changed from `projectId` to `projectCode`

Addresses changes in 
In https://github.com/ministryofjustice/hmpps-community-payback-api/pull/123 and https://github.com/ministryofjustice/hmpps-community-payback-api/pull/122