### PR TITLE
CPB-697: Fix property value accessor method

### DIFF
--- a/server/controllers/courseCompletions/process/baseController.test.ts
+++ b/server/controllers/courseCompletions/process/baseController.test.ts
@@ -59,10 +59,9 @@ describe('BaseController', () => {
         })
       })
 
-      it('should render page with team from query string', async () => {
+      it.each(['', 'value'])('should render page with team from query string', async (team?: string) => {
         const showPath = '/show'
         const formId = '12'
-        const teamCode = 'TEAM-123'
         const viewData = {
           backLink: '/back',
           updatePath: '/update',
@@ -74,7 +73,7 @@ describe('BaseController', () => {
 
         const request = createMock<Request>({
           params: { id: '1' },
-          query: { form: formId, team: teamCode },
+          query: { form: formId, team },
           body: {},
         })
 
@@ -83,43 +82,44 @@ describe('BaseController', () => {
 
         expect(response.render).toHaveBeenCalledWith(templatePath, {
           ...viewData,
-          team: teamCode,
+          team,
         })
       })
 
-      it('should render page with team from formData', async () => {
-        const showPath = '/show'
-        const formId = '12'
-        const teamCode = 'TEAM-456'
-        const formWithTeam = courseCompletionFormFactory.build({ team: teamCode })
-        courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
+      it.each(['', 'value'])(
+        'should render page with team from formData if team on body has no value',
+        async (team: string) => {
+          const showPath = '/show'
+          const formId = '12'
+          const formWithTeam = courseCompletionFormFactory.build({ team })
+          courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
 
-        const viewData = {
-          backLink: '/back',
-          updatePath: '/update',
-          courseName: 'Customer service',
-          communityCampusPerson: { name: 'John Smith' },
-        }
-        page.viewData.mockReturnValue(viewData)
-        page.updatePath.mockReturnValue(showPath)
+          const viewData = {
+            backLink: '/back',
+            updatePath: '/update',
+            courseName: 'Customer service',
+            communityCampusPerson: { name: 'John Smith' },
+          }
+          page.viewData.mockReturnValue(viewData)
+          page.updatePath.mockReturnValue(showPath)
 
-        const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
+          const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
 
-        const requestHandler = testController.show()
-        await requestHandler(request, response, next)
+          const requestHandler = testController.show()
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith(templatePath, {
-          ...viewData,
-          team: teamCode,
-        })
-      })
+          expect(response.render).toHaveBeenCalledWith(templatePath, {
+            ...viewData,
+            team,
+          })
+        },
+      )
     })
 
     describe('submit', () => {
-      it('should pass team from body on validation error', async () => {
+      it.each(['', 'value'])('should pass team from body on validation error', async (team: string) => {
         const showPath = '/show'
         const formId = '12'
-        const teamCode = 'TEAM-789'
         const viewData = {
           backLink: '/back',
           courseName: 'Customer service',
@@ -136,7 +136,7 @@ describe('BaseController', () => {
         const request = createMock<Request>({
           params: { id: '1' },
           query: { form: formId },
-          body: { team: teamCode },
+          body: { team },
         })
 
         const requestHandler = testController.submit()
@@ -144,48 +144,50 @@ describe('BaseController', () => {
 
         expect(response.render).toHaveBeenCalledWith(templatePath, {
           ...viewData,
-          team: teamCode,
+          team,
           errors,
           errorSummary,
         })
       })
 
-      it('should pass team from formData on validation error when body is undefined', async () => {
-        const showPath = '/show'
-        const formId = '12'
-        const teamCode = 'TEAM-101'
-        const formWithTeam = courseCompletionFormFactory.build({ team: teamCode })
-        courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
+      it.each(['', 'value'])(
+        'should pass team from formData on validation error when body is undefined',
+        async (team: string) => {
+          const showPath = '/show'
+          const formId = '12'
+          const formWithTeam = courseCompletionFormFactory.build({ team })
+          courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
 
-        const viewData = {
-          courseName: 'Customer service',
-          backLink: '/back',
-          updatePath: '/update',
-          communityCampusPerson: { name: 'John Smith' },
-        }
-        page.viewData.mockReturnValue(viewData)
-        page.updatePath.mockReturnValue(showPath)
+          const viewData = {
+            courseName: 'Customer service',
+            backLink: '/back',
+            updatePath: '/update',
+            communityCampusPerson: { name: 'John Smith' },
+          }
+          page.viewData.mockReturnValue(viewData)
+          page.updatePath.mockReturnValue(showPath)
 
-        const errorSummary = [{ text: 'Error 1', href: '#1', attributes: {} }]
-        const errors = { appointmentId: { text: 'Error' } }
-        page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+          const errorSummary = [{ text: 'Error 1', href: '#1', attributes: {} }]
+          const errors = { appointmentId: { text: 'Error' } }
+          page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
 
-        const request = createMock<Request>({
-          params: { id: '1' },
-          query: { form: formId },
-          body: {},
-        })
+          const request = createMock<Request>({
+            params: { id: '1' },
+            query: { form: formId },
+            body: {},
+          })
 
-        const requestHandler = testController.submit()
-        await requestHandler(request, response, next)
+          const requestHandler = testController.submit()
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith(templatePath, {
-          ...viewData,
-          team: teamCode,
-          errors,
-          errorSummary,
-        })
-      })
+          expect(response.render).toHaveBeenCalledWith(templatePath, {
+            ...viewData,
+            team,
+            errors,
+            errorSummary,
+          })
+        },
+      )
     })
   })
 })

--- a/server/controllers/courseCompletions/process/baseController.test.ts
+++ b/server/controllers/courseCompletions/process/baseController.test.ts
@@ -1,0 +1,191 @@
+import { createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import AppointmentPage from '../../../pages/courseCompletions/process/appointmentPage'
+import BaseController, { StepViewDataParams } from './baseController'
+import CourseCompletionService from '../../../services/courseCompletionService'
+import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
+import courseCompletionFactory from '../../../testutils/factories/courseCompletionFactory'
+import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
+
+class TestController extends BaseController<AppointmentPage> {
+  protected override async getStepViewData({ req, formData }: StepViewDataParams) {
+    const team = this.getPropertyValue({ propertyName: 'team', req, formData })
+    return Promise.resolve({ team })
+  }
+}
+
+describe('BaseController', () => {
+  const response = createMock<Response>()
+  const next = createMock<NextFunction>({})
+
+  const templatePath = '/views/page.njk'
+  const courseCompletionService = createMock<CourseCompletionService>()
+  const courseCompletionFormService = createMock<CourseCompletionFormService>()
+  const courseCompletion = courseCompletionFactory.build()
+  const form = courseCompletionFormFactory.build({ team: undefined })
+
+  let testController: TestController
+  const page = createMock<AppointmentPage>({ templatePath })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    testController = new TestController(page, courseCompletionService, courseCompletionFormService)
+    courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
+    courseCompletionFormService.getForm.mockResolvedValue(form)
+  })
+
+  describe('getPropertyValue', () => {
+    describe('show', () => {
+      it('should render page with undefined team if no team value provided', async () => {
+        const showPath = '/show'
+        const formId = '12'
+        const viewData = {
+          backLink: '/back',
+          updatePath: '/update',
+          communityCampusPerson: { name: 'John Smith' },
+          courseName: 'Customer service',
+        }
+        page.viewData.mockReturnValue(viewData)
+        page.updatePath.mockReturnValue(showPath)
+
+        const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
+
+        const requestHandler = testController.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(templatePath, {
+          ...viewData,
+          team: undefined,
+        })
+      })
+
+      it('should render page with team from query string', async () => {
+        const showPath = '/show'
+        const formId = '12'
+        const teamCode = 'TEAM-123'
+        const viewData = {
+          backLink: '/back',
+          updatePath: '/update',
+          communityCampusPerson: { name: 'John Smith' },
+          courseName: 'Customer service',
+        }
+        page.viewData.mockReturnValue(viewData)
+        page.updatePath.mockReturnValue(showPath)
+
+        const request = createMock<Request>({
+          params: { id: '1' },
+          query: { form: formId, team: teamCode },
+          body: {},
+        })
+
+        const requestHandler = testController.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(templatePath, {
+          ...viewData,
+          team: teamCode,
+        })
+      })
+
+      it('should render page with team from formData', async () => {
+        const showPath = '/show'
+        const formId = '12'
+        const teamCode = 'TEAM-456'
+        const formWithTeam = courseCompletionFormFactory.build({ team: teamCode })
+        courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
+
+        const viewData = {
+          backLink: '/back',
+          updatePath: '/update',
+          courseName: 'Customer service',
+          communityCampusPerson: { name: 'John Smith' },
+        }
+        page.viewData.mockReturnValue(viewData)
+        page.updatePath.mockReturnValue(showPath)
+
+        const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
+
+        const requestHandler = testController.show()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(templatePath, {
+          ...viewData,
+          team: teamCode,
+        })
+      })
+    })
+
+    describe('submit', () => {
+      it('should pass team from body on validation error', async () => {
+        const showPath = '/show'
+        const formId = '12'
+        const teamCode = 'TEAM-789'
+        const viewData = {
+          backLink: '/back',
+          courseName: 'Customer service',
+          updatePath: '/update',
+          communityCampusPerson: { name: 'John Smith' },
+        }
+        page.viewData.mockReturnValue(viewData)
+        page.updatePath.mockReturnValue(showPath)
+
+        const errorSummary = [{ text: 'Error 1', href: '#1', attributes: {} }]
+        const errors = { appointmentId: { text: 'Error' } }
+        page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+
+        const request = createMock<Request>({
+          params: { id: '1' },
+          query: { form: formId },
+          body: { team: teamCode },
+        })
+
+        const requestHandler = testController.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(templatePath, {
+          ...viewData,
+          team: teamCode,
+          errors,
+          errorSummary,
+        })
+      })
+
+      it('should pass team from formData on validation error when body is undefined', async () => {
+        const showPath = '/show'
+        const formId = '12'
+        const teamCode = 'TEAM-101'
+        const formWithTeam = courseCompletionFormFactory.build({ team: teamCode })
+        courseCompletionFormService.getForm.mockResolvedValue(formWithTeam)
+
+        const viewData = {
+          courseName: 'Customer service',
+          backLink: '/back',
+          updatePath: '/update',
+          communityCampusPerson: { name: 'John Smith' },
+        }
+        page.viewData.mockReturnValue(viewData)
+        page.updatePath.mockReturnValue(showPath)
+
+        const errorSummary = [{ text: 'Error 1', href: '#1', attributes: {} }]
+        const errors = { appointmentId: { text: 'Error' } }
+        page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+
+        const request = createMock<Request>({
+          params: { id: '1' },
+          query: { form: formId },
+          body: {},
+        })
+
+        const requestHandler = testController.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(templatePath, {
+          ...viewData,
+          team: teamCode,
+          errors,
+          errorSummary,
+        })
+      })
+    })
+  })
+})

--- a/server/controllers/courseCompletions/process/baseController.ts
+++ b/server/controllers/courseCompletions/process/baseController.ts
@@ -95,18 +95,8 @@ export default abstract class BaseController<TPage extends BaseCourseCompletionF
     const query = req.query as T
     const body = req.body as T
 
-    if (query?.[propertyName]) {
-      return req.query[propertyName].toString()
-    }
+    const value = query?.[propertyName] ?? body?.[propertyName] ?? formData[propertyName]
 
-    if (body?.[propertyName]) {
-      return req.body[propertyName].toString()
-    }
-
-    if (formData[propertyName]) {
-      return formData[propertyName]
-    }
-
-    return undefined
+    return value?.toString()
   }
 }

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -53,6 +53,9 @@ describe('OutcomeController', () => {
         isSensitiveItems: [],
       })
       expect(formService.getForm).toHaveBeenCalledTimes(1)
+      expect(GovukFrontendDateInput.getDateItemsFromStructuredDate).toHaveBeenLastCalledWith({}, false)
+
+      expect(GovUkRadioGroup.yesNoItems).toHaveBeenCalledWith({ checkedValue: undefined })
     })
 
     it('returns values from form if not undefined', async () => {

--- a/server/controllers/courseCompletions/process/outcomeController.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.ts
@@ -4,7 +4,7 @@ import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import GovukFrontendDateInput, { GovUkFrontendDateInputItem } from '../../../forms/GovukFrontendDateInput'
 import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
-import { ValidationErrors, ViewDataWithNotes, ViewDataWithTimeToCredit } from '../../../@types/user-defined'
+import { ValidationErrors, ViewDataWithNotes, ViewDataWithTimeToCredit, YesOrNo } from '../../../@types/user-defined'
 
 type ViewData = {
   dateItems: Array<GovUkFrontendDateInputItem>
@@ -33,8 +33,10 @@ export default class OutcomeController extends BaseController<OutcomePage> {
     const hasDateError = (errors as ValidationErrors<OutcomePageBody>)['date-day'] !== undefined
     const dateItems = GovukFrontendDateInput.getDateItemsFromStructuredDate(date, hasDateError)
     const notes = this.getPropertyValue({ propertyName: 'notes', req, formData })
-    const isSensitive = this.getPropertyValue({ propertyName: 'isSensitive', req, formData })
-    const isSensitiveItems = GovUkRadioGroup.yesNoItems({ checkedValue: isSensitive })
+    const isSensitiveValue = this.getPropertyValue({ propertyName: 'isSensitive', req, formData }) as
+      | YesOrNo
+      | undefined
+    const isSensitiveItems = GovUkRadioGroup.yesNoItems({ checkedValue: isSensitiveValue })
 
     return { timeToCredit, dateItems, notes, isSensitiveItems }
   }

--- a/server/controllers/courseCompletions/process/requirementController.ts
+++ b/server/controllers/courseCompletions/process/requirementController.ts
@@ -23,7 +23,7 @@ export default class RequirementController extends BaseController<RequirementPag
       crn,
     })
 
-    const unpaidWorkOptions = this.page.getUnpaidWorkOptions(unpaidWorkDetails, deliusEventNumber)
+    const unpaidWorkOptions = this.page.getUnpaidWorkOptions(unpaidWorkDetails, Number(deliusEventNumber))
 
     return { unpaidWorkOptions }
   }


### PR DESCRIPTION
## Context

Fixes unable to clear saved value on in progress form
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR

I have introduced a shared method to determine the correct value of a page input (from request form body > saved form), but the implementation did not consider empty strings in the form body (for example, when clearing an input), as empty strings are treated as falsy values.

Fixing this by using the nullish coalescing operator (??), which only aligns the right hand side value if the left hand side is null or undefined. 

Also add explicit tests for original behaviour and new ones for the fix, rather than relying on coverage in implementing controller classes.

### Screenshots of UI changes


https://github.com/user-attachments/assets/7c7c3351-7735-4f17-95b3-bec2980f2a31



## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
