### PR TITLE
Fix course completion content shown on outcome page

### DIFF
--- a/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
+++ b/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
@@ -27,9 +27,6 @@ export default class CourseDetailsComponent {
     const completionDate = DateTimeFormats.isoDateToUIDate(this.courseCompletion.completionDateTime)
 
     this.details.getValueWithLabel('Completion date').should('contain.text', completionDate)
-    this.details.getValueWithLabel('Course name').should('contain.text', this.courseCompletion.courseName)
-    this.details.getValueWithLabel('Course type').should('contain.text', this.courseCompletion.courseType)
-    this.details.getValueWithLabel('Provider').should('contain.text', this.courseCompletion.provider)
     this.details.getValueWithLabel('Expected time').should('contain.text', expectedTime)
     this.details.getValueWithLabel('Expected time with 20% allowance').should('contain.text', expectedTimeWithAllowance)
     this.details.getValueWithLabel('Total time spent').should('contain.text', totalTimeSpent)

--- a/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
+++ b/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
@@ -24,6 +24,9 @@ export default class CourseDetailsComponent {
       this.courseCompletion.totalTimeMinutes,
     )
 
+    const completionDate = DateTimeFormats.isoDateToUIDate(this.courseCompletion.completionDateTime)
+
+    this.details.getValueWithLabel('Completion date').should('contain.text', completionDate)
     this.details.getValueWithLabel('Course name').should('contain.text', this.courseCompletion.courseName)
     this.details.getValueWithLabel('Course type').should('contain.text', this.courseCompletion.courseType)
     this.details.getValueWithLabel('Provider').should('contain.text', this.courseCompletion.provider)

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -28,6 +28,7 @@ describe('OutcomeController', () => {
   let outcomeController: OutcomeController
   const page = createMock<OutcomePage>({ templatePath })
   const courseDetailsItems = {
+    completionDate: '12 July 2025',
     courseName: 'Customer service',
     courseType: 'Accredited',
     provider: 'Test Provider',

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -29,9 +29,6 @@ describe('OutcomeController', () => {
   const page = createMock<OutcomePage>({ templatePath })
   const courseDetailsItems = {
     completionDate: '12 July 2025',
-    courseName: 'Customer service',
-    courseType: 'Accredited',
-    provider: 'Test Provider',
     expectedTime: '42 hours',
     expectedTimeWithAllowance: '50 hours',
     totalTimeSpent: '1 hour 20 minutes',

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -39,10 +39,13 @@ describe('CourseCompletionUtils', () => {
           if (minutes === 180) return expectedTimeWithAllowance
           return '0 hours 0 minutes'
         })
+      const date = '13 July 2025'
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(date)
       const courseCompletion = courseCompletionFactory.build({ expectedTimeMinutes: 150, totalTimeMinutes: 100 })
 
       const result = CourseCompletionUtils.formattedCourseDetails(courseCompletion)
       expect(result).toEqual({
+        completionDate: date,
         courseName: courseCompletion.courseName,
         courseType: courseCompletion.courseType,
         provider: courseCompletion.provider,
@@ -54,6 +57,7 @@ describe('CourseCompletionUtils', () => {
 
       expect(DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes).toHaveBeenCalledWith(150)
       expect(DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes).toHaveBeenCalledWith(180)
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(courseCompletion.completionDateTime)
     })
   })
   describe('formattedOffenderDetails', () => {

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -46,9 +46,6 @@ describe('CourseCompletionUtils', () => {
       const result = CourseCompletionUtils.formattedCourseDetails(courseCompletion)
       expect(result).toEqual({
         completionDate: date,
-        courseName: courseCompletion.courseName,
-        courseType: courseCompletion.courseType,
-        provider: courseCompletion.provider,
         expectedTime,
         expectedTimeWithAllowance,
         totalTimeSpent,

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -13,6 +13,7 @@ export interface LearnerDetails {
 }
 
 export interface CourseDetails {
+  completionDate: string
   courseName: string
   courseType: string
   provider: string
@@ -47,6 +48,7 @@ export default class CourseCompletionUtils {
     const totalTimeSpent = DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes)
 
     return {
+      completionDate: DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime),
       courseName: courseCompletion.courseName,
       courseType: courseCompletion.courseType,
       provider: courseCompletion.provider,

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -14,9 +14,6 @@ export interface LearnerDetails {
 
 export interface CourseDetails {
   completionDate: string
-  courseName: string
-  courseType: string
-  provider: string
   expectedTime: string
   expectedTimeWithAllowance: string
   totalTimeSpent: string
@@ -49,9 +46,6 @@ export default class CourseCompletionUtils {
 
     return {
       completionDate: DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime),
-      courseName: courseCompletion.courseName,
-      courseType: courseCompletion.courseType,
-      provider: courseCompletion.provider,
       expectedTime,
       expectedTimeWithAllowance,
       totalTimeSpent,

--- a/server/views/courseCompletions/_courseDetails.njk
+++ b/server/views/courseCompletions/_courseDetails.njk
@@ -19,30 +19,6 @@
     },
     {
       key: {
-        text: 'Course name'
-      },
-      value: {
-        text: courseDetailsItems.courseName
-      }
-    },
-    {
-      key: {
-        text: 'Course type'
-      },
-      value: {
-        text: courseDetailsItems.courseType
-      }
-    },
-    {
-      key: {
-        text: 'Provider'
-      },
-      value: {
-        text: courseDetailsItems.provider
-      }
-    },
-    {
-      key: {
         text: 'Expected time'
       },
       value: {

--- a/server/views/courseCompletions/_courseDetails.njk
+++ b/server/views/courseCompletions/_courseDetails.njk
@@ -11,6 +11,14 @@
   rows: [
     {
       key: {
+        text: 'Completion date'
+      },
+      value: {
+        text: courseDetailsItems.completionDate
+      }
+    },
+    {
+      key: {
         text: 'Course name'
       },
       value: {


### PR DESCRIPTION
## Context

Update contextual content displayed on the outcome page of a course completion form to match the designs.

## Changes in this PR

- Add course completion date
- Remove course name, type and provider

### Screenshots of UI changes

Before:
<img width="1313" height="915" alt="" src="https://github.com/user-attachments/assets/dcd551c2-6143-4397-b4db-4691a9fe49b3" />

Now:
<img width="1405" height="934" alt="" src="https://github.com/user-attachments/assets/84994a6a-6f0c-4dfd-ba92-1d9b815cfaae" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
