### PR TITLE
CPB-827: Add appointment and project details to travel time form page

### DIFF
--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto } from '../../../server/@types/shared'
+import { AppointmentDto, ProjectDto } from '../../../server/@types/shared'
 import Offender from '../../../server/models/offender'
 import paths from '../../../server/paths'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
@@ -38,7 +38,7 @@ export default class UpdateTravelTimePage extends Page {
     })
   }
 
-  shouldShowAppointmentDetails(contactOutcome: string) {
+  shouldShowAppointmentDetails(contactOutcome: string, project: ProjectDto) {
     this.appointmentDetails
       .getValueWithLabel('Date')
       .should('contain.text', DateTimeFormats.isoDateToUIDate(this.appointment.date))
@@ -52,5 +52,8 @@ export default class UpdateTravelTimePage extends Page {
     this.appointmentDetails
       .getValueWithLabel('Actual end time')
       .should('contain.text', DateTimeFormats.stripTime(this.appointment.endTime))
+
+    this.appointmentDetails.getValueWithLabel('Project').should('contain.text', project.projectName)
+    this.appointmentDetails.getValueWithLabel('Project type').should('contain.text', project.projectType.name)
   }
 }

--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -1,13 +1,17 @@
 import { AppointmentDto } from '../../../server/@types/shared'
 import Offender from '../../../server/models/offender'
 import paths from '../../../server/paths'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
+import SummaryListComponent from '../components/summaryListComponent'
 import Page from '../page'
 
 export default class UpdateTravelTimePage extends Page {
   readonly timeInput = new HoursMinutesInputComponent()
 
-  constructor(appointment: AppointmentDto) {
+  readonly appointmentDetails = new SummaryListComponent('Appointment details')
+
+  constructor(private readonly appointment: AppointmentDto) {
     const offender = new Offender(appointment.offender)
     super(offender.name)
   }
@@ -32,5 +36,21 @@ export default class UpdateTravelTimePage extends Page {
     cy.get('[data-testid="error-summary"]').within(() => {
       cy.get('li').contains(message)
     })
+  }
+
+  shouldShowAppointmentDetails(contactOutcome: string) {
+    this.appointmentDetails
+      .getValueWithLabel('Date')
+      .should('contain.text', DateTimeFormats.isoDateToUIDate(this.appointment.date))
+
+    this.appointmentDetails.getValueWithLabel('Contact outcome').should('contain.text', contactOutcome)
+
+    this.appointmentDetails
+      .getValueWithLabel('Actual start time')
+      .should('contain.text', DateTimeFormats.stripTime(this.appointment.startTime))
+
+    this.appointmentDetails
+      .getValueWithLabel('Actual end time')
+      .should('contain.text', DateTimeFormats.stripTime(this.appointment.endTime))
   }
 }

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -36,8 +36,10 @@
 //    When I click not eligible for travel time
 //    Then I see the travel time dashboard with a success message
 
+import { ContactOutcomeDto } from '../../../server/@types/shared'
 import { ProviderSummaryDto } from '../../../server/@types/shared/models/ProviderSummaryDto'
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
+import { contactOutcomeFactory } from '../../../server/testutils/factories/contactOutcomeFactory'
 import pagedModelAppointmentTaskSummaryFactory from '../../../server/testutils/factories/pagedModelAppointmentTaskSummaryFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import SearchAttendedPage from '../../pages/appointments/searchAttendedPage'
@@ -48,6 +50,7 @@ context('Update travel time page', () => {
   const appointment = appointmentFactory.build()
   let providers: Array<ProviderSummaryDto>
   let provider: ProviderSummaryDto
+  let contactOutcome: ContactOutcomeDto
 
   beforeEach(() => {
     cy.task('reset')
@@ -58,6 +61,9 @@ context('Update travel time page', () => {
     providers = providerSummaryFactory.buildList(2)
     ;[provider] = providers
     cy.task('stubGetProviders', { providers: { providers } })
+    contactOutcome = contactOutcomeFactory.build({ code: appointment.contactOutcomeCode })
+    const contactOutcomes = [contactOutcome, contactOutcomeFactory.build()]
+    cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes } })
   })
 
   // Scenario: viewing the 'Adjust travel time' page
@@ -93,6 +99,7 @@ context('Update travel time page', () => {
   it('submits travel time and returns to dashboard', () => {
     // Given I am on the adjust travel time page for an appointment
     const page = UpdateTravelTimePage.visit(appointment)
+    page.shouldShowAppointmentDetails(contactOutcome.name)
 
     //  When I complete the form
     page.timeInput.enterTime()

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -36,11 +36,12 @@
 //    When I click not eligible for travel time
 //    Then I see the travel time dashboard with a success message
 
-import { ContactOutcomeDto } from '../../../server/@types/shared'
+import { ContactOutcomeDto, ProjectDto } from '../../../server/@types/shared'
 import { ProviderSummaryDto } from '../../../server/@types/shared/models/ProviderSummaryDto'
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
 import { contactOutcomeFactory } from '../../../server/testutils/factories/contactOutcomeFactory'
 import pagedModelAppointmentTaskSummaryFactory from '../../../server/testutils/factories/pagedModelAppointmentTaskSummaryFactory'
+import projectFactory from '../../../server/testutils/factories/projectFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import SearchAttendedPage from '../../pages/appointments/searchAttendedPage'
 import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
@@ -51,6 +52,7 @@ context('Update travel time page', () => {
   let providers: Array<ProviderSummaryDto>
   let provider: ProviderSummaryDto
   let contactOutcome: ContactOutcomeDto
+  let project: ProjectDto
 
   beforeEach(() => {
     cy.task('reset')
@@ -64,6 +66,8 @@ context('Update travel time page', () => {
     contactOutcome = contactOutcomeFactory.build({ code: appointment.contactOutcomeCode })
     const contactOutcomes = [contactOutcome, contactOutcomeFactory.build()]
     cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes } })
+    project = projectFactory.build({ projectCode: appointment.projectCode })
+    cy.task('stubFindProject', { project })
   })
 
   // Scenario: viewing the 'Adjust travel time' page
@@ -99,7 +103,7 @@ context('Update travel time page', () => {
   it('submits travel time and returns to dashboard', () => {
     // Given I am on the adjust travel time page for an appointment
     const page = UpdateTravelTimePage.visit(appointment)
-    page.shouldShowAppointmentDetails(contactOutcome.name)
+    page.shouldShowAppointmentDetails(contactOutcome.name, project)
 
     //  When I complete the form
     page.timeInput.enterTime()

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -13,6 +13,8 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import * as ErrorUtils from '../../utils/errorUtils'
 import ReferenceDataService from '../../services/referenceDataService'
 import { contactOutcomesFactory } from '../../testutils/factories/contactOutcomeFactory'
+import ProjectService from '../../services/projectService'
+import projectFactory from '../../testutils/factories/projectFactory'
 
 describe('AdjustTravelTimeController', () => {
   const username = 'user'
@@ -22,6 +24,7 @@ describe('AdjustTravelTimeController', () => {
   const providerService = createMock<ProviderService>()
   const offenderService = createMock<OffenderService>()
   const referenceDataService = createMock<ReferenceDataService>()
+  const projectService = createMock<ProjectService>()
   const response = createMock<Response>({ locals: { user: { username } } })
   const next = createMock<NextFunction>({})
   let controller: AdjustTravelTimeController
@@ -36,6 +39,7 @@ describe('AdjustTravelTimeController', () => {
       appointmentService,
       offenderService,
       referenceDataService,
+      projectService,
     )
   })
 
@@ -93,6 +97,10 @@ describe('AdjustTravelTimeController', () => {
         endTime: '17:00',
         contactOutcome: 'Attended',
       },
+      project: {
+        name: 'Project',
+        type: 'Group',
+      },
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -103,6 +111,7 @@ describe('AdjustTravelTimeController', () => {
       page.viewData.mockReturnValue(viewData)
       appointmentService.getAppointment.mockResolvedValue(appointmentFactory.build())
       referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomesFactory.build())
+      projectService.getProject.mockResolvedValue(projectFactory.build())
     })
 
     it('should render the page', async () => {
@@ -145,6 +154,10 @@ describe('AdjustTravelTimeController', () => {
         endTime: '17:00',
         contactOutcome: 'Attended',
       },
+      project: {
+        name: 'Project',
+        type: 'Group',
+      },
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -155,6 +168,7 @@ describe('AdjustTravelTimeController', () => {
       page.viewData.mockReturnValue(viewData)
       appointmentService.getAppointment.mockResolvedValue(appointmentFactory.build())
       referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomesFactory.build())
+      projectService.getProject.mockResolvedValue(projectFactory.build())
     })
 
     describe('no errors', () => {

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -11,6 +11,8 @@ import SearchTravelTimePage from '../../pages/appointments/searchTravelTimePage'
 import OffenderService from '../../services/offenderService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import * as ErrorUtils from '../../utils/errorUtils'
+import ReferenceDataService from '../../services/referenceDataService'
+import { contactOutcomesFactory } from '../../testutils/factories/contactOutcomeFactory'
 
 describe('AdjustTravelTimeController', () => {
   const username = 'user'
@@ -19,6 +21,7 @@ describe('AdjustTravelTimeController', () => {
   const appointmentService = createMock<AppointmentService>()
   const providerService = createMock<ProviderService>()
   const offenderService = createMock<OffenderService>()
+  const referenceDataService = createMock<ReferenceDataService>()
   const response = createMock<Response>({ locals: { user: { username } } })
   const next = createMock<NextFunction>({})
   let controller: AdjustTravelTimeController
@@ -27,7 +30,13 @@ describe('AdjustTravelTimeController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    controller = new AdjustTravelTimeController(page, providerService, appointmentService, offenderService)
+    controller = new AdjustTravelTimeController(
+      page,
+      providerService,
+      appointmentService,
+      offenderService,
+      referenceDataService,
+    )
   })
 
   describe('index', () => {
@@ -78,6 +87,12 @@ describe('AdjustTravelTimeController', () => {
       backLink: '/back',
       updatePath: '/update',
       completeTaskPath: '/complete',
+      appointment: {
+        date: '10 Jan 2024',
+        startTime: '09:00',
+        endTime: '17:00',
+        contactOutcome: 'Attended',
+      },
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -86,6 +101,8 @@ describe('AdjustTravelTimeController', () => {
 
     beforeEach(() => {
       page.viewData.mockReturnValue(viewData)
+      appointmentService.getAppointment.mockResolvedValue(appointmentFactory.build())
+      referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomesFactory.build())
     })
 
     it('should render the page', async () => {
@@ -122,6 +139,12 @@ describe('AdjustTravelTimeController', () => {
       backLink: '/back',
       updatePath: '/update',
       completeTaskPath: '/complete',
+      appointment: {
+        date: '10 Jan 2024',
+        startTime: '09:00',
+        endTime: '17:00',
+        contactOutcome: 'Attended',
+      },
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -130,6 +153,8 @@ describe('AdjustTravelTimeController', () => {
 
     beforeEach(() => {
       page.viewData.mockReturnValue(viewData)
+      appointmentService.getAppointment.mockResolvedValue(appointmentFactory.build())
+      referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomesFactory.build())
     })
 
     describe('no errors', () => {

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -7,6 +7,7 @@ import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import SearchTravelTimePage from '../../pages/appointments/searchTravelTimePage'
 import OffenderService from '../../services/offenderService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
+import ReferenceDataService from '../../services/referenceDataService'
 
 export default class AdjustTravelTimeController {
   constructor(
@@ -14,6 +15,7 @@ export default class AdjustTravelTimeController {
     private readonly providerService: ProviderService,
     private readonly appointmentService: AppointmentService,
     private readonly offenderService: OffenderService,
+    private readonly referenceDataService: ReferenceDataService,
   ) {}
 
   index(): RequestHandler {
@@ -37,7 +39,9 @@ export default class AdjustTravelTimeController {
         username: res.locals.user.username,
       })
 
-      const viewData = this.page.viewData(appointment, taskId)
+      const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
+
+      const viewData = this.page.viewData({ appointment, taskId, contactOutcomes })
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('appointments/update/travelTime/update', { ...viewData, errorList })
@@ -63,8 +67,12 @@ export default class AdjustTravelTimeController {
           minutes,
         }
 
+        const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(
+          res.locals.user.username,
+        )
+
         const viewData = {
-          ...this.page.viewData(appointment, taskId),
+          ...this.page.viewData({ appointment, taskId, contactOutcomes }),
           errorSummary,
           errors,
           time,

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -8,6 +8,7 @@ import SearchTravelTimePage from '../../pages/appointments/searchTravelTimePage'
 import OffenderService from '../../services/offenderService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 import ReferenceDataService from '../../services/referenceDataService'
+import ProjectService from '../../services/projectService'
 
 export default class AdjustTravelTimeController {
   constructor(
@@ -16,6 +17,7 @@ export default class AdjustTravelTimeController {
     private readonly appointmentService: AppointmentService,
     private readonly offenderService: OffenderService,
     private readonly referenceDataService: ReferenceDataService,
+    private readonly projectService: ProjectService,
   ) {}
 
   index(): RequestHandler {
@@ -40,8 +42,9 @@ export default class AdjustTravelTimeController {
       })
 
       const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
+      const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
-      const viewData = this.page.viewData({ appointment, taskId, contactOutcomes })
+      const viewData = this.page.viewData({ appointment, taskId, contactOutcomes, project })
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('appointments/update/travelTime/update', { ...viewData, errorList })
@@ -71,8 +74,10 @@ export default class AdjustTravelTimeController {
           res.locals.user.username,
         )
 
+        const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
+
         const viewData = {
-          ...this.page.viewData({ appointment, taskId, contactOutcomes }),
+          ...this.page.viewData({ appointment, taskId, contactOutcomes, project }),
           errorSummary,
           errors,
           time,

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -42,6 +42,7 @@ const controllers = (services: Services) => {
     services.appointmentService,
     services.offenderService,
     services.referenceDataService,
+    services.projectService,
   )
 
   return {

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -41,6 +41,7 @@ const controllers = (services: Services) => {
     services.providerService,
     services.appointmentService,
     services.offenderService,
+    services.referenceDataService,
   )
 
   return {

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -1,7 +1,9 @@
 import HoursAndMinutesInput from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
 import paths from '../../paths'
+import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import UpdateTravelTimePage from './updateTravelTimePage'
 
@@ -51,7 +53,7 @@ describe('UpdateTravelTimePage', () => {
   })
 
   describe('viewData', () => {
-    it('returns offender and paths', () => {
+    it('returns offender, paths and appointmentDetails', () => {
       const taskId = '1'
       const appointment = appointmentFactory.build()
       const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
@@ -66,7 +68,22 @@ describe('UpdateTravelTimePage', () => {
         return offender
       })
 
-      const result = page.viewData(appointment, taskId)
+      const uiDate = '10 Jan 2024'
+      const startTime = '09:00'
+      const endTime = '17:00'
+
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(uiDate)
+      jest.spyOn(DateTimeFormats, 'stripTime').mockImplementation((time: string) => {
+        return time === appointment.startTime ? startTime : endTime
+      })
+
+      const contactOutcomes = contactOutcomeFactory.buildList(2)
+
+      const result = page.viewData({
+        appointment,
+        taskId,
+        contactOutcomes,
+      })
 
       expect(result).toEqual({
         offender,
@@ -81,7 +98,37 @@ describe('UpdateTravelTimePage', () => {
           taskId,
         }),
         backLink: paths.appointments.travelTime.index({}),
+        appointment: {
+          date: uiDate,
+          startTime,
+          endTime,
+          contactOutcome: undefined,
+        },
       })
+
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(appointment.date)
+      expect(DateTimeFormats.stripTime).toHaveBeenCalledWith(appointment.startTime)
+      expect(DateTimeFormats.stripTime).toHaveBeenCalledWith(appointment.endTime)
+    })
+
+    it('returns contact outcome name when it matches the appointment code', () => {
+      const contactOutcomeName = 'Attended'
+      const appointment = appointmentFactory.build()
+
+      const matchingContactOutcome = contactOutcomeFactory.build({
+        code: appointment.contactOutcomeCode,
+        name: contactOutcomeName,
+      })
+
+      const contactOutcomes = [contactOutcomeFactory.build(), matchingContactOutcome]
+
+      const result = page.viewData({
+        appointment,
+        taskId: '1',
+        contactOutcomes,
+      })
+
+      expect(result.appointment.contactOutcome).toBe(contactOutcomeName)
     })
   })
 

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -1,9 +1,9 @@
 import HoursAndMinutesInput from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
 import paths from '../../paths'
-import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
+import projectFactory from '../../testutils/factories/projectFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import UpdateTravelTimePage from './updateTravelTimePage'
 
@@ -78,11 +78,13 @@ describe('UpdateTravelTimePage', () => {
       })
 
       const contactOutcomes = contactOutcomeFactory.buildList(2)
+      const project = projectFactory.build()
 
       const result = page.viewData({
         appointment,
         taskId,
         contactOutcomes,
+        project,
       })
 
       expect(result).toEqual({
@@ -104,6 +106,10 @@ describe('UpdateTravelTimePage', () => {
           endTime,
           contactOutcome: undefined,
         },
+        project: {
+          name: project.projectName,
+          type: project.projectType.name,
+        },
       })
 
       expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(appointment.date)
@@ -121,11 +127,13 @@ describe('UpdateTravelTimePage', () => {
       })
 
       const contactOutcomes = [contactOutcomeFactory.build(), matchingContactOutcome]
+      const project = projectFactory.build()
 
       const result = page.viewData({
         appointment,
         taskId: '1',
         contactOutcomes,
+        project,
       })
 
       expect(result.appointment.contactOutcome).toBe(contactOutcomeName)

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ContactOutcomeDto, CreateAdjustmentDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, CreateAdjustmentDto, ProjectDto } from '../../@types/shared'
 import { ValidationErrors } from '../../@types/user-defined'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
@@ -19,6 +19,10 @@ interface PageViewData {
   updatePath: string
   completeTaskPath: string
   appointment: AppointmentDetails
+  project: {
+    name: string
+    type: string
+  }
 }
 
 export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithHoursAndMinutes> {
@@ -30,10 +34,12 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     appointment,
     taskId,
     contactOutcomes,
+    project,
   }: {
     appointment: AppointmentDto
     taskId: string
     contactOutcomes: Array<ContactOutcomeDto>
+    project: ProjectDto
   }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
@@ -45,6 +51,10 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
         startTime: DateTimeFormats.stripTime(appointment.startTime),
         endTime: DateTimeFormats.stripTime(appointment.endTime),
         contactOutcome: this.selectedContactOutcomeName(appointment, contactOutcomes),
+      },
+      project: {
+        name: project.projectName,
+        type: project.projectType.name,
       },
     }
   }

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, CreateAdjustmentDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, CreateAdjustmentDto } from '../../@types/shared'
 import { ValidationErrors } from '../../@types/user-defined'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
@@ -6,11 +6,19 @@ import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import PageWithValidation from '../pageWithValidation'
 
+interface AppointmentDetails {
+  date: string
+  startTime: string
+  endTime: string
+  contactOutcome?: string
+}
+
 interface PageViewData {
   backLink: string
   offender: Offender
   updatePath: string
   completeTaskPath: string
+  appointment: AppointmentDetails
 }
 
 export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithHoursAndMinutes> {
@@ -18,12 +26,26 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     return HoursAndMinutesInput.validationErrors(query, 'travel time')
   }
 
-  viewData(appointment: AppointmentDto, taskId: string): PageViewData {
+  viewData({
+    appointment,
+    taskId,
+    contactOutcomes,
+  }: {
+    appointment: AppointmentDto
+    taskId: string
+    contactOutcomes: Array<ContactOutcomeDto>
+  }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
       backLink: paths.appointments.travelTime.index({}),
       updatePath: this.updatePath(appointment, taskId),
       completeTaskPath: paths.appointments.travelTime.complete(this.pathParams(appointment, taskId)),
+      appointment: {
+        date: DateTimeFormats.isoDateToUIDate(appointment.date),
+        startTime: DateTimeFormats.stripTime(appointment.startTime),
+        endTime: DateTimeFormats.stripTime(appointment.endTime),
+        contactOutcome: this.selectedContactOutcomeName(appointment, contactOutcomes),
+      },
     }
   }
 
@@ -62,5 +84,14 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     }
 
     return `${offender.name}'s appointment ${dateDetail} ${actionDescription}`
+  }
+
+  private selectedContactOutcomeName(
+    appointment: AppointmentDto,
+    contactOutcomes: ContactOutcomeDto[],
+  ): string | undefined {
+    const selectedOutcome = contactOutcomes.find(outcome => outcome.code === appointment.contactOutcomeCode)
+
+    return selectedOutcome?.name
   }
 }

--- a/server/views/appointments/update/travelTime/_appointmentDetails.njk
+++ b/server/views/appointments/update/travelTime/_appointmentDetails.njk
@@ -15,6 +15,22 @@
               text: appointment.date
             }
           },
+           {
+            key: {
+              text: "Project"
+            },
+            value: {
+              text: project.name
+            }
+          },
+          {
+            key: {
+              text: "Project type"
+            },
+            value: {
+              text: project.type
+            }
+          },
           {
             key: {
               text: "Contact outcome"

--- a/server/views/appointments/update/travelTime/_appointmentDetails.njk
+++ b/server/views/appointments/update/travelTime/_appointmentDetails.njk
@@ -1,0 +1,43 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+      {{ govukSummaryList({
+        card: {
+          title: {
+            text: 'Appointment details'
+          }
+        },
+        rows: [
+          {
+            key: {
+              text: "Date"
+            },
+            value: {
+              text: appointment.date
+            }
+          },
+          {
+            key: {
+              text: "Contact outcome"
+            },
+            value: {
+              text: appointment.contactOutcome
+            }
+          },
+          {
+            key: {
+              text: "Actual start time"
+            },
+            value: {
+              text: appointment.startTime
+            }
+          },
+          {
+            key: {
+              text: "Actual end time"
+            },
+            value: {
+              text: appointment.endTime
+            }
+          }
+        ]
+      }) }}

--- a/server/views/appointments/update/travelTime/update.njk
+++ b/server/views/appointments/update/travelTime/update.njk
@@ -18,6 +18,12 @@
     }) }}
   {% endif %}
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% include "./_appointmentDetails.njk" %}
+    </div>
+  </div>
+
   <form id="completeForm" action="{{ completeTaskPath }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
   </form>


### PR DESCRIPTION
## Context

Adds context about an appointment to a form to adjust travel time
[CPB-827](https://dsdmoj.atlassian.net/browse/CPB-827)

## Changes in this PR

- Add appointment details to summary list in view
- Fetch contact outcomes to enable display of the name for the contact outcome code on the appointment
- Fetch and display project name and type along with appointment details

### Screenshots of UI changes

Travel time form page with new appointment details section:

<img width="1000" height="660" alt="" src="https://github.com/user-attachments/assets/016957ea-9d19-46b9-bfeb-4ba08b4fa63a" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-827]: https://dsdmoj.atlassian.net/browse/CPB-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ