### PR TITLE
Fix API endpoint updates: Get single session

### DIFF
--- a/integration_tests/mockApis/sessions.ts
+++ b/integration_tests/mockApis/sessions.ts
@@ -38,13 +38,15 @@ export default {
     })
   },
   stubFindSession: ({
-    projectId,
+    projectCode = 'prj',
+    date = '2025-09-07',
     responseHasLimitedOffenders = false,
   }: {
-    projectId: string
+    projectCode: string
+    date: string
     responseHasLimitedOffenders: boolean
   }): SuperAgentRequest => {
-    const pattern = paths.projects.sessionAppointments({ projectId })
+    const pattern = paths.projects.sessionAppointments({ projectCode, date })
     return stubFor({
       request: {
         method: 'GET',

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -10,7 +10,7 @@ export default class ViewSessionPage extends Page {
   }
 
   static visit(): ViewSessionPage {
-    const path = `${paths.sessions.show({ id: '3' })}?date=2025-01-01`
+    const path = `${paths.sessions.show({ projectCode: 'prj' })}?date=2025-09-07&startTime=09:00&endTime=17:00`
     cy.visit(path)
 
     return Page.verifyOnPage(ViewSessionPage)

--- a/integration_tests/tests/findASession.cy.ts
+++ b/integration_tests/tests/findASession.cy.ts
@@ -111,7 +111,7 @@ context('Home', () => {
     page.submitForm()
 
     // And I click on a session in the results
-    cy.task('stubFindSession', { projectId: '3' })
+    cy.task('stubFindSession', { projectCode: 'prj', date: '2025-09-07' })
     page.clickOnASession()
 
     //  Then I see the session details page

--- a/integration_tests/tests/updateAnAppointment.cy.ts
+++ b/integration_tests/tests/updateAnAppointment.cy.ts
@@ -26,7 +26,7 @@ context('Session details', () => {
   it('shows an option to update an appointment on a session', () => {
     // Given I am on the view session page
     cy.signIn()
-    cy.task('stubFindSession', { projectId: '3' })
+    cy.task('stubFindSession', {})
     const page = ViewSessionPage.visit()
     page.shouldShowAppointmentsList()
 
@@ -42,7 +42,7 @@ context('Session details', () => {
   it('does not enable appointment update for a limited access offender', () => {
     // Given I am on the view session page
     cy.signIn()
-    cy.task('stubFindSession', { projectId: '3', responseHasLimitedOffenders: true })
+    cy.task('stubFindSession', { responseHasLimitedOffenders: true })
     const page = ViewSessionPage.visit()
 
     // Then I see limited information about offenders and cannot update

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,8 +1,18 @@
-export interface GetSessionsRequest {
+export interface BaseRequest {
   username: string
+}
+
+export interface GetSessionsRequest extends BaseRequest {
   teamCode: string
   startDate: string
   endDate: string
+}
+
+export interface GetSessionRequest extends BaseRequest {
+  projectCode: string
+  date: string
+  startTime: string
+  endTime: string
 }
 
 export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow'

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -77,9 +77,18 @@ export default class SessionsController {
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const { id } = _req.params
-      const { date } = _req.query
-      const session = await this.sessionService.getSession(res.locals.user.username, id, date.toString())
+      const { projectCode } = _req.params
+      const { date, startTime, endTime } = _req.query
+
+      const request = {
+        username: res.locals.user.username,
+        projectCode,
+        date: date.toString(),
+        startTime: startTime.toString(),
+        endTime: endTime.toString(),
+      }
+
+      const session = await this.sessionService.getSession(request)
       const sessionList = SessionUtils.sessionListTableRows(session.appointmentSummaries)
 
       res.render('sessions/show', { session, sessionList })

--- a/server/data/sessionClient.test.ts
+++ b/server/data/sessionClient.test.ts
@@ -24,9 +24,11 @@ describe('SessionClient', () => {
 
   describe('find', () => {
     it('should make a GET request to the find sessions path using user token and return the response body', async () => {
-      const projectId = '1'
+      const projectCode = '1'
       const date = '2026-01-01'
-      const queryString = createQueryString({ date })
+      const startTime = '09:00'
+      const endTime = '17:00'
+      const queryString = createQueryString({ startTime, endTime })
 
       const session: SessionDto = {
         projectName: 'Park cleaning',
@@ -51,11 +53,11 @@ describe('SessionClient', () => {
       }
 
       nock(config.apis.communityPaybackApi.url)
-        .get(`/projects/${projectId}/appointments?${queryString}`)
+        .get(`/projects/${projectCode}/sessions/${date}?${queryString}`)
         .matchHeader('authorization', 'Bearer test-system-token')
         .reply(200, session)
 
-      const response = await sessionClient.find('some-username', projectId, date)
+      const response = await sessionClient.find({ username: 'some-username', projectCode, date, startTime, endTime })
 
       expect(response).toEqual(session)
     })

--- a/server/data/sessionClient.ts
+++ b/server/data/sessionClient.ts
@@ -3,8 +3,8 @@ import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients
 import config from '../config'
 import logger from '../../logger'
 import paths from '../paths/api'
-import { SessionSummariesDto, SessionDto } from '../@types/shared'
-import { GetSessionsRequest } from '../@types/user-defined'
+import { SessionDto, SessionSummariesDto } from '../@types/shared'
+import { GetSessionRequest, GetSessionsRequest } from '../@types/user-defined'
 import { createQueryString } from '../utils/utils'
 
 export default class SessionClient extends RestClient {
@@ -19,9 +19,9 @@ export default class SessionClient extends RestClient {
     )) as SessionSummariesDto
   }
 
-  async find(username: string, projectId: string, date: string): Promise<SessionDto> {
-    const path = paths.projects.sessionAppointments({ projectId })
-    const query = createQueryString({ date })
+  async find({ username, projectCode, date, startTime, endTime }: GetSessionRequest): Promise<SessionDto> {
+    const path = paths.projects.sessionAppointments({ projectCode, date })
+    const query = createQueryString({ startTime, endTime })
     return (await this.get({ path, query }, asSystem(username))) as SessionDto
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -14,7 +14,7 @@ export default {
   },
   projects: {
     sessions: projectsPath.path('session-search'),
-    sessionAppointments: projectsPath.path(':projectId').path('appointments'),
+    sessionAppointments: projectsPath.path(':projectCode').path('sessions').path(':date'),
   },
   referenceData: {
     projectTypes: referenceDataPath.path('project-types'),

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -7,7 +7,7 @@ const paths = {
   sessions: {
     index: sessionsPath,
     search: sessionsPath.path('search'),
-    show: sessionsPath.path(':id'),
+    show: sessionsPath.path(':projectCode'),
   },
   appointments: {
     update: appointmentsPath.path(':appointmentId').path('/update'),

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -68,7 +68,13 @@ describe('ProviderService', () => {
     }
 
     sessionClient.find.mockResolvedValue(session)
-    const result = await sessionService.getSession('some-username', '1', '2025-01-01')
+    const result = await sessionService.getSession({
+      username: 'some-username',
+      projectCode: '1',
+      date: '2025-01-01',
+      startTime: '09:00',
+      endTime: '17:00',
+    })
 
     expect(sessionClient.find).toHaveBeenCalledTimes(1)
     expect(result).toEqual(session)

--- a/server/services/sessionService.ts
+++ b/server/services/sessionService.ts
@@ -1,5 +1,5 @@
-import { SessionSummariesDto, SessionDto } from '../@types/shared'
-import { GetSessionsRequest } from '../@types/user-defined'
+import { SessionDto, SessionSummariesDto } from '../@types/shared'
+import { GetSessionRequest, GetSessionsRequest } from '../@types/user-defined'
 import SessionClient from '../data/sessionClient'
 
 export default class SessionService {
@@ -11,9 +11,8 @@ export default class SessionService {
     return sessions
   }
 
-  async getSession(username: string, projectId: string, date: string): Promise<SessionDto> {
-    const appointments = this.sessionClient.find(username, projectId, date)
-
+  async getSession(request: GetSessionRequest): Promise<SessionDto> {
+    const appointments = await this.sessionClient.find(request)
     return appointments
   }
 }

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -49,7 +49,7 @@ describe('SessionUtils', () => {
 
       expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
         allocation.projectName,
-        `${paths.sessions.show({ id: allocation.projectId.toString() })}?${createQueryString({ date: allocation.date })}`,
+        `${paths.sessions.show({ projectCode: allocation.projectCode.toString() })}?${createQueryString({ date: allocation.date, startTime: allocation.startTime, endTime: allocation.endTime })}`,
       )
 
       expect(HtmlUtils.getElementWithContent).toHaveBeenNthCalledWith(1, fakeLink)

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -9,7 +9,8 @@ import { GovUKTableRow } from '../@types/user-defined'
 export default class SessionUtils {
   static sessionResultTableRows(sessions: SessionSummariesDto) {
     return sessions.allocations.map(session => {
-      const showPath = `${paths.sessions.show({ id: session.projectId.toString() })}?${createQueryString({ date: session.date })}`
+      const { date, startTime, endTime } = session
+      const showPath = `${paths.sessions.show({ projectCode: session.projectCode })}?${createQueryString({ date, startTime, endTime })}`
       const projectLink = HtmlUtils.getAnchor(session.projectName, showPath)
 
       return [


### PR DESCRIPTION
In the Community Payback API schema, the shape of the endpoint to find a single session has changed 
- from `/projects/{projectId}/appointments?date={date}` 
- to `projects/{projectCode}/sessions/{date}?startTime={startTime}&endTime={endTime`}. 

This fix addresses that change.

I have introduced a new Request object, to make passing these properties along simpler. Have also simplified our stubs with some default URL values to match those in the defined 'visitPage' route in the Page Object Model.