### PR TITLE
CPB-826 case admin UI remove log start and end time page when updating an appointment with an unacceptable absence

### DIFF
--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -47,11 +47,13 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
     this.confirmPage = page
   }
 
-  async toShowAnswers(supervisor: string, availability: ProjectAvailability) {
-    const startTime = DateTimeFormats.stripTime(availability.startTime)
-    const endTime = DateTimeFormats.stripTime(availability.endTime)
+  async toShowAnswers(supervisor: string, availability: ProjectAvailability, attended = true) {
     await this.confirmPage.details.expect.toHaveItemWith('Supervising officer', supervisor)
-    await this.confirmPage.details.expect.toHaveItemWith('Start and end time', `${startTime} - ${endTime}`)
+    if (attended) {
+      const startTime = DateTimeFormats.stripTime(availability.startTime)
+      const endTime = DateTimeFormats.stripTime(availability.endTime)
+      await this.confirmPage.details.expect.toHaveItemWith('Start and end time', `${startTime} - ${endTime}`)
+    }
   }
 
   async toShowPenaltyHoursAnswerWithHoursApplied() {

--- a/e2e-tests/steps/completeAttendanceOutcome.ts
+++ b/e2e-tests/steps/completeAttendanceOutcome.ts
@@ -10,20 +10,6 @@ export const completeAttendedEnforceableOutcome = async (page: Page, attendanceO
   return step(page, attendanceOutcomePage, () => attendanceOutcomePage.chooseAttendedEnforceableOutcome())
 }
 
-export const completeNotAttendedEnforceableOutcome = async (
-  page: Page,
-  attendanceOutcomePage: AttendanceOutcomePage,
-) => {
-  return step(page, attendanceOutcomePage, () => attendanceOutcomePage.chooseEnforcementOutcome())
-}
-
-export const completeNotAttendedNotEnforceableOutcome = async (
-  page: Page,
-  attendanceOutcomePage: AttendanceOutcomePage,
-) => {
-  return step(page, attendanceOutcomePage, () => attendanceOutcomePage.chooseNotAttendedNotEnforcementOutcome())
-}
-
 const step = async (page: Page, attendanceOutcomePage: AttendanceOutcomePage, chooseOutcome: () => Promise<void>) => {
   const logHoursPage = new LogHoursPage(page)
 

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -4,7 +4,6 @@ import searchForASession from '../../steps/searchForASession'
 import selectASession from '../../steps/selectASession'
 import clickUpdateAnAppointment from '../../steps/clickUpdateAnAppointment'
 import completeCheckAppointmentDetails from '../../steps/completeCheckAppointmentDetails'
-import { completeNotAttendedEnforceableOutcome } from '../../steps/completeAttendanceOutcome'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import { checkAppointmentOnDelius } from '../../steps/delius'
 import DateTimeUtils from '../../utils/DateTimeUtils'
@@ -32,11 +31,11 @@ test('Update a session appointment with an enforceable outcome', async ({
     team.supervisor,
   )
 
-  const logHoursPage = await completeNotAttendedEnforceableOutcome(page, attendanceOutcomePage)
-  await logHoursPage.continue()
+  await attendanceOutcomePage.chooseEnforcementOutcome()
+  await attendanceOutcomePage.continue()
 
   const confirmPage = new ConfirmPage(page)
-  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
+  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
   await confirmPage.expect.toShowAttendanceAnswer('Unacceptable Absence')
   await confirmPage.expect.toShowMessageThatOutcomeWillAlert()
 

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -4,7 +4,6 @@ import searchForASession from '../../steps/searchForASession'
 import selectASession from '../../steps/selectASession'
 import clickUpdateAnAppointment from '../../steps/clickUpdateAnAppointment'
 import completeCheckAppointmentDetails from '../../steps/completeCheckAppointmentDetails'
-import { completeNotAttendedNotEnforceableOutcome } from '../../steps/completeAttendanceOutcome'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import { checkAppointmentOnDelius } from '../../steps/delius'
 import DateTimeUtils from '../../utils/DateTimeUtils'
@@ -32,13 +31,13 @@ test('Update a session appointment with a not attended but not enforceable outco
     team.supervisor,
   )
 
-  const logHoursPage = await completeNotAttendedNotEnforceableOutcome(page, attendanceOutcomePage)
-  await logHoursPage.continue()
+  await attendanceOutcomePage.chooseNotAttendedNotEnforcementOutcome()
+  await attendanceOutcomePage.continue()
 
   const confirmPage = new ConfirmPage(page)
   await confirmPage.expect.toBeOnThePage()
 
-  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
+  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
   await confirmPage.expect.toShowAttendanceAnswer('Rescheduled - Service Request')
 
   await confirmPage.confirmButtonLocator.click()

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -29,7 +29,7 @@
 // Scenario: navigating back from confirm - not attended
 //    Given I am on the confirm page of an in progress update
 //    And I click back
-//    Then I can see the log hours question
+//    Then I can see the attendance outcome page
 //
 // Scenario: navigating back to a given section
 //    Given I am on the confirm page of an in progress update
@@ -210,8 +210,12 @@ context('Confirm appointment details page', () => {
       compliancePage.shouldShowEnteredAnswers(form.attendanceData)
     })
 
-    // Scenario: navigating back from confirm - did not attended
-    it('did not attend => returns to log hours page', function test() {
+    // Scenario: navigating back from confirm - not attended
+    it('did not attend => returns to attendance outcome page', function test() {
+      const attendedOutcome = contactOutcomeFactory.build({ attended: true })
+      const contactOutcomes = contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] })
+      cy.task('stubGetContactOutcomes', { contactOutcomes })
+
       // Given I am on the confirm page of an in progress update not attended
       const form = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({
@@ -227,8 +231,8 @@ context('Confirm appointment details page', () => {
       // And I click back
       page.clickBack()
 
-      // Then I can see the log hours questions
-      Page.verifyOnPage(LogHoursPage, this.appointment)
+      // Then I can see the attendance outcome page
+      Page.verifyOnPage(AttendanceOutcomePage, this.appointment)
     })
   })
 
@@ -335,7 +339,8 @@ context('Confirm appointment details page', () => {
     })
 
     it('navigates back to the log hours page via start and end time section', function test() {
-      const form = appointmentOutcomeFormFactory.build()
+      const contactOutcome = contactOutcomeFactory.build({ attended: true })
+      const form = appointmentOutcomeFormFactory.build({ contactOutcome })
 
       // Given I am on the confirm page of an in progress update
       cy.task('stubFindAppointment', { appointment: this.appointment })

--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -22,12 +22,18 @@
 //    When I submit the form
 //    Then I see the attendance outcome page with errors
 
-//  Scenario: Completing the attendance outcome page
+//  Scenario: Completing the attendance outcome page (attended)
 //    Given I am on the attendance outcome page for an appointment
-//    And I complete the form with an outcome
+//    And I complete the form with an attended outcome
 //    When I submit the form
 //    Then I see the log time page
-//
+
+//  Scenario: Completing the attendance outcome page (not attended)
+//    Given I am on the attendance outcome page for an appointment
+//    And I complete the form with a not attended outcome
+//    When I submit the form
+//    Then I see the confirm details page
+
 //  Scenario: Returning to the appointment details page
 //    Given I am on the attendance outcome page for an appointment
 //    When I click back
@@ -48,6 +54,7 @@ import { ContactOutcomeDto } from '../../../server/@types/shared'
 import appointmentOutcomeFormFactory from '../../../server/testutils/factories/appointmentOutcomeFormFactory'
 import projectFactory from '../../../server/testutils/factories/projectFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
+import ConfirmDetailsPage from '../../pages/appointments/confirmDetailsPage'
 
 context('Attendance outcome', () => {
   beforeEach(() => {
@@ -58,7 +65,8 @@ context('Attendance outcome', () => {
     const appointment = appointmentFactory.build({ id: 1001 })
     cy.wrap(appointment).as('appointment')
 
-    const contactOutcomes = contactOutcomesFactory.build()
+    const attendedOutcome = contactOutcomeFactory.build({ attended: true })
+    const contactOutcomes = contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] })
     cy.wrap(contactOutcomes).as('contactOutcomes')
   })
 
@@ -143,12 +151,12 @@ context('Attendance outcome', () => {
     page.shouldShowErrorSummary('attendanceOutcome', 'The outcome entered must be: acceptable absence')
   })
 
-  // Scenario: Completing the attendance outcome page
+  // Scenario: Completing the attendance outcome page (attended)
   it('submits the form and navigates to the next page', function test() {
     // Given I am on the attendance outcome page for an appointment
     const page = AttendanceOutcomePage.visit(this.appointment)
 
-    // And I complete the form with an outcome
+    // And I complete the form with an attended outcome
     page.completeForm(this.contactOutcomes.contactOutcomes[0].code)
 
     cy.task('stubSaveAppointmentForm')
@@ -157,6 +165,26 @@ context('Attendance outcome', () => {
 
     // Then I see the log time page
     Page.verifyOnPage(LogHoursPage, this.appointment)
+  })
+
+  // Scenario: Completing the attendance outcome page (not attended)
+  it('submits the form and navigates to the next page', function test() {
+    const notAttendedOutcome = contactOutcomeFactory.build({ attended: false })
+    const contactOutcomes = contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] })
+    cy.task('stubGetContactOutcomes', { contactOutcomes })
+
+    // Given I am on the attendance outcome page for an appointment
+    const page = AttendanceOutcomePage.visit(this.appointment)
+
+    // And I complete the form with a not attended outcome
+    page.completeForm(contactOutcomes.contactOutcomes[0].code)
+
+    cy.task('stubSaveAppointmentForm')
+    // When I submit the form
+    page.clickSubmit()
+
+    // Then I see the confirm details page
+    Page.verifyOnPage(ConfirmDetailsPage, this.appointment)
   })
 
   //  Scenario: Returning to appointment details page

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -445,20 +445,45 @@ describe('AttendanceOutcomePage', () => {
   })
 
   describe('next', () => {
-    it('should return log hours link with given appointmentId', () => {
-      const appointmentId = '1'
-      const projectCode = '2'
-      const path = '/path'
-      const page = new AttendanceOutcomePage({
-        query: {},
-        appointment,
-        contactOutcomes: contactOutcomesFactory.build().contactOutcomes,
+    describe('when the contact outcome is attended', () => {
+      it('should return log hours link with given appointmentId', () => {
+        const appointmentId = '1'
+        const projectCode = '2'
+        const path = '/path'
+
+        const attendedOutcome = contactOutcomeFactory.build({ attended: true })
+
+        const page = new AttendanceOutcomePage({
+          query: { attendanceOutcome: attendedOutcome.code },
+          appointment,
+          contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] }).contactOutcomes,
+        })
+
+        jest.spyOn(paths.appointments, 'logHours').mockReturnValue(path)
+
+        expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+        expect(paths.appointments.logHours).toHaveBeenCalledWith({ projectCode, appointmentId })
       })
+    })
+    describe('when the contact outcome is not attended', () => {
+      it('should return confirm link with given appointmentId', () => {
+        const appointmentId = '1'
+        const projectCode = '2'
+        const path = '/path'
 
-      jest.spyOn(paths.appointments, 'logHours').mockReturnValue(path)
+        const notAttendedOutcome = contactOutcomeFactory.build({ attended: false })
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.logHours).toHaveBeenCalledWith({ projectCode, appointmentId })
+        const page = new AttendanceOutcomePage({
+          query: { attendanceOutcome: notAttendedOutcome.code },
+          appointment,
+          contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }).contactOutcomes,
+        })
+
+        jest.spyOn(paths.appointments, 'confirm').mockReturnValue(path)
+
+        expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+        expect(paths.appointments.confirm).toHaveBeenCalledWith({ projectCode, appointmentId })
+      })
     })
   })
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -90,6 +90,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {
+    const contactOutcome = this.contactOutcomes.find(outcome => outcome.code === this.query.attendanceOutcome)
+
+    if (!contactOutcome?.attended) {
+      return paths.appointments.confirm({ projectCode, appointmentId })
+    }
+
     return paths.appointments.logHours({ projectCode, appointmentId })
   }
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -63,14 +63,14 @@ describe('ConfirmPage', () => {
         expect(result.backLink).toBe(pathWithQuery)
       })
 
-      it('should return an object containing a back link to the log hours page if did not attend', async () => {
-        jest.spyOn(paths.appointments, 'logHours')
+      it('should return an object containing a back link to the attendance outcome page if did not attend', async () => {
+        jest.spyOn(paths.appointments, 'attendanceOutcome')
         const formWithoutEnforcement = appointmentOutcomeFormFactory.build({
           contactOutcome: contactOutcomeFactory.build({ attended: false }),
         })
 
         const result = page.viewData(appointment, formWithoutEnforcement)
-        expect(paths.appointments.logHours).toHaveBeenCalledWith({
+        expect(paths.appointments.attendanceOutcome).toHaveBeenCalledWith({
           projectCode: appointment.projectCode,
           appointmentId: appointment.id.toString(),
         })
@@ -212,13 +212,7 @@ describe('ConfirmPage', () => {
               html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
             },
             actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'start and end time',
-                },
-              ],
+              items: [],
             },
           },
         ])
@@ -272,13 +266,7 @@ describe('ConfirmPage', () => {
               html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
             },
             actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'start and end time',
-                },
-              ],
+              items: [],
             },
           }),
         )

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -61,8 +61,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     if (this.form && this.form.contactOutcome?.attended) {
       return paths.appointments.logCompliance({ projectCode, appointmentId })
     }
-
-    return paths.appointments.logHours({ projectCode, appointmentId })
+    return paths.appointments.attendanceOutcome({ projectCode, appointmentId })
   }
 
   protected updatePath(appointment: AppointmentDto): string {
@@ -185,13 +184,15 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           html: this.getStartAndEndTime(form),
         },
         actions: {
-          items: [
-            {
-              href: this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId })),
-              text: 'Change',
-              visuallyHiddenText: 'start and end time',
-            },
-          ],
+          items: form.contactOutcome.attended
+            ? [
+                {
+                  href: this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId })),
+                  text: 'Change',
+                  visuallyHiddenText: 'start and end time',
+                },
+              ]
+            : [],
         },
       },
     ]


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-826)

When we're recording an outcome whether there is no attendance, we now wish to skip the log hours screen. This PR implements this functionality, and also makes a minor adjustment to the confirm details page such that the "Change" link on the hours row is no longer shown, and the "Back" link returns the user to the attendance page rather than the log hours page.

## Changes in this PR

### Screenshots of UI changes

Select a non-attending outcome here...
<img width="1714" height="1335" alt="not-attended-1" src="https://github.com/user-attachments/assets/f593caa8-6993-440f-bd6d-d57d060888ee" />

End up here...
<img width="1714" height="1335" alt="not-attended-2" src="https://github.com/user-attachments/assets/a0334c37-b20f-4a80-be27-7ae73843b344" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
