### PR TITLE
Ensure outcome details are removed when creating a new appointment

### DIFF
--- a/server/controllers/courseCompletions/process/appointmentsController.test.ts
+++ b/server/controllers/courseCompletions/process/appointmentsController.test.ts
@@ -90,6 +90,10 @@ describe('AppointmentsController', () => {
         'username',
         expect.objectContaining({
           appointmentIdToUpdate: undefined,
+          timeToCredit: undefined,
+          'date-day': undefined,
+          'date-month': undefined,
+          'date-year': undefined,
         }),
       )
       expect(response.redirect).toHaveBeenCalledWith('/course-completions/1/outcome?form=12')

--- a/server/controllers/courseCompletions/process/appointmentsController.ts
+++ b/server/controllers/courseCompletions/process/appointmentsController.ts
@@ -48,6 +48,10 @@ export default class AppointmentsController extends BaseController<AppointmentPa
       this.formService.saveForm(formId, res.locals.user.username, {
         ...formData,
         appointmentIdToUpdate: undefined,
+        timeToCredit: undefined,
+        'date-day': undefined,
+        'date-month': undefined,
+        'date-year': undefined,
       })
 
       return res.redirect(pathWithQuery(paths.courseCompletions.process({ id, page: 'outcome' }), { form: formId }))


### PR DESCRIPTION
## Context

Ensure outcome details are removed when creating a new appointment.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
