### PR TITLE
CPB-858: Fix delius setup failures in e2e tests

### DIFF
--- a/e2e-tests/fixtures/appointment.fixture.ts
+++ b/e2e-tests/fixtures/appointment.fixture.ts
@@ -11,6 +11,7 @@ interface FixtureSetup {
   project: Project
   placementType: PlacementType
   personOnProbation: PersonOnProbation
+  isLoggedInToDelius: boolean
 }
 
 export default async ({

--- a/e2e-tests/fixtures/personOnProbation.fixture.ts
+++ b/e2e-tests/fixtures/personOnProbation.fixture.ts
@@ -10,6 +10,7 @@ interface PersonOnProbationFixtureSetup {
   page: Page
   team: Team
   testInfo: TestInfo
+  isLoggedInToDelius: boolean
 }
 
 export default async ({ page, testInfo, team }: PersonOnProbationFixtureSetup): Promise<PersonOnProbation> => {

--- a/e2e-tests/fixtures/project.fixture.ts
+++ b/e2e-tests/fixtures/project.fixture.ts
@@ -1,6 +1,5 @@
 import { test as base, Page } from '@playwright/test'
 import { createUpwProject } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/create-upw-project'
-import { login } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
 import DateTimeUtils from '../utils/DateTimeUtils'
 import { PlacementType, Team } from './testOptions'
 import Project from '../delius/project'
@@ -10,6 +9,7 @@ interface ProjectFixtureSetup {
   page: Page
   team: Team
   placementType: PlacementType
+  isLoggedInToDelius: boolean
 }
 
 interface ProjectCache {
@@ -25,8 +25,6 @@ const projectCache: ProjectCache = {}
 
 export default async ({ page, team, placementType }: ProjectFixtureSetup): Promise<Project> => {
   const projectFixture = await base.step(`Creating UPW ${placementType} placement project`, async () => {
-    await login(page)
-
     const startDate = new Date()
     // allow incomplete appointments to be rescheduled a week later
     const endDate = DateTimeUtils.plusDays(startDate, 8)

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -1,4 +1,5 @@
 import { test as base, TestInfo } from '@playwright/test'
+import { login } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
 import { TestOptions } from './testOptions'
 import setupPersonOnProbationFixture from './personOnProbation.fixture'
 import setupProjectFixture from './project.fixture'
@@ -30,6 +31,13 @@ export default base.extend<TestOptions>({
       pdu: 'Suffolk',
     },
     { option: true },
+  ],
+  isLoggedInToDelius: [
+    async ({ page }, use) => {
+      await login(page)
+      use(true)
+    },
+    { scope: 'test' },
   ],
   personOnProbation: [
     async ({ page, team }, use, testInfo) => {

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -39,14 +39,6 @@ export default base.extend<TestOptions>({
     },
     { scope: 'test' },
   ],
-  personOnProbation: [
-    async ({ page, team, isLoggedInToDelius }, use, testInfo) => {
-      const personOnProbation = await setupPersonOnProbationFixture({ page, testInfo, team, isLoggedInToDelius })
-
-      use(personOnProbation)
-    },
-    { scope: 'test' },
-  ],
   project: [
     async ({ page, team, placementType, isLoggedInToDelius }, use) => {
       const project = await setupProjectFixture({ page, team, placementType, isLoggedInToDelius })
@@ -64,6 +56,15 @@ export default base.extend<TestOptions>({
     },
     { scope: 'test' },
   ],
+  personOnProbation: [
+    async ({ page, team, isLoggedInToDelius }, use, testInfo) => {
+      const personOnProbation = await setupPersonOnProbationFixture({ page, testInfo, team, isLoggedInToDelius })
+
+      use(personOnProbation)
+    },
+    { scope: 'test' },
+  ],
+  // Appointment should directly follow personOnProbation in the fixtures in the test
   appointment: [
     async ({ page, team, placementType, personOnProbation, project, isLoggedInToDelius }, use) => {
       const appointment = await setupAppointment({

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -40,16 +40,16 @@ export default base.extend<TestOptions>({
     { scope: 'test' },
   ],
   personOnProbation: [
-    async ({ page, team }, use, testInfo) => {
-      const personOnProbation = await setupPersonOnProbationFixture({ page, testInfo, team })
+    async ({ page, team, isLoggedInToDelius }, use, testInfo) => {
+      const personOnProbation = await setupPersonOnProbationFixture({ page, testInfo, team, isLoggedInToDelius })
 
       use(personOnProbation)
     },
     { scope: 'test' },
   ],
   project: [
-    async ({ page, team, placementType }, use) => {
-      const project = await setupProjectFixture({ page, team, placementType })
+    async ({ page, team, placementType, isLoggedInToDelius }, use) => {
+      const project = await setupProjectFixture({ page, team, placementType, isLoggedInToDelius })
 
       use(project)
     },
@@ -65,8 +65,15 @@ export default base.extend<TestOptions>({
     { scope: 'test' },
   ],
   appointment: [
-    async ({ page, team, placementType, personOnProbation, project }, use) => {
-      const appointment = await setupAppointment({ page, team, placementType, personOnProbation, project })
+    async ({ page, team, placementType, personOnProbation, project, isLoggedInToDelius }, use) => {
+      const appointment = await setupAppointment({
+        page,
+        team,
+        placementType,
+        personOnProbation,
+        project,
+        isLoggedInToDelius,
+      })
 
       use(appointment)
     },

--- a/e2e-tests/fixtures/testOptions.ts
+++ b/e2e-tests/fixtures/testOptions.ts
@@ -15,6 +15,7 @@ export interface TestOptions {
   }
   team: Team
   testCount: number
+  isLoggedInToDelius: boolean
   personOnProbation: PersonOnProbation
   project: Project
   placementType: PlacementType

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -10,8 +10,8 @@ test('Process course completion - credit time on existing appointment', async ({
   page,
   deliusUser,
   team,
-  personOnProbation,
   project,
+  personOnProbation,
   appointment,
 }) => {
   await test.step('Send Course Completion Message', async () => {

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -11,7 +11,7 @@ import { completeAttendedCompliedOutcome } from '../../steps/completeAttendanceO
 import { checkAppointmentOnDelius } from '../../steps/delius'
 import DateTimeUtils from '../../utils/DateTimeUtils'
 
-test('Update a session appointment', async ({ page, deliusUser, team, personOnProbation, project, appointment }) => {
+test('Update a session appointment', async ({ page, deliusUser, team, project, personOnProbation, appointment }) => {
   await page.goto('/sign-out')
   await expect(page.locator('h1')).toContainText('Sign in')
 

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -12,8 +12,8 @@ test('Update a session appointment with an enforceable outcome', async ({
   page,
   deliusUser,
   team,
-  personOnProbation,
   project,
+  personOnProbation,
   appointment,
 }) => {
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -13,8 +13,8 @@ test('Update a session appointment with an attended but enforceable outcome', as
   page,
   deliusUser,
   team,
-  personOnProbation,
   project,
+  personOnProbation,
   appointment,
 }) => {
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -12,8 +12,8 @@ test('Update a session appointment with a not attended but not enforceable outco
   page,
   deliusUser,
   team,
-  personOnProbation,
   project,
+  personOnProbation,
   appointment,
 }) => {
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -13,8 +13,8 @@ test('Update an individual placement appointment with attended complied', async 
   page,
   deliusUser,
   team,
-  personOnProbation,
   project,
+  personOnProbation,
   appointment,
 }) => {
   const homePage = await signIn(page, deliusUser)


### PR DESCRIPTION
## Context

In #489 I split up some of our delius set up steps to enable some steps to be used independently (or to create a person without creating any appointments).

When tidying up fixture requirements across these fixtures (removing project from a few), I broke the tests as the test user signs into delius in the project step. Have created a new `isLoggedIntoDelius` fixture that handles log in independently, allowing fixtures to be less interdependent.

**Note:** the `appointment` fixture is still dependent on the `personOnProbation` fixture, and should follow on directly in any usage, as the current `allocateCurrentCaseToUpwProject` requires the user to be on the page for that person first. This could be fixed in the `probation-integration-ete-tests` step in the future.

[CPB-858](https://dsdmoj.atlassian.net/browse/CPB-858)

## Pre merge

- [x] E2E tests [passing in pipeline](https://github.com/ministryofjustice/hmpps-community-payback-ui/actions/runs/24776214810/job/72495059709?pr=496)

<!-- ```
$ ./script/test
``` -->


[CPB-858]: https://dsdmoj.atlassian.net/browse/CPB-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ