### PR TITLE
CPB-872 Handle CRN not found

### DIFF
--- a/integration_tests/pages/courseCompletions/process/crnPage.ts
+++ b/integration_tests/pages/courseCompletions/process/crnPage.ts
@@ -16,12 +16,16 @@ export default class CrnPage extends BaseCourseCompletionsPage {
     return new CrnPage()
   }
 
-  enterCrn() {
-    this.crnField.type('123')
+  enterCrn(crn: string) {
+    this.crnField.type(crn)
   }
 
-  shouldShowErrors() {
+  shouldShowValidationErrors() {
     this.shouldShowErrorSummary('crn', 'Enter a CRN')
+  }
+
+  shouldShowCrnNotFoundError() {
+    this.shouldShowErrorSummary('crn', 'Sorry the CRN you have entered could not be found.')
   }
 
   shouldHaveCrnValue(crn: string) {

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -18,6 +18,11 @@
 //    When I click back
 //    Then I should see the course completion details page
 
+//  Scenario: CRN not found
+//    Given I am on the form page
+//    When I complete the form with an invalid CRN
+//    Then I should see the page with errors
+
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
@@ -49,7 +54,7 @@ context('Crn Page', () => {
     const page = CrnPage.visit(courseCompletion)
 
     //  When I complete the form
-    page.enterCrn()
+    page.enterCrn(offender.crn)
     page.clickSubmit()
 
     // Then I should see the next page of the form
@@ -66,7 +71,21 @@ context('Crn Page', () => {
 
     // Then I should see the page with errors
     Page.verifyOnPage(CrnPage)
-    page.shouldShowErrors()
+    page.shouldShowValidationErrors()
+  })
+
+  // Scenario: CRN not found
+  it('shows CRN not found error', () => {
+    //  Given I am on the form page
+    const page = CrnPage.visit(courseCompletion)
+
+    //  When I complete the form with an invalid CRN
+    page.enterCrn('invalid-crn')
+    page.clickSubmit()
+
+    // Then I should see the page with errors
+    Page.verifyOnPage(CrnPage)
+    page.shouldShowCrnNotFoundError()
   })
 
   // Scenario: Navigating back

--- a/server/controllers/courseCompletions/process/crnController.test.ts
+++ b/server/controllers/courseCompletions/process/crnController.test.ts
@@ -6,6 +6,8 @@ import CrnPage from '../../../pages/courseCompletions/process/crnPage'
 import courseCompletionFactory from '../../../testutils/factories/courseCompletionFactory'
 import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
+import OffenderService from '../../../services/offenderService'
+import caseDetailsSummaryFactory from '../../../testutils/factories/caseDetailsSummaryFactory'
 
 describe('CrnController', () => {
   const response = createMock<Response>()
@@ -14,8 +16,10 @@ describe('CrnController', () => {
   const templatePath = '/views/page.njk'
   const courseCompletionService = createMock<CourseCompletionService>()
   const formService = createMock<CourseCompletionFormService>()
+  const offenderService = createMock<OffenderService>()
   const courseCompletion = courseCompletionFactory.build()
   const form = courseCompletionFormFactory.build()
+  const caseDetailsSummary = caseDetailsSummaryFactory.build()
 
   const stepViewData = {
     crn: '123',
@@ -27,9 +31,10 @@ describe('CrnController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    crnController = new CrnController(page, courseCompletionService, formService)
+    crnController = new CrnController(page, courseCompletionService, formService, offenderService)
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue(form)
+    offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
   })
 
   describe('show', () => {
@@ -105,7 +110,7 @@ describe('CrnController', () => {
       })
     })
 
-    describe('has errors', () => {
+    describe('has validation errors', () => {
       it('rerenders page if validation errors', async () => {
         const viewData = {
           backLink: '/back',
@@ -166,6 +171,62 @@ describe('CrnController', () => {
           errorSummary,
         })
         expect(formService.getForm).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('has API errors', () => {
+      describe('when the error status is 404', () => {
+        it('rerenders the page with errors', async () => {
+          offenderService.getOffenderSummary.mockRejectedValue({
+            responseStatus: 404,
+          })
+
+          const viewData = {
+            backLink: '/back',
+            updatePath: '/update',
+            communityCampusPerson: { name: 'Mary Smith' },
+            courseName: 'Customer service',
+          }
+          page.viewData.mockReturnValue(viewData)
+          page.stepViewData.mockReturnValue(stepViewData)
+
+          const crnNotFoundErrors = {
+            errorSummary: [{ text: 'Error 1', href: '#1', attributes: {} }],
+            errors: { crn: { text: 'Error' } },
+          }
+
+          page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
+          page.getCrnNotFoundErrors.mockReturnValue(crnNotFoundErrors)
+
+          const request = createMock<Request>({ params: { id: '1' }, query: {} })
+
+          const requestHandler = crnController.submit()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith(templatePath, {
+            ...viewData,
+            ...stepViewData,
+            ...crnNotFoundErrors,
+          })
+          expect(formService.saveForm).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the error status is not 404', () => {
+        it('throws the error', async () => {
+          const apiError = {
+            responseStatus: 500,
+          }
+
+          offenderService.getOffenderSummary.mockRejectedValue(apiError)
+
+          page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
+
+          const request = createMock<Request>({ params: { id: '1' }, query: {} })
+
+          const requestHandler = crnController.submit()
+          await expect(requestHandler(request, response, next)).rejects.toEqual(apiError)
+        })
       })
     })
   })

--- a/server/controllers/courseCompletions/process/crnController.ts
+++ b/server/controllers/courseCompletions/process/crnController.ts
@@ -1,16 +1,18 @@
-import type { Request, Response } from 'express'
+import type { Request, RequestHandler, Response } from 'express'
 
 import { randomUUID } from 'crypto'
 import CrnPage from '../../../pages/courseCompletions/process/crnPage'
 import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import CourseCompletionFormService, { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import OffenderService from '../../../services/offenderService'
 
 export default class CrnController extends BaseController<CrnPage> {
   constructor(
     page: CrnPage,
     courseCompletionService: CourseCompletionService,
     formService: CourseCompletionFormService,
+    private readonly offenderService: OffenderService,
   ) {
     super(page, courseCompletionService, formService)
   }
@@ -35,5 +37,54 @@ export default class CrnController extends BaseController<CrnPage> {
     }
 
     return { formId, formData }
+  }
+
+  override submit(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const courseCompletionId = req.params.id.toString()
+      const { hasErrors: hasValidationErrors, errorSummary, errors } = this.page.validationErrors(req.body)
+
+      const { formId, formData } = await this.getForm(req, res, true)
+
+      if (hasValidationErrors) {
+        const courseCompletion = await this.courseCompletionService.getCourseCompletion({
+          username: res.locals.user.username,
+          id: req.params.id,
+        })
+
+        const viewData = {
+          ...this.page.viewData(courseCompletion, formId),
+          ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors })),
+          errorSummary,
+          errors,
+        }
+        return res.render(this.page.templatePath, viewData)
+      }
+
+      try {
+        await this.offenderService.getOffenderSummary({ username: res.locals.user.username, crn: req.body.crn })
+      } catch (apiError) {
+        if (apiError.responseStatus !== 404) {
+          throw apiError
+        }
+
+        const courseCompletion = await this.courseCompletionService.getCourseCompletion({
+          username: res.locals.user.username,
+          id: req.params.id,
+        })
+
+        const viewData = {
+          ...this.page.viewData(courseCompletion, formId),
+          ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors: {} })),
+          ...this.page.getCrnNotFoundErrors(),
+        }
+        return res.render(this.page.templatePath, viewData)
+      }
+
+      const updatedFormData = this.page.getFormData(formData, req.body)
+      await this.courseCompletionFormService.saveForm(formId, res.locals.user.username, updatedFormData)
+
+      return res.redirect(this.page.nextPath(courseCompletionId, formId))
+    }
   }
 }

--- a/server/controllers/courseCompletions/process/crnController.ts
+++ b/server/controllers/courseCompletions/process/crnController.ts
@@ -62,7 +62,7 @@ export default class CrnController extends BaseController<CrnPage> {
       }
 
       try {
-        await this.offenderService.getOffenderSummary({ username: res.locals.user.username, crn: req.body.crn })
+        await this.offenderService.getOffenderSummary({ username: res.locals.user.username, crn: req.body.crn.trim() })
       } catch (apiError) {
         if (apiError.responseStatus !== 404) {
           throw apiError

--- a/server/controllers/courseCompletions/process/index.ts
+++ b/server/controllers/courseCompletions/process/index.ts
@@ -43,7 +43,12 @@ const controllers = (services: Services) => {
     offenderService,
     appointmentService,
   )
-  const crnController = new CrnController(new CrnPage(), courseCompletionService, courseCompletionFormService)
+  const crnController = new CrnController(
+    new CrnPage(),
+    courseCompletionService,
+    courseCompletionFormService,
+    offenderService,
+  )
   const personController = new PersonController(
     new PersonPage(),
     courseCompletionService,

--- a/server/pages/courseCompletions/process/crnPage.test.ts
+++ b/server/pages/courseCompletions/process/crnPage.test.ts
@@ -140,4 +140,35 @@ describe('CrnPage', () => {
       })
     })
   })
+
+  describe('getCrnNotFoundErrors', () => {
+    it('returns errors and error summary for CRN not found', () => {
+      const errorSummary = [
+        {
+          text: 'Sorry the CRN you have entered could not be found.',
+          href: '#crn',
+          attributes: {},
+        },
+      ]
+
+      jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
+
+      const result = page.getCrnNotFoundErrors()
+
+      expect(result).toEqual({
+        errorSummary: [
+          {
+            text: 'Sorry the CRN you have entered could not be found.',
+            href: '#crn',
+            attributes: {},
+          },
+        ],
+        errors: {
+          crn: {
+            text: 'Sorry the CRN you have entered could not be found.',
+          },
+        },
+      })
+    })
+  })
 })

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -3,6 +3,7 @@ import { ValidationErrors } from '../../../@types/user-defined'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
+import { ErrorSummaryItem, generateErrorSummary } from '../../../utils/errorUtils'
 
 export interface CrnPageBody {
   crn?: string
@@ -11,6 +12,11 @@ export interface CrnPageBody {
 interface ViewData {
   crn?: string
   hintText: string
+}
+
+type ApiError<T> = {
+  errorSummary: ErrorSummaryItem[]
+  errors: Record<keyof T, Record<string, string>>
 }
 
 export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
@@ -28,6 +34,15 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
     }
 
     return errors
+  }
+
+  getCrnNotFoundErrors(): ApiError<CrnPageBody> {
+    const crnNotFoundError = 'Sorry the CRN you have entered could not be found.'
+
+    return {
+      errorSummary: generateErrorSummary({ crn: { text: crnNotFoundError } }),
+      errors: { crn: { text: crnNotFoundError } },
+    }
   }
 
   stepViewData(

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -23,7 +23,7 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
   protected page: CourseCompletionPage = 'crn'
 
   getFormData(formData: CourseCompletionForm, body: CrnPageBody): CourseCompletionForm {
-    return { ...formData, crn: body.crn }
+    return { ...formData, crn: body.crn.trim() }
   }
 
   protected getValidationErrors(query: CrnPageBody): ValidationErrors<CrnPageBody> {


### PR DESCRIPTION
[CPB-872](https://dsdmoj.atlassian.net/browse/CPB-872?atlOrigin=eyJpIjoiY2FmYjJlODY0MWU4NDVkM2IzMTk1YTM3ODE3MDY3YTEiLCJwIjoiaiJ9)
[CPB-852](https://dsdmoj.atlassian.net/browse/CPB-852?atlOrigin=eyJpIjoiMmZhMDgyODQxMDQzNDk4Mjk5Y2VhMTBmMTNkNTdkODAiLCJwIjoiaiJ9)

## Context
In the event that a CRN is not found, re-render the page with errors. Ignore all other types of API errors to be caught by middleware.

The "Confirm person" page makes a call to retrieve the error summary to be displayed on that page. This change adds an additional call on the CRN page that verifies the CRN is valid before saving it to the form.

Note: I thought about creating a more reusable pattern for handling API errors on pages, but I think it's best to wait for a second instance of this to inform the behaviour of the abstraction. For example, not all API errors require linking to a form field.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Handle form submission in CRN controller
* Make additional API call to verify valid CRN
* Remove whitespace from CRN

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1270" height="637" alt="Screenshot 2026-04-23 at 17 51 30" src="https://github.com/user-attachments/assets/6ca97539-83a3-4325-af27-0d3c8547bbed" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-872]: https://dsdmoj.atlassian.net/browse/CPB-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPB-852]: https://dsdmoj.atlassian.net/browse/CPB-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ