### PR TITLE
CPB-827: Tweak travel time page content

### DIFF
--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -32,6 +32,10 @@ export default class UpdateTravelTimePage extends Page {
     cy.get('button').contains('Not eligible').click()
   }
 
+  override clickSubmit() {
+    cy.get('button').contains('Credit travel time').click()
+  }
+
   override shouldShowErrorSummary(message: string) {
     cy.get('[data-testid="error-summary"]').within(() => {
       cy.get('li').contains(message)

--- a/server/views/appointments/update/travelTime/update.njk
+++ b/server/views/appointments/update/travelTime/update.njk
@@ -4,6 +4,7 @@
 {% extends "../layout.njk" %}
 
 {% set pageTitle = 'Credit travel time for appointment' %}
+{% set formButtonText = "Credit travel time" %}
 
 {% block formHeader %}{% endblock %}
 

--- a/server/views/appointments/update/travelTime/update.njk
+++ b/server/views/appointments/update/travelTime/update.njk
@@ -3,7 +3,7 @@
 
 {% extends "../layout.njk" %}
 
-{% set pageTitle = 'Adjust travel time' %}
+{% set pageTitle = 'Credit travel time for appointment' %}
 
 {% block formHeader %}{% endblock %}
 

--- a/server/views/appointments/update/travelTime/update.njk
+++ b/server/views/appointments/update/travelTime/update.njk
@@ -32,7 +32,7 @@
 {% block formContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {{ hoursMinutesInputs(time, errors, 'Add travel time') }}
+      {{ hoursMinutesInputs(time, errors, 'How much time should be credited for travel?') }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Context

Adjusts wording to more closely match the requirements in [CPB-827](https://dsdmoj.atlassian.net/browse/CPB-827)/[CPB-798](https://dsdmoj.atlassian.net/browse/CPB-798)

## Changes in this PR

- Update question text
- Update submit button text
- Tweak page title

### Screenshots of UI changes

Travel time form showing updated question text: 'How much time should be credited for travel?' and updated button text: 'Credit travel time':

<img width="1002" height="659" alt="" src="https://github.com/user-attachments/assets/fd83ff19-944c-4cc5-9fad-69cc47aec93c" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-827]: https://dsdmoj.atlassian.net/browse/CPB-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPB-798]: https://dsdmoj.atlassian.net/browse/CPB-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ