### PR TITLE
Update `@types/node` to v22.19.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@ministryofjustice/frontend": "^9.0.0",
         "@ministryofjustice/hmpps-auth-clients": "^1.0.2",
         "@ministryofjustice/hmpps-monitoring": "^1.0.2",
-        "@ministryofjustice/hmpps-probation-integration-e2e-tests": "1.187.0",
+        "@ministryofjustice/hmpps-probation-integration-e2e-tests": "^1.187.0",
         "@ministryofjustice/hmpps-rest-client": "^1.2.0",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "^1.58.2",
         "@sentry/node": "^10.47.0",
         "@types/js-yaml": "4.0.9",
         "applicationinsights": "^2.9.8",
@@ -62,7 +62,7 @@
         "@types/http-errors": "^2.0.5",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "22.19.15",
+        "@types/node": "^22.19.17",
         "@types/nunjucks": "^3.2.6",
         "@types/passport": "^1.0.17",
         "@types/passport-oauth2": "^1.8.0",
@@ -74,7 +74,7 @@
         "babel-jest": "^30.3.0",
         "chokidar": "^5.0.0",
         "concurrently": "^9.2.1",
-        "cypress": "15.11.0",
+        "cypress": "^15.11.0",
         "cypress-axe": "^1.7.0",
         "esbuild": "^0.28.0",
         "esbuild-plugin-clean": "^1.0.1",
@@ -6953,9 +6953,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@types/http-errors": "^2.0.5",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^22.19.15",
+    "@types/node": "^22.19.17",
     "@types/nunjucks": "^3.2.6",
     "@types/passport": "^1.0.17",
     "@types/passport-oauth2": "^1.8.0",


### PR DESCRIPTION
## Context

This package was included in the latest Renovate PR, but I assumed it would include the same breaking changes as we faced in https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui/pull/226. Turns out it didn't!

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
