### PR TITLE
CPB-833 Show appointment type on confirm details page

### DIFF
--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -14,6 +14,10 @@ export default class SummaryListComponent {
     return this.component().find('dt').should('not.contain.text', label)
   }
 
+  shouldNotContainAction(label: string) {
+    return this.getValueWithLabel(label).closest('.govuk-summary-list__row').find('a').should('not.exist')
+  }
+
   private component() {
     return this.title ? cy.get('.govuk-summary-card').filter(`:contains(${this.title})`) : cy.get('dl')
   }

--- a/integration_tests/pages/courseCompletions/process/appointmentPage.ts
+++ b/integration_tests/pages/courseCompletions/process/appointmentPage.ts
@@ -41,4 +41,8 @@ export default class AppointmentPage extends BaseCourseCompletionsPage {
   shouldShowNoAppointments() {
     cy.get('p').contains('There are no existing appointments.').should('be.visible')
   }
+
+  shouldShowAppointment(appointmentId: number) {
+    this.appointmentOptions.shouldHaveSelectedValue(appointmentId.toString())
+  }
 }

--- a/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
+++ b/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
@@ -52,6 +52,7 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
       )
     this.formDetails.getValueWithLabel('Project team').should('contain.text', team.name)
     this.formDetails.getValueWithLabel('Project', { exact: true }).should('contain.text', project.projectName)
+    this.shouldShowAppointmentType('existing')
     this.formDetails
       .getValueWithLabel('Credited time')
       .should(
@@ -70,8 +71,17 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
       .should('contain.text', this.form.isSensitive.charAt(0).toUpperCase() + this.form.isSensitive.slice(1))
   }
 
+  shouldShowAppointmentType(type: 'existing' | 'new') {
+    const appointmentTypeText = type === 'existing' ? 'Existing appointment' : 'New appointment'
+    this.formDetails.getValueWithLabel('Appointment type', { exact: true }).should('contain.text', appointmentTypeText)
+  }
+
   clickChange(label: string) {
     this.formDetails.clickActionWithLabel(label)
+  }
+
+  shouldNotShowChangeLink(label: string) {
+    this.formDetails.shouldNotContainAction(label)
   }
 
   override shouldShowErrorSummary(message: string) {

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -69,6 +69,10 @@ import Page from '../../../pages/page'
 import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
 import { communityCampusPdusFactory } from '../../../../server/testutils/factories/communityCampusPduFactory'
 import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
+import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
+import DateTimeFormats from '../../../../server/utils/dateTimeUtils'
+import AppointmentPage from '../../../pages/courseCompletions/process/appointmentPage'
+import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
 
 context('Confirm details page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -85,6 +89,14 @@ context('Confirm details page', () => {
   })
   const offender = offenderFullFactory.build({ crn: form.crn })
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender, unpaidWorkDetails: [upwDetails] })
+  const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+  const request = {
+    outcomeCodes: ['NO_OUTCOME'],
+    projectTypeGroup: 'ETE',
+    projectCodes: [project.projectCode],
+    crn: offender.crn,
+    fromDate: DateTimeFormats.dateObjToIsoString(new Date()),
+  }
 
   beforeEach(() => {
     cy.task('reset')
@@ -98,6 +110,7 @@ context('Confirm details page', () => {
     cy.task('stubGetOffenderSummary', {
       caseDetailsSummary,
     })
+    cy.task('stubGetAppointments', { request, pagedAppointments })
   })
 
   // Scenario: Confirming a course completion update
@@ -111,6 +124,26 @@ context('Confirm details page', () => {
     //  And I can answer yes or no to question asking if I want to alert the probation practitioner
     page.alertPractitionerQuestion.checkOptionWithValue('yes')
     page.alertPractitionerQuestion.checkOptionWithValue('no')
+  })
+
+  describe('showing appointment type', () => {
+    it('shows value for existing appointment', () => {
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(courseCompletion, form)
+
+      // Then I can see my submitted answers
+      page.shouldShowAppointmentType('existing')
+    })
+
+    it('shows value for new appointment', () => {
+      cy.task('stubGetCourseCompletionForm', { ...form, appointmentIdToUpdate: undefined })
+
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(courseCompletion, form)
+
+      // Then I can see my submitted answers
+      page.shouldShowAppointmentType('new')
+    })
   })
 
   // Scenario: Navigating back
@@ -242,6 +275,46 @@ context('Confirm details page', () => {
       // Then I can see the outcome page
       const outcomePage = Page.verifyOnPage(OutcomePage)
       outcomePage.notesQuestions.shouldShowIsSensitiveValue(form.isSensitive)
+    })
+
+    // Scenario: Changing the appointment
+    describe('appointment type', () => {
+      describe('when appointment can be changed', () => {
+        it('navigates back to the appointment page', () => {
+          const appointmentSummary = appointmentSummaryFactory.build({ id: form.appointmentIdToUpdate })
+
+          cy.task('stubGetAppointments', {
+            request,
+            pagedAppointments: pagedModelAppointmentSummaryFactory.build({ content: [appointmentSummary] }),
+          })
+
+          // Given I am on the confirm page of an in progress update
+          const page = ConfirmDetailsPage.visit(courseCompletion, form)
+
+          // And I click change appointment
+          page.clickChange('Appointment type')
+
+          // Then I can see the appointment page
+          const appointmentPage = Page.verifyOnPage(AppointmentPage)
+          appointmentPage.shouldShowAppointment(form.appointmentIdToUpdate)
+        })
+      })
+
+      describe('when appointment cannot be changed', () => {
+        it('does not show change link', () => {
+          cy.task('stubGetAppointments', {
+            request,
+            pagedAppointments: pagedModelAppointmentSummaryFactory.build({ content: [] }),
+          })
+
+          // Given I am on the confirm page of an in progress update
+          const page = ConfirmDetailsPage.visit(courseCompletion, form)
+
+          // And the appointment cannot be changed
+          // Then I should not see a change link
+          page.shouldNotShowChangeLink('Appointment type')
+        })
+      })
     })
   })
 

--- a/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
@@ -26,6 +26,7 @@ import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/fa
 import pagedModelProjectOutcomeSummaryFactory from '../../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import unpaidWorkDetailsFactory from '../../../../server/testutils/factories/unpaidWorkDetailsFactory'
+import DateTimeFormats from '../../../../server/utils/dateTimeUtils'
 import AppointmentPage from '../../../pages/courseCompletions/process/appointmentPage'
 import ConfirmDetailsPage from '../../../pages/courseCompletions/process/confirmDetailsPage'
 import OutcomePage from '../../../pages/courseCompletions/process/outcomePage'
@@ -73,6 +74,13 @@ context('Outcome Page', () => {
     const projects = pagedModelProjectOutcomeSummaryFactory.build()
     const [project] = projects.content
     const { providerCode } = courseCompletion.pdu
+    const request = {
+      outcomeCodes: ['NO_OUTCOME'],
+      projectTypeGroup: 'ETE',
+      projectCodes: [project.projectCode],
+      crn: caseDetailsSummary.offender.crn,
+      fromDate: DateTimeFormats.dateObjToIsoString(new Date()),
+    }
 
     cy.task(
       'stubGetCourseCompletionForm',
@@ -86,6 +94,7 @@ context('Outcome Page', () => {
     )
     cy.task('stubGetProjects', { teamCode: team.code, providerCode, projects })
     cy.task('stubGetTeams', { teams: { providers: teams }, providerCode })
+    cy.task('stubGetAppointments', { request, pagedAppointments: pagedModelAppointmentSummaryFactory.build() })
 
     //  Given I am on the form page
     const page = OutcomePage.visit(courseCompletion)

--- a/server/controllers/courseCompletions/process/confirmController.test.ts
+++ b/server/controllers/courseCompletions/process/confirmController.test.ts
@@ -17,6 +17,8 @@ import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
 import paths from '../../../paths'
 import courseCompletionResolutionFactory from '../../../testutils/factories/courseCompletionResolutionFactory'
 import * as ErrorUtils from '../../../utils/errorUtils'
+import AppointmentService from '../../../services/appointmentService'
+import pagedModelAppointmentSummaryFactory from '../../../testutils/factories/pagedModelAppointmentSummaryFactory'
 
 describe('ConfirmController', () => {
   const username = 'username'
@@ -29,12 +31,14 @@ describe('ConfirmController', () => {
   const providerService = createMock<ProviderService>()
   const projectService = createMock<ProjectService>()
   const offenderService = createMock<OffenderService>()
+  const appointmentService = createMock<AppointmentService>()
 
   const courseCompletion = courseCompletionFactory.build()
   const form = courseCompletionFormFactory.build()
   const teamsResponse = { providers: providerTeamSummaryFactory.buildList(2) }
   const projectsResponse = pagedModelProjectOutcomeSummaryFactory.build()
   const offenderResponse = caseDetailsSummaryFactory.build()
+  const appointmentResponse = pagedModelAppointmentSummaryFactory.build()
 
   let confirmController: ConfirmController
   const page = createMock<ConfirmPage>({ templatePath })
@@ -48,12 +52,14 @@ describe('ConfirmController', () => {
       providerService,
       projectService,
       offenderService,
+      appointmentService,
     )
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue(form)
     providerService.getTeams.mockResolvedValue(teamsResponse)
     projectService.getProjects.mockResolvedValue(projectsResponse)
     offenderService.getOffenderSummary.mockResolvedValue(offenderResponse)
+    appointmentService.getAppointments.mockResolvedValue(appointmentResponse)
   })
 
   describe('show', () => {

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -11,6 +11,8 @@ import { UnpaidWorkDetailsDto } from '../../../@types/shared'
 import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
 import paths from '../../../paths'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../../utils/errorUtils'
+import AppointmentService from '../../../services/appointmentService'
+import DateTimeFormats from '../../../utils/dateTimeUtils'
 
 export default class ConfirmController extends BaseController<ConfirmPage> {
   constructor(
@@ -20,6 +22,7 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
     private readonly providerService: ProviderService,
     private readonly projectService: ProjectService,
     private readonly offenderService: OffenderService,
+    private readonly appointmentService: AppointmentService,
   ) {
     super(page, courseCompletionService, formService)
   }
@@ -68,6 +71,14 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
       : []
     const unpaidWorkDetails = await this.getUnpaidWorkDetails({ username, formData })
 
+    const appointments = await this.appointmentService.getAppointments(res.locals.user.username, {
+      crn: formData.crn,
+      projectTypeGroup: 'ETE',
+      outcomeCodes: ['NO_OUTCOME'],
+      projectCodes: [formData.project],
+      fromDate: DateTimeFormats.dateObjToIsoString(new Date()),
+    })
+
     const personItems = this.page.personItems({
       courseCompletionId: req.params.id,
       form: formData,
@@ -81,6 +92,7 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
       formId,
       teams: teams.providers,
       projects,
+      canChangeAppointment: appointments.content.length > 0,
     })
 
     const alertPractitionerItems = GovUkRadioGroup.yesNoItems({})

--- a/server/controllers/courseCompletions/process/index.ts
+++ b/server/controllers/courseCompletions/process/index.ts
@@ -41,6 +41,7 @@ const controllers = (services: Services) => {
     providerService,
     projectService,
     offenderService,
+    appointmentService,
   )
   const crnController = new CrnController(new CrnPage(), courseCompletionService, courseCompletionFormService)
   const personController = new PersonController(

--- a/server/pages/courseCompletions/process/confirmPage.test.ts
+++ b/server/pages/courseCompletions/process/confirmPage.test.ts
@@ -11,7 +11,7 @@ import ConfirmPage from './confirmPage'
 import pathMap from './pathMap'
 import DateTimeFormats from '../../../utils/dateTimeUtils'
 import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
-import { YesOrNo } from '../../../@types/user-defined'
+import { GovUKActionItem, YesOrNo } from '../../../@types/user-defined'
 
 describe('ConfirmPage', () => {
   const pageName = 'confirm'
@@ -285,7 +285,14 @@ describe('ConfirmPage', () => {
           const matchingProject = projectOutcomeSummaryFactory.build({ projectCode: project })
           const projects = [matchingProject, projectOutcomeSummaryFactory.build()]
 
-          const result = page.appointmentItems({ courseCompletionId, form, formId, teams, projects })
+          const result = page.appointmentItems({
+            courseCompletionId,
+            form,
+            formId,
+            teams,
+            projects,
+            canChangeAppointment: false,
+          })
 
           const teamItem = {
             key: {
@@ -339,7 +346,7 @@ describe('ConfirmPage', () => {
           const formId = '12'
           const courseCompletionId = '23'
 
-          const result = page.appointmentItems({ courseCompletionId, form, formId })
+          const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
           const teamItem = {
             key: {
@@ -395,7 +402,14 @@ describe('ConfirmPage', () => {
           const projects = projectOutcomeSummaryFactory.buildList(2)
           const teams = providerTeamSummaryFactory.buildList(2)
 
-          const result = page.appointmentItems({ courseCompletionId, form, formId, projects, teams })
+          const result = page.appointmentItems({
+            courseCompletionId,
+            form,
+            formId,
+            projects,
+            teams,
+            canChangeAppointment: false,
+          })
 
           const teamItem = {
             key: {
@@ -441,6 +455,135 @@ describe('ConfirmPage', () => {
       })
     })
 
+    describe('Appointment type', () => {
+      describe('when appointment ID is present', () => {
+        it('returns item with value set to "existing appointment"', () => {
+          const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: 1 })
+          const formId = '12'
+          const courseCompletionId = '23'
+
+          const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: true })
+
+          const appointmentTypeItem = {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'Existing appointment',
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery(
+                    paths.courseCompletions.process({ page: 'appointments', id: courseCompletionId }),
+                    {
+                      form: formId,
+                    },
+                  ),
+                  text: 'Change',
+                  visuallyHiddenText: 'appointment type',
+                },
+              ],
+            },
+          }
+
+          expect(result).toContainEqual(appointmentTypeItem)
+        })
+      })
+      describe('when appointment ID is not present', () => {
+        it('returns item with value set to "new appointment"', () => {
+          const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: undefined })
+          const formId = '12'
+          const courseCompletionId = '23'
+
+          const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: true })
+
+          const appointmentTypeItem = {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'New appointment',
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery(
+                    paths.courseCompletions.process({ page: 'appointments', id: courseCompletionId }),
+                    {
+                      form: formId,
+                    },
+                  ),
+                  text: 'Change',
+                  visuallyHiddenText: 'appointment type',
+                },
+              ],
+            },
+          }
+
+          expect(result).toContainEqual(appointmentTypeItem)
+        })
+      })
+      describe('when appointment can be changed', () => {
+        it('returns item with change link', () => {
+          const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: 1 })
+          const formId = '12'
+          const courseCompletionId = '23'
+
+          const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: true })
+
+          const appointmentTypeItem = {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'Existing appointment',
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery(
+                    paths.courseCompletions.process({ page: 'appointments', id: courseCompletionId }),
+                    {
+                      form: formId,
+                    },
+                  ),
+                  text: 'Change',
+                  visuallyHiddenText: 'appointment type',
+                },
+              ],
+            },
+          }
+
+          expect(result).toContainEqual(appointmentTypeItem)
+        })
+      })
+
+      describe('when appointment cannot be changed', () => {
+        it('returns item without change link', () => {
+          const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: undefined })
+          const formId = '12'
+          const courseCompletionId = '23'
+
+          const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
+
+          const appointmentTypeItem = {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'New appointment',
+            },
+            actions: {
+              items: [] as GovUKActionItem[],
+            },
+          }
+
+          expect(result).toContainEqual(appointmentTypeItem)
+        })
+      })
+    })
+
     describe('Credited time', () => {
       it('returns form item with formatted credited time when hours and minutes are present', () => {
         const form = courseCompletionFormFactory.build({
@@ -449,7 +592,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const creditedTimeItem = {
           key: {
@@ -481,7 +624,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const creditedTimeItem = {
           key: {
@@ -513,7 +656,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const creditedTimeItem = {
           key: {
@@ -545,7 +688,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const creditedTimeItem = {
           key: {
@@ -581,7 +724,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const appointmentDateItem = {
           key: {
@@ -615,7 +758,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const appointmentDateItem = {
           key: {
@@ -661,7 +804,7 @@ describe('ConfirmPage', () => {
         const matchingProject = projectOutcomeSummaryFactory.build({ projectCode: project })
         const projects = [matchingProject, projectOutcomeSummaryFactory.build()]
 
-        const result = page.appointmentItems({ courseCompletionId, form, projects, teams })
+        const result = page.appointmentItems({ courseCompletionId, form, projects, teams, canChangeAppointment: false })
 
         const appointmentItems = [
           {
@@ -696,6 +839,17 @@ describe('ConfirmPage', () => {
                   visuallyHiddenText: 'project',
                 },
               ],
+            },
+          },
+          {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'Existing appointment',
+            },
+            actions: {
+              items: [],
             },
           },
           {
@@ -785,7 +939,14 @@ describe('ConfirmPage', () => {
         const matchingProject = projectOutcomeSummaryFactory.build({ projectCode: project })
         const projects = [matchingProject, projectOutcomeSummaryFactory.build()]
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId, projects, teams })
+        const result = page.appointmentItems({
+          courseCompletionId,
+          form,
+          formId,
+          projects,
+          teams,
+          canChangeAppointment: false,
+        })
 
         const appointmentItems = [
           {
@@ -824,6 +985,17 @@ describe('ConfirmPage', () => {
                   visuallyHiddenText: 'project',
                 },
               ],
+            },
+          },
+          {
+            key: {
+              text: 'Appointment type',
+            },
+            value: {
+              text: 'New appointment',
+            },
+            actions: {
+              items: [],
             },
           },
           {
@@ -916,7 +1088,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const notesItem = {
           key: {
@@ -969,7 +1141,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const sensitivityItem = {
           key: {
@@ -1001,7 +1173,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const notesItem = {
           key: {
@@ -1033,7 +1205,7 @@ describe('ConfirmPage', () => {
         const formId = '12'
         const courseCompletionId = '23'
 
-        const result = page.appointmentItems({ courseCompletionId, form, formId })
+        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
 
         const sensitivityItem = {
           key: {

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -35,6 +35,7 @@ interface AppointmentItems {
   formId?: string
   teams?: ProviderTeamSummaryDto[]
   projects?: ProjectOutcomeSummaryDto[]
+  canChangeAppointment: boolean
 }
 
 export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
@@ -103,10 +104,18 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
     ]
   }
 
-  appointmentItems({ courseCompletionId, form, formId, teams, projects }: AppointmentItems): GovUkSummaryListItem[] {
+  appointmentItems({
+    courseCompletionId,
+    form,
+    formId,
+    teams,
+    projects,
+    canChangeAppointment,
+  }: AppointmentItems): GovUkSummaryListItem[] {
     return [
       this.teamRow(form, courseCompletionId, formId, teams),
       this.projectRow(form, courseCompletionId, formId, projects),
+      this.appointmentTypeRow(form, courseCompletionId, canChangeAppointment, formId),
       this.creditedTimeRow(form, courseCompletionId, formId),
       this.appointmentDateRow(form, courseCompletionId, formId),
       ...this.notesRows(form, courseCompletionId, formId),
@@ -231,6 +240,36 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
             visuallyHiddenText: 'project',
           },
         ],
+      },
+    }
+  }
+
+  private appointmentTypeRow(
+    form: CourseCompletionForm,
+    courseCompletionId: string,
+    canChangeAppointment: boolean,
+    formId?: string,
+  ): GovUkSummaryListItem {
+    return {
+      key: {
+        text: 'Appointment type',
+      },
+      value: {
+        text: form.appointmentIdToUpdate ? 'Existing appointment' : 'New appointment',
+      },
+      actions: {
+        items: canChangeAppointment
+          ? [
+              {
+                href: this.pathWithFormId(
+                  paths.courseCompletions.process({ page: 'appointments', id: courseCompletionId }),
+                  formId,
+                ),
+                text: 'Change',
+                visuallyHiddenText: 'appointment type',
+              },
+            ]
+          : [],
       },
     }
   }


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-833)

## Context
Distinguish between a new appointment and updating an existing
appointment on the confirm page.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

#### New appointment - when there are existing appointments
<img width="1265" height="522" alt="Screenshot 2026-04-16 at 12 29 37" src="https://github.com/user-attachments/assets/7b95172b-8c9f-4d31-a4a4-fa9ef43c7c40" />

#### New appointment - when there are no existing appointments
<img width="1274" height="508" alt="Screenshot 2026-04-16 at 12 26 57" src="https://github.com/user-attachments/assets/6fdb234b-4645-44d3-9d71-06dd3c4b06d0" />

#### Existing appointment
<img width="1273" height="507" alt="Screenshot 2026-04-16 at 12 28 46" src="https://github.com/user-attachments/assets/86021dc8-fdc4-4743-822f-7017a0b35db1" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
