### PR TITLE
Enforce minimum age of dependencies installed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,5 +9,11 @@ save-exact = true
 # Fail if trying to use incorrect version of npm
 engine-strict = true
 
-# Show any output of scripts in the console 
+# Show any output of scripts in the console
 foreground-scripts = true
+
+# Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released
+min-release-age = 7
+
+# Don't allow git dependencies see here
+allow-git = none

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ UI for Community Payback
 
 ## Running the application
 
+### Requirements
+
+- **Node.js**: 24
+- **Npm**: ^11.10
+
 ### Using CP stack
 
 In order to spin up a full local stack with the API (integrating with dependent services) use (CP stack)[https://github.com/ministryofjustice/hmpps-community-payback-api/tree/main/tools/cp-stack].


### PR DESCRIPTION
Following [changes to the hmpps-typescript-template](https://github.com/ministryofjustice/hmpps-template-typescript/pull/706/changes/a82984a29bedda23961bdc0445813cd5be63b6fa#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR15)

Note: we will need to update our npm versions to ^11.10 for this to work, which I have reflected in the README.