### PR TITLE
(fix)CPB-858: Community campus E2E test

### DIFF
--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -30,7 +30,7 @@ export default async (
       'Health and Safety Basics',
     ]),
     pdu: team.pdu,
-    office: team.provider,
+    region: team.provider,
   }
 
   if (externalApiClient.enabled) {
@@ -74,7 +74,7 @@ export interface CourseCompletionContent {
   lastName: string
   completionDateTime: string
   pdu: string
-  office: string
+  region: string
   courseName: string
 }
 
@@ -89,9 +89,9 @@ export class CourseCompletionMessageBuilder {
          "firstName": "${content.firstName}",
          "lastName": "${content.lastName}",
          "dateOfBirth": "1990-01-01",
-         "region": "Wales",
+         "region": "${content.region}",
          "pdu": "${content.pdu}",
-         "office": "${content.office}",
+         "office": "${content.region}",
          "email": "john.doe@example.com",
          "courseName": "${content.courseName}",
          "courseType": "Example Course Type",
@@ -115,13 +115,13 @@ export class CourseCompletionMessageBuilder {
             "firstName": "${content.firstName}",
             "lastName": "${content.lastName}",
             "dateOfBirth": "1990-01-01",
-            "region": "Wales",
-            "pdu": "Cardiff and Vale",
+            "region": "${content.region}",
+            "pdu": "${content.pdu}",
             "office": "Cardiff",
             "email": "john.doe@example.com"
           },
           "course": {
-            "courseName": "First Aid",
+            "courseName": "${content.courseName}",
             "courseType": "Example Course Type",
             "provider": "Moodle",
             "completionDateTime": "${content.completionDateTime}",


### PR DESCRIPTION
## Context

This fixes the region course completion messages are set to when tests are run in the pipeline
[CPB-858](https://dsdmoj.atlassian.net/browse/CPB-858)

## Changes in this PR

In #458 I had updated course completion messages to send with the region and PDU defined in our test fixture, but had missed that the external API message is set up separately and is still hardcoded, which meant that the test was search in a region different to that the messages were sent with. 



## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.
- [x] Have verified [this passes in our pipeline](https://github.com/ministryofjustice/hmpps-community-payback-ui/actions/runs/24504931272/job/71620911248).

<!-- ```
$ ./script/test
``` -->


[CPB-858]: https://dsdmoj.atlassian.net/browse/CPB-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ