### PR TITLE
Fix update api types

### DIFF
--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -40,6 +40,7 @@ export type { PagedModelAppointmentTaskSummaryDto } from './models/PagedModelApp
 export type { PagedModelEteCourseCompletionEventDto } from './models/PagedModelEteCourseCompletionEventDto';
 export type { PagedModelProjectOutcomeSummaryDto } from './models/PagedModelProjectOutcomeSummaryDto';
 export type { PageMetadata } from './models/PageMetadata';
+export type { PageMetaDto } from './models/PageMetaDto';
 export type { PickUpDataDto } from './models/PickUpDataDto';
 export type { PickUpLocationDto } from './models/PickUpLocationDto';
 export type { PickUpLocationsDto } from './models/PickUpLocationsDto';

--- a/server/@types/shared/models/PageMetaDto.ts
+++ b/server/@types/shared/models/PageMetaDto.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PageMetaDto = {
+    size: number;
+    number: number;
+    totalElements: number;
+    totalPages: number;
+};
+

--- a/server/@types/shared/models/SessionSummariesDto.ts
+++ b/server/@types/shared/models/SessionSummariesDto.ts
@@ -2,11 +2,19 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { PageMetaDto } from './PageMetaDto';
 import type { SessionSummaryDto } from './SessionSummaryDto';
 export type SessionSummariesDto = {
     /**
+     *
+     * Deprecated: use the `content` property instead.
+     *
      * List of project allocations
+     *
+     * @deprecated
      */
     allocations: Array<SessionSummaryDto>;
+    content: Array<SessionSummaryDto>;
+    page: PageMetaDto;
 };
 

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -14,6 +14,7 @@ import * as ErrorUtils from '../utils/errorUtils'
 import sessionSummaryFactory from '../testutils/factories/sessionSummaryFactory'
 import getProvidersAndTeams, { ProvidersAndTeams } from './shared/getProvidersAndTeams'
 import sessionFactory from '../testutils/factories/sessionFactory'
+import pagedMetadataFactory from '../testutils/factories/pagedMetadataFactory'
 
 jest.mock('../pages/groupSessionIndexPage')
 jest.mock('./shared/getProvidersAndTeams')
@@ -121,6 +122,8 @@ describe('SessionsController', () => {
 
       const sessions: SessionSummariesDto = {
         allocations: sessionSummaryFactory.buildList(2),
+        content: sessionSummaryFactory.buildList(2),
+        page: pagedMetadataFactory.build(),
       }
 
       const response = createMock<Response>()
@@ -146,6 +149,8 @@ describe('SessionsController', () => {
     it('showNoResultsMessage should be true if sessions list is empty', async () => {
       const sessions: SessionSummariesDto = {
         allocations: [],
+        content: [],
+        page: pagedMetadataFactory.build(),
       }
       resultTableRowsSpy.mockReturnValue([])
       sessionService.getSessions.mockResolvedValue(sessions)

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -3,6 +3,7 @@ import SessionClient from '../data/sessionClient'
 import SessionService from './sessionService'
 import sessionFactory from '../testutils/factories/sessionFactory'
 import sessionSummaryFactory from '../testutils/factories/sessionSummaryFactory'
+import pagedMetadataFactory from '../testutils/factories/pagedMetadataFactory'
 
 jest.mock('../data/sessionClient')
 
@@ -17,6 +18,8 @@ describe('ProviderService', () => {
   it('should call getSessions on the api client and return its result', async () => {
     const sessions: SessionSummariesDto = {
       allocations: sessionSummaryFactory.buildList(1),
+      content: sessionSummaryFactory.buildList(1),
+      page: pagedMetadataFactory.build(),
     }
 
     sessionClient.getSessions.mockResolvedValue(sessions)

--- a/server/testutils/factories/pagedMetadataFactory.ts
+++ b/server/testutils/factories/pagedMetadataFactory.ts
@@ -1,8 +1,8 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
-import { PageMetadata } from '../../@types/shared'
+import { PageMetaDto } from '../../@types/shared'
 
-export default Factory.define<PageMetadata>(() => ({
+export default Factory.define<PageMetaDto>(() => ({
   size: 10,
   number: faker.number.int({ min: 0, max: 5 }),
   totalElements: faker.number.int({ min: 1, max: 50 }),

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -5,6 +5,7 @@ import paths from '../paths'
 import appointmentFactory from '../testutils/factories/appointmentFactory'
 import appointmentSummaryFactory from '../testutils/factories/appointmentSummaryFactory'
 import { contactOutcomeFactory } from '../testutils/factories/contactOutcomeFactory'
+import pagedMetadataFactory from '../testutils/factories/pagedMetadataFactory'
 import sessionFactory from '../testutils/factories/sessionFactory'
 import sessionSummaryFactory from '../testutils/factories/sessionSummaryFactory'
 import DateTimeFormats from './dateTimeUtils'
@@ -38,6 +39,8 @@ describe('SessionUtils', () => {
 
       const sessions: SessionSummariesDto = {
         allocations: [allocation],
+        content: [allocation],
+        page: pagedMetadataFactory.build(),
       }
 
       const result = SessionUtils.sessionResultTableRows(sessions, { provider: 'X123' } as GroupSessionIndexPageInput)


### PR DESCRIPTION
`SessionSummaryDto` now expects paginated properties

And the `pagedMetadataFactory` should now build a `PageMetaDto`.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
