### PR TITLE
Fix CSS specificity for sortable table sorting arrows

### DIFF
--- a/assets/scss/components/_sortable-table.scss
+++ b/assets/scss/components/_sortable-table.scss
@@ -44,32 +44,32 @@
     }
   }
 
+  [aria-sort="ascending"] {
+    button, a {
+      &:before {
+        content: none;
+      }
+
+      &:after {
+        font-size: .8em;
+      }
+    }
+  }
+
+  [aria-sort="descending"] {
+    button, a {
+      &:after {
+        content: none;
+      }
+
+      &:before {
+        font-size: .8em;
+        top: 2px
+      }
+    }
+  }
+
   button svg {
     display: none;
-  }
-}
-
-[aria-sort="ascending"] {
-  button, a {
-    &:before {
-      content: none;
-    }
-
-    &:after {
-      font-size: .8em;
-    }
-  }
-}
-
-[aria-sort="descending"] {
-  button, a {
-    &:after {
-      content: none;
-    }
-
-    &:before {
-      font-size: .8em;
-      top: 2px
-    }
   }
 }


### PR DESCRIPTION
The CSS for the sorting arrows to show whether the column was being sorted and which direction was being ignored because it should have been inside the `.moj-sortable-table` nested selector.

## Changes in this PR

### Screenshots of UI changes

<img width="1715" height="1335" alt="sortable-table-arrows" src="https://github.com/user-attachments/assets/3576148c-fb53-4321-a548-08bdcc52b0d4" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
