### PR TITLE
Update deprecated appointment save endpoint

### DIFF
--- a/integration_tests/mockApis/appointments.ts
+++ b/integration_tests/mockApis/appointments.ts
@@ -58,7 +58,7 @@ export default {
     })
     return stubFor({
       request: {
-        method: 'POST',
+        method: 'PUT',
         urlPathPattern: pattern,
       },
       response: {

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -104,6 +104,7 @@ describe('ConfirmController', () => {
           attendanceData: form.attendanceData,
           supervisorOfficerCode: form.supervisor.code,
           notes: form.notes,
+          date: appointment.date,
         },
         'user-name',
       )

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -61,6 +61,7 @@ export default class ConfirmController {
         attendanceData: didAttend ? form.attendanceData : undefined,
         supervisorOfficerCode: form.supervisor.code,
         notes: form.notes,
+        date: appointment.date,
       }
 
       await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)

--- a/server/data/appointmentClient.test.ts
+++ b/server/data/appointmentClient.test.ts
@@ -55,7 +55,7 @@ describe('appointmentClient', () => {
       const appointment = appointmentFactory.build()
 
       nock(config.apis.communityPaybackApi.url)
-        .post(paths.appointments.outcome({ appointmentId: '1001', projectCode: appointment.projectCode }))
+        .put(paths.appointments.outcome({ appointmentId: '1001', projectCode: appointment.projectCode }))
         .matchHeader('authorization', 'Bearer test-system-token')
         .reply(200)
 

--- a/server/data/appointmentClient.ts
+++ b/server/data/appointmentClient.ts
@@ -43,7 +43,7 @@ export default class AppointmentClient extends RestClient {
 
   async save(username: string, projectCode: string, data: UpdateAppointmentOutcomeDto): Promise<void> {
     const path = paths.appointments.outcome({ projectCode, appointmentId: data.deliusId.toString() })
-    return this.post({ path, data }, asSystem(username))
+    return this.put({ path, data }, asSystem(username))
   }
 
   async getAppointmentTasks(params: GetAppointmentTasksRequest): Promise<PagedModelAppointmentTaskSummaryDto> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -18,7 +18,7 @@ export default {
   appointments: {
     filter: adminUiPath.path('appointments'),
     singleAppointment: projectAppointmentsPath.path(':appointmentId'),
-    outcome: projectAppointmentsPath.path(':appointmentId/outcome'),
+    outcome: projectAppointmentsPath.path(':appointmentId'),
     tasks: {
       filter: appointmentTasksPath.path('pending'),
       complete: appointmentTasksPath.path(':taskId/complete'),


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-879)

This endpoint is now a PUT rather than a POST, with a slightly different path, and requires the appointment date to be sent in the payload.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
