### PR TITLE
CPB-858: Add e2e test for community campus form => new appointment

### DIFF
--- a/e2e-tests/delius/projectType.ts
+++ b/e2e-tests/delius/projectType.ts
@@ -1,0 +1,14 @@
+import { PlacementType } from '../fixtures/testOptions'
+
+export default function getProjectType(placementType: PlacementType): {
+  projectType?: string
+} {
+  if (placementType === 'individual') {
+    return { projectType: 'Individual Placement - ICP (Individual Community Placement)' }
+  }
+
+  if (placementType === 'ete') {
+    return { projectType: 'ETE - HMPPS Portal' }
+  }
+  return {}
+}

--- a/e2e-tests/fixtures/personOnProbation.fixture.ts
+++ b/e2e-tests/fixtures/personOnProbation.fixture.ts
@@ -7,6 +7,7 @@ import { createCommunityEvent } from '@ministryofjustice/hmpps-probation-integra
 import PersonOnProbation from '../delius/personOnProbation'
 import { PlacementType, Team } from './testOptions'
 import Project from '../delius/project'
+import getProjectType from '../delius/projectType'
 
 interface PersonOnProbationFixtureSetup {
   page: Page
@@ -54,19 +55,19 @@ export default async ({
     })
   })
 
-  await page.locator('a', { hasText: 'Personal Details' }).click()
+  if (placementType !== 'ete') {
+    await page.locator('a', { hasText: 'Personal Details' }).click()
 
-  await base.step(`Allocating ${pop.crn} to ${project.name}`, async () => {
-    await allocateCurrentCaseToUpwProject(page, {
-      crn: pop.crn,
-      providerName: team.provider,
-      teamName: team.name,
-      projectName: project.name,
-      ...(placementType === 'group'
-        ? {}
-        : { projectType: 'Individual Placement - ICP (Individual Community Placement)' }),
+    await base.step(`Allocating ${pop.crn} to ${project.name}`, async () => {
+      await allocateCurrentCaseToUpwProject(page, {
+        crn: pop.crn,
+        providerName: team.provider,
+        teamName: team.name,
+        projectName: project.name,
+        ...getProjectType(placementType),
+      })
     })
-  })
+  }
 
   return pop
 }

--- a/e2e-tests/fixtures/project.fixture.ts
+++ b/e2e-tests/fixtures/project.fixture.ts
@@ -46,27 +46,32 @@ export default async ({ page, team, placementType }: ProjectFixtureSetup): Promi
         return projectCache[placementType]
       })
     }
-    const project = await base.step(`Creating fresh project`, async () => {
-      return createUpwProject(page, {
-        providerName: team.provider,
-        teamName: team.name,
-        endDate,
-        projectAvailability: {
-          startDate,
-          endDate,
-        },
-        ...getProjectType(placementType),
-      })
-    })
+    const project =
+      placementType === 'ete'
+        ? { projectName: 'Community Campus Test', projectCode: '', projectAvailability: undefined }
+        : await base.step(`Creating fresh project`, async () => {
+            return createUpwProject(page, {
+              providerName: team.provider,
+              teamName: team.name,
+              endDate,
+              projectAvailability: {
+                startDate,
+                endDate,
+              },
+              ...getProjectType(placementType),
+            })
+          })
 
     await base.step(`Caching project: ${project.projectName}`, async () => {
       projectCache[placementType] = {
         name: project.projectName,
         code: project.projectCode,
-        availability: {
-          startTime: project.projectAvailability.startTime,
-          endTime: project.projectAvailability.endTime,
-        },
+        availability: project.projectAvailability
+          ? {
+              startTime: project.projectAvailability.startTime,
+              endTime: project.projectAvailability.endTime,
+            }
+          : undefined,
       }
     })
 

--- a/e2e-tests/fixtures/project.fixture.ts
+++ b/e2e-tests/fixtures/project.fixture.ts
@@ -4,6 +4,7 @@ import { login } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/
 import DateTimeUtils from '../utils/DateTimeUtils'
 import { PlacementType, Team } from './testOptions'
 import Project from '../delius/project'
+import getProjectType from '../delius/projectType'
 
 interface ProjectFixtureSetup {
   page: Page
@@ -14,6 +15,7 @@ interface ProjectFixtureSetup {
 interface ProjectCache {
   group?: Project
   individual?: Project
+  ete?: Project
 }
 
 /*
@@ -53,9 +55,7 @@ export default async ({ page, team, placementType }: ProjectFixtureSetup): Promi
           startDate,
           endDate,
         },
-        ...(placementType === 'group'
-          ? {}
-          : { projectType: 'Individual Placement - ICP (Individual Community Placement)' }),
+        ...getProjectType(placementType),
       })
     })
 

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test'
+import { test as base, TestInfo } from '@playwright/test'
 import { TestOptions } from './testOptions'
 import setupPersonOnProbationFixture from './personOnProbation.fixture'
 import setupProjectFixture from './project.fixture'
@@ -48,10 +48,22 @@ export default base.extend<TestOptions>({
   placementType: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use, testInfo) => {
-      const type: TestOptions['placementType'] = testInfo.file.includes('group-placements') ? 'group' : 'individual'
+      const type = getPlacementType(testInfo)
 
       use(type)
     },
     { scope: 'test' },
   ],
 })
+
+function getPlacementType(testInfo: TestInfo): TestOptions['placementType'] {
+  if (testInfo.file.includes('group-placements')) {
+    return 'group'
+  }
+
+  if (testInfo.file.includes('ete')) {
+    return 'ete'
+  }
+
+  return 'individual'
+}

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -26,6 +26,7 @@ export default base.extend<TestOptions>({
       provider: 'East of England',
       name: 'CPB Automated Test Team',
       supervisor: 'CPBTest Supervisor [PS1 - PS - Other]',
+      pdu: 'Suffolk',
     },
     { option: true },
   ],

--- a/e2e-tests/fixtures/testOptions.ts
+++ b/e2e-tests/fixtures/testOptions.ts
@@ -20,7 +20,7 @@ export interface TestOptions {
   placementType: PlacementType
 }
 
-export type PlacementType = 'group' | 'individual'
+export type PlacementType = 'group' | 'individual' | 'ete'
 
 export interface Team {
   name: string

--- a/e2e-tests/fixtures/testOptions.ts
+++ b/e2e-tests/fixtures/testOptions.ts
@@ -26,4 +26,5 @@ export interface Team {
   name: string
   provider: string
   supervisor: string
+  pdu: string
 }

--- a/e2e-tests/pages/appointments/logHoursPage.ts
+++ b/e2e-tests/pages/appointments/logHoursPage.ts
@@ -1,25 +1,22 @@
 import { Locator, Page } from '@playwright/test'
 import AppointmentFormPage from './appointmentFormPage'
+import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 
 export default class LogHoursPage extends AppointmentFormPage {
   startTimeFieldLocator: Locator
 
   endTimeFieldLocator: Locator
 
-  penaltyTimeHoursFieldLocator: Locator
-
-  penaltyTimeMinutesFieldLocator: Locator
+  hoursMinutesInput: HoursMinutesInputComponent
 
   constructor(page: Page) {
     super(page, 'Log start and end time')
     this.startTimeFieldLocator = page.getByLabel('Start time')
     this.endTimeFieldLocator = page.getByLabel('End time')
-    this.penaltyTimeHoursFieldLocator = page.getByLabel('Hours')
-    this.penaltyTimeMinutesFieldLocator = page.getByLabel('Minutes')
+    this.hoursMinutesInput = new HoursMinutesInputComponent(page)
   }
 
-  async enterPenaltyHours() {
-    await this.penaltyTimeHoursFieldLocator.fill('1')
-    await this.penaltyTimeMinutesFieldLocator.fill('00')
+  async enterPenaltyHours(hours = '1', minutes = '00') {
+    await this.hoursMinutesInput.enterHours(hours, minutes)
   }
 }

--- a/e2e-tests/pages/components/dataTableComponent.ts
+++ b/e2e-tests/pages/components/dataTableComponent.ts
@@ -7,9 +7,12 @@ export default class DataTableComponent {
 
   readonly itemsLocator: Locator
 
+  readonly nextPageButtonLocator: Locator
+
   constructor(page: Page) {
     this.expect = new DataTableAssertions(this)
     this.itemsLocator = page.getByRole('table').getByRole('row')
+    this.nextPageButtonLocator = page.getByRole('link', { name: 'Next' })
   }
 
   resultCount(): Promise<number> {
@@ -17,7 +20,16 @@ export default class DataTableComponent {
   }
 
   async getRowByContent(content: string): Promise<Locator> {
-    return this.itemsLocator.filter({ hasText: content })
+    const row = this.itemsLocator.filter({ hasText: content })
+    if (await row.isVisible()) {
+      return row
+    }
+
+    if (await this.nextPageButtonLocator.isVisible()) {
+      await this.nextPageButtonLocator.click()
+      return this.getRowByContent(content)
+    }
+    throw new Error(`Row with content "${content}" not found`)
   }
 }
 

--- a/e2e-tests/pages/components/dateInputComponent.ts
+++ b/e2e-tests/pages/components/dateInputComponent.ts
@@ -1,0 +1,21 @@
+import { Locator, Page } from '@playwright/test'
+
+export default class DateInputComponent {
+  readonly dayFieldLocator: Locator
+
+  readonly monthFieldLocator: Locator
+
+  readonly yearFieldLocator: Locator
+
+  constructor(page: Page) {
+    this.dayFieldLocator = page.getByLabel('day')
+    this.monthFieldLocator = page.getByLabel('month')
+    this.yearFieldLocator = page.getByLabel('year')
+  }
+
+  async enterDate(date: Date) {
+    await this.dayFieldLocator.fill(date.getDate().toString())
+    await this.monthFieldLocator.fill((date.getMonth() + 1).toString().padStart(2, '0'))
+    await this.yearFieldLocator.fill(date.getFullYear().toString())
+  }
+}

--- a/e2e-tests/pages/components/hoursMinutesInputComponent.ts
+++ b/e2e-tests/pages/components/hoursMinutesInputComponent.ts
@@ -1,0 +1,17 @@
+import { Locator, Page } from '@playwright/test'
+
+export default class HoursMinutesInputComponent {
+  hoursFieldLocator: Locator
+
+  minutesFieldLocator: Locator
+
+  constructor(page: Page) {
+    this.hoursFieldLocator = page.getByLabel('Hours')
+    this.minutesFieldLocator = page.getByLabel('Minutes')
+  }
+
+  async enterHours(hours: string, minutes: string) {
+    await this.hoursFieldLocator.fill(hours)
+    await this.minutesFieldLocator.fill(minutes)
+  }
+}

--- a/e2e-tests/pages/components/pduFilterComponent.ts
+++ b/e2e-tests/pages/components/pduFilterComponent.ts
@@ -16,12 +16,12 @@ export default class PduFilterComponent {
     this.applyButtonLocator = page.getByRole('button', { name: 'Apply', exact: true })
   }
 
-  async selectPdu() {
-    await this.pduSelectLocator.selectOption({ label: 'Cardiff and Vale' })
+  async selectPdu(label: string) {
+    await this.pduSelectLocator.selectOption({ label })
   }
 
-  async selectRegion() {
-    await this.regionSelectLocator.selectOption({ label: 'Wales' })
+  async selectRegion(label: string) {
+    await this.regionSelectLocator.selectOption({ label })
   }
 
   async submitForm() {

--- a/e2e-tests/pages/courseCompletions/courseCompletionDetailsPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionDetailsPage.ts
@@ -13,6 +13,10 @@ export default class CourseCompletionDetailsPage extends BasePage {
     super(page)
     this.expect = new CourseCompletionDetailsPageAssertions(this, expectedTitle)
   }
+
+  async clickProcess() {
+    await this.page.getByRole('button', { name: 'Process' }).click()
+  }
 }
 
 class CourseCompletionDetailsPageAssertions {

--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -1,0 +1,93 @@
+/* eslint max-classes-per-file: "off" -- splitting out these classes would cause an import dependency loop */
+
+import { expect, Locator, Page } from '@playwright/test'
+import BasePage from '../basePage'
+import { CourseCompletionPage } from '../../../server/pages/courseCompletions/process/pathMap'
+import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
+import DateInputComponent from '../components/dateInputComponent'
+import { Team } from '../../fixtures/testOptions'
+
+export default class CourseCompletionFormPage extends BasePage {
+  readonly expect: CourseCompletionFormPageAssertions
+
+  private readonly crnFieldLocator: Locator
+
+  private readonly requirementRadioGroupLocator: Locator
+
+  private readonly teamFieldLocator: Locator
+
+  private readonly applyTeamButtonLocator: Locator
+
+  private readonly projectFieldLocator: Locator
+
+  private readonly hoursMinutesInput: HoursMinutesInputComponent
+
+  private readonly dateInput: DateInputComponent
+
+  private readonly continueButtonLocator: Locator
+
+  private readonly submitButtonLocator: Locator
+
+  readonly createNewAppointmentButton: Locator
+
+  constructor(page: Page) {
+    super(page)
+    this.expect = new CourseCompletionFormPageAssertions(this)
+    this.hoursMinutesInput = new HoursMinutesInputComponent(page)
+    this.dateInput = new DateInputComponent(page)
+    this.continueButtonLocator = page.getByRole('button', { name: 'Continue' })
+    this.crnFieldLocator = page.getByLabel('Add a crn')
+    this.requirementRadioGroupLocator = page.getByRole('group', { name: 'Existing requirements' })
+    this.teamFieldLocator = page.getByLabel('Project team')
+    this.applyTeamButtonLocator = page.getByRole('button', { name: 'Select team' })
+    this.projectFieldLocator = page.getByLabel('Choose project', { exact: true })
+    this.submitButtonLocator = page.getByRole('button', { name: 'Submit' })
+    this.createNewAppointmentButton = page.getByRole('button', { name: 'Connect an appointment' })
+  }
+
+  async continue() {
+    await this.continueButtonLocator.click()
+  }
+
+  async fillCrn(crn: string) {
+    await this.crnFieldLocator.fill(crn)
+  }
+
+  async selectRequirement() {
+    await this.requirementRadioGroupLocator.getByRole('radio').nth(0).check()
+  }
+
+  async selectTeam(team: Team) {
+    await this.teamFieldLocator.selectOption({ label: team.name })
+    await this.applyTeamButtonLocator.click()
+    await this.projectFieldLocator.selectOption({ index: 1 })
+  }
+
+  async completeOutcomeForm() {
+    await this.hoursMinutesInput.enterHours('1', '10')
+    await this.dateInput.enterDate(new Date())
+  }
+
+  async submit() {
+    await this.submitButtonLocator.click()
+  }
+}
+
+class CourseCompletionFormPageAssertions {
+  constructor(private readonly page: CourseCompletionFormPage) {}
+
+  async toBeOnThePage(formStep: CourseCompletionPage) {
+    await expect(this.page.headingLocator).toContainText(this.expectedTitle[formStep])
+  }
+
+  private expectedTitle: Record<CourseCompletionPage, string> = {
+    crn: 'Match with CRN',
+    person: 'Confirm CRN match',
+    requirement: 'Choose an unpaid work requirement',
+    history: 'Check course history',
+    project: 'Match with a project',
+    appointments: 'Connect an appointment',
+    outcome: 'Record an outcome',
+    confirm: 'Confirm details',
+  }
+}

--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -43,7 +43,7 @@ export default class CourseCompletionFormPage extends BasePage {
     this.applyTeamButtonLocator = page.getByRole('button', { name: 'Select team' })
     this.projectFieldLocator = page.getByLabel('Choose project', { exact: true })
     this.submitButtonLocator = page.getByRole('button', { name: 'Submit' })
-    this.createNewAppointmentButton = page.getByRole('button', { name: 'Connect an appointment' })
+    this.createNewAppointmentButton = page.getByRole('button', { name: 'Create an appointment' })
   }
 
   async continue() {
@@ -87,7 +87,7 @@ class CourseCompletionFormPageAssertions {
     requirement: 'Choose an unpaid work requirement',
     history: 'Check course history',
     project: 'Match with a project',
-    appointments: 'Connect an appointment',
+    appointments: 'Create an appointment',
     outcome: 'Record an outcome',
     confirm: 'Confirm details',
   }

--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -6,6 +6,7 @@ import { CourseCompletionPage } from '../../../server/pages/courseCompletions/pr
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 import DateInputComponent from '../components/dateInputComponent'
 import { Team } from '../../fixtures/testOptions'
+import Project from '../../delius/project'
 
 export default class CourseCompletionFormPage extends BasePage {
   readonly expect: CourseCompletionFormPageAssertions
@@ -57,10 +58,10 @@ export default class CourseCompletionFormPage extends BasePage {
     await this.requirementRadioGroupLocator.getByRole('radio').nth(0).check()
   }
 
-  async selectTeam(team: Team) {
+  async selectProject(team: Team, project: Project) {
     await this.teamFieldLocator.selectOption({ label: team.name })
     await this.applyTeamButtonLocator.click()
-    await this.projectFieldLocator.selectOption({ index: 1 })
+    await this.projectFieldLocator.selectOption({ label: project.name })
   }
 
   async completeOutcomeForm() {

--- a/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -31,10 +31,7 @@ export default class SearchCourseCompletionsPage extends BasePage {
 
   readonly pduFilter: PduFilterComponent
 
-  constructor(
-    private readonly page: Page,
-    expectedTitle: string,
-  ) {
+  constructor(page: Page, expectedTitle: string) {
     super(page)
     this.expect = new SearchCourseCompletionsPageAssertions(this, expectedTitle)
     this.courseCompletions = new DataTableComponent(page)
@@ -63,17 +60,13 @@ export default class SearchCourseCompletionsPage extends BasePage {
     await this.searchButtonLocator.click()
   }
 
-  async clickViewACourseCompletion() {
-    const personName = this.page
-      .locator('.govuk-table__body .govuk-table__row')
-      .first()
-      .locator('td')
-      .first()
-      .innerText()
+  async clickCourseCompletion(personName: string) {
+    const row = await this.courseCompletions.getRowByContent(personName)
+    await this.clickProcess(row)
+  }
 
-    await this.courseCompletions.itemsLocator.getByRole('link', { name: 'Process' }).first().click()
-
-    return personName
+  async clickProcess(row: Locator) {
+    await row.getByRole('link', { name: 'Process' }).click()
   }
 }
 

--- a/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -4,6 +4,7 @@ import { expect, Locator, Page } from '@playwright/test'
 import BasePage from '../basePage'
 import DataTableComponent from '../components/dataTableComponent'
 import PduFilterComponent from '../components/pduFilterComponent'
+import { Team } from '../../fixtures/testOptions'
 
 export default class SearchCourseCompletionsPage extends BasePage {
   readonly expect: SearchCourseCompletionsPageAssertions
@@ -49,9 +50,9 @@ export default class SearchCourseCompletionsPage extends BasePage {
     this.applyRegionLocator = page.getByRole('button', { name: 'Apply', exact: true })
   }
 
-  async completeSearchForm() {
-    await this.pduFilter.selectRegion()
-    await this.pduFilter.selectPdu()
+  async completeSearchForm(team: Team) {
+    await this.pduFilter.selectRegion(team.provider)
+    await this.pduFilter.selectPdu(team.pdu)
   }
 
   async applyRegion() {

--- a/e2e-tests/steps/searchCourseCompletions.ts
+++ b/e2e-tests/steps/searchCourseCompletions.ts
@@ -1,8 +1,9 @@
 import { Page } from '@playwright/test'
 import HomePage from '../pages/homePage'
 import SearchCourseCompletionsPage from '../pages/courseCompletions/searchCourseCompletionsPage'
+import { Team } from '../fixtures/testOptions'
 
-export default async (page: Page, homePage: HomePage) => {
+export default async (page: Page, homePage: HomePage, team: Team) => {
   const searchCourseCompletionsPage = new SearchCourseCompletionsPage(
     page,
     'Process Community Campus course completions',
@@ -11,7 +12,7 @@ export default async (page: Page, homePage: HomePage) => {
   await homePage.courseCompletionsLink.click()
   await searchCourseCompletionsPage.expect.toBeOnThePage()
 
-  await searchCourseCompletionsPage.completeSearchForm()
+  await searchCourseCompletionsPage.completeSearchForm(team)
   await searchCourseCompletionsPage.submitForm()
   return searchCourseCompletionsPage
 }

--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -1,19 +1,36 @@
 import request from 'superagent'
 import { faker } from '@faker-js/faker'
+import { randomUUID } from 'node:crypto'
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
+import { Team } from '../fixtures/testOptions'
+import PersonOnProbation from '../delius/personOnProbation'
 
-export default async (externalApiClient: {
-  enabled: boolean
-  certBase64: string
-  apiKey: string
-  privateKeyBase64: string
-  url: string
-}) => {
+export default async (
+  externalApiClient: {
+    enabled: boolean
+    certBase64: string
+    apiKey: string
+    privateKeyBase64: string
+    url: string
+  },
+  team: Team,
+  personOnProbation?: PersonOnProbation,
+) => {
   const messageContent = {
-    externalRef: crypto.randomUUID(),
-    firstName: faker.person.firstName(),
-    lastName: faker.person.lastName(),
+    externalRef: randomUUID(),
+    firstName: personOnProbation?.firstName ?? faker.person.firstName(),
+    lastName: personOnProbation?.lastName ?? faker.person.lastName(),
     completionDateTime: new Date().toISOString(),
+    courseName: faker.helpers.arrayElement([
+      'First aid',
+      'Customer Service Excellence',
+      'Food Hygiene Level 2',
+      'Business Communication Skills',
+      'Construction Skills',
+      'Health and Safety Basics',
+    ]),
+    pdu: team.pdu,
+    office: team.provider,
   }
 
   if (externalApiClient.enabled) {
@@ -56,6 +73,9 @@ export interface CourseCompletionContent {
   firstName: string
   lastName: string
   completionDateTime: string
+  pdu: string
+  office: string
+  courseName: string
 }
 
 export class CourseCompletionMessageBuilder {
@@ -70,10 +90,10 @@ export class CourseCompletionMessageBuilder {
          "lastName": "${content.lastName}",
          "dateOfBirth": "1990-01-01",
          "region": "Wales",
-         "pdu": "Cardiff and Vale",
-         "office": "Cardiff",
+         "pdu": "${content.pdu}",
+         "office": "${content.office}",
          "email": "john.doe@example.com",
-         "courseName": "First Aid",
+         "courseName": "${content.courseName}",
          "courseType": "Example Course Type",
          "provider": "Moodle",
          "completionDateTime": "${content.completionDateTime}",

--- a/e2e-tests/tests/ete/06_course_completion.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion.spec.ts
@@ -11,6 +11,7 @@ test('Process course completion - create new appointment', async ({
   deliusUser,
   team,
   personOnProbation,
+  project,
 }) => {
   await test.step('Send Course Completion Message', async () => {
     return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
@@ -46,7 +47,7 @@ test('Process course completion - create new appointment', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectTeam(team)
+  await courseCompletionFormPage.selectProject(team, project)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')

--- a/e2e-tests/tests/ete/06_course_completion.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion.spec.ts
@@ -4,9 +4,9 @@ import searchCourseCompletions from '../../steps/searchCourseCompletions'
 import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
 import signIn from '../../steps/signIn'
 
-test('Process course completion', async ({ eteExternalApiClient, page, deliusUser }) => {
+test('Process course completion', async ({ eteExternalApiClient, page, deliusUser, team, personOnProbation }) => {
   await test.step('Send Course Completion Message', async () => {
-    await sendCourseCompletionMessage(eteExternalApiClient)
+    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
   })
 
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/ete/06_course_completion.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion.spec.ts
@@ -10,7 +10,7 @@ test('Process course completion', async ({ eteExternalApiClient, page, deliusUse
   })
 
   const homePage = await signIn(page, deliusUser)
-  const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage)
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
 
   await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
 

--- a/e2e-tests/tests/ete/06_course_completion.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion.spec.ts
@@ -14,7 +14,9 @@ test('Process course completion', async ({ eteExternalApiClient, page, deliusUse
 
   await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
 
-  const personName = await searchCourseCompletionsPage.clickViewACourseCompletion()
+  const personName = personOnProbation.getFullName()
+
+  await searchCourseCompletionsPage.clickCourseCompletion(personName)
 
   const courseCompletionsDetailsPage = new CourseCompletionDetailsPage(page, personName)
   await courseCompletionsDetailsPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/ete/06_course_completion.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion.spec.ts
@@ -1,10 +1,17 @@
 import test from '../../fixtures/test'
 import CourseCompletionDetailsPage from '../../pages/courseCompletions/courseCompletionDetailsPage'
+import CourseCompletionFormPage from '../../pages/courseCompletions/courseCompletionFormPage'
 import searchCourseCompletions from '../../steps/searchCourseCompletions'
 import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
 import signIn from '../../steps/signIn'
 
-test('Process course completion', async ({ eteExternalApiClient, page, deliusUser, team, personOnProbation }) => {
+test('Process course completion - create new appointment', async ({
+  eteExternalApiClient,
+  page,
+  deliusUser,
+  team,
+  personOnProbation,
+}) => {
   await test.step('Send Course Completion Message', async () => {
     return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
   })
@@ -20,4 +27,37 @@ test('Process course completion', async ({ eteExternalApiClient, page, deliusUse
 
   const courseCompletionsDetailsPage = new CourseCompletionDetailsPage(page, personName)
   await courseCompletionsDetailsPage.expect.toBeOnThePage()
+  await courseCompletionsDetailsPage.clickProcess()
+
+  const courseCompletionFormPage = new CourseCompletionFormPage(page)
+
+  await courseCompletionFormPage.expect.toBeOnThePage('crn')
+  await courseCompletionFormPage.fillCrn(personOnProbation.crn)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('person')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('history')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('requirement')
+  await courseCompletionFormPage.selectRequirement()
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('project')
+  await courseCompletionFormPage.selectTeam(team)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('appointments')
+  await courseCompletionFormPage.createNewAppointmentButton.click()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('outcome')
+  await courseCompletionFormPage.completeOutcomeForm()
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.continue()
+
+  await searchCourseCompletionsPage.expect.toBeOnThePage()
 })

--- a/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
@@ -2,13 +2,12 @@ import { expect } from '@playwright/test'
 import test from '../../fixtures/test'
 import signIn from '../../steps/signIn'
 import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
-import CourseCompletionDetailsPage from '../../pages/courseCompletions/courseCompletionDetailsPage'
 import SearchCourseCompletionsPage from '../../pages/courseCompletions/searchCourseCompletionsPage'
 
 test.describe('Without javascript', () => {
   test.use({ javaScriptEnabled: false })
 
-  test('Process course completion', async ({ eteExternalApiClient, page, deliusUser, team }) => {
+  test('Search for course completions', async ({ eteExternalApiClient, page, deliusUser, team }) => {
     await page.goto('/sign-out')
     await expect(page.locator('h1')).toContainText('Sign in')
 
@@ -30,10 +29,5 @@ test.describe('Without javascript', () => {
     await searchCourseCompletionsPage.submitForm()
 
     await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
-
-    const personName = await searchCourseCompletionsPage.clickViewACourseCompletion()
-
-    const courseCompletionsDetailsPage = new CourseCompletionDetailsPage(page, personName)
-    await courseCompletionsDetailsPage.expect.toBeOnThePage()
   })
 })

--- a/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
@@ -8,11 +8,11 @@ import SearchCourseCompletionsPage from '../../pages/courseCompletions/searchCou
 test.describe('Without javascript', () => {
   test.use({ javaScriptEnabled: false })
 
-  test('Process course completion', async ({ eteExternalApiClient, page, deliusUser }) => {
+  test('Process course completion', async ({ eteExternalApiClient, page, deliusUser, team }) => {
     await page.goto('/sign-out')
     await expect(page.locator('h1')).toContainText('Sign in')
 
-    await sendCourseCompletionMessage(eteExternalApiClient)
+    await sendCourseCompletionMessage(eteExternalApiClient, team)
 
     const homePage = await signIn(page, deliusUser)
 

--- a/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
@@ -24,9 +24,9 @@ test.describe('Without javascript', () => {
     await homePage.courseCompletionsLink.click()
     await searchCourseCompletionsPage.expect.toBeOnThePage()
 
-    await searchCourseCompletionsPage.pduFilter.selectRegion()
+    await searchCourseCompletionsPage.pduFilter.selectRegion(team.provider)
     await searchCourseCompletionsPage.applyRegion()
-    await searchCourseCompletionsPage.pduFilter.selectPdu()
+    await searchCourseCompletionsPage.pduFilter.selectPdu(team.pdu)
     await searchCourseCompletionsPage.submitForm()
 
     await searchCourseCompletionsPage.expect.toSeeCourseCompletions()


### PR DESCRIPTION
## Context

Adds an e2e test for recording time for a course completion event against a new appointment

[CPB-858](https://dsdmoj.atlassian.net/browse/CPB-858)

## Changes in this PR

This adds the functional steps for processing a course completion event by creating a new appointment. 
It does not assert on any content on each page, unless part of an action (such as selecting a given option) - we have integration tests that cover this.

Have expanded the course completion message builder to take more of the config from the test fixtures.

Still to come:
- Assertion for credit time in delius (need to add a step in https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests)
- Test for crediting time against an existing appointment
- Improve project selection

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
