### PR TITLE
CPB-895: Add sorting by full name for course completions

### DIFF
--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -86,7 +86,7 @@ export interface GetCourseCompletionsRequest extends BaseRequest, PagedRequest {
 }
 
 export interface GetCourseCompletionsParams extends BaseRequest, PagedRequest, GetCourseCompletionsRequest {
-  sortBy: CourseCompletionSortField
+  sortBy: CourseCompletionSortField | CourseCompletionSortField[]
   sortDirection: SortDirection
 }
 
@@ -100,7 +100,7 @@ export interface GetAppointmentTasksRequest extends BaseRequest, PagedRequest {
 }
 
 export interface GetAppointmentTasksParams extends BaseRequest, PagedRequest, GetAppointmentTasksRequest {
-  sortBy: TravelTimeSortField
+  sortBy: TravelTimeSortField | TravelTimeSortField[]
   sortDirection: SortDirection
 }
 

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -176,7 +176,7 @@ export type TableCell = (TextItem | HtmlItem) & {
 
 export type AriaSortDirection = 'none' | 'ascending' | 'descending'
 
-export type CourseCompletionSortField = 'lastName' | 'courseName' | 'completionDateTime'
+export type CourseCompletionSortField = 'firstName' | 'lastName' | 'courseName' | 'completionDateTime'
 
 export type TravelTimeSortField = 'appointment.crn' | 'appointment.date'
 

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -8,7 +8,7 @@ import ReferenceDataService from '../../services/referenceDataService'
 import getProvidersAndPdus from '../shared/getProvidersAndPdus'
 import ProviderService from '../../services/providerService'
 
-const courseCompletionSortFields = ['lastName', 'courseName', 'completionDateTime'] as const
+const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime'] as const
 
 export default class CourseCompletionsController {
   constructor(

--- a/server/pages/appointments/searchTravelTimePage.ts
+++ b/server/pages/appointments/searchTravelTimePage.ts
@@ -22,7 +22,11 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
     return validationErrors
   }
 
-  static tableHeaders(sortBy: TravelTimeSortField, sortDirection: SortDirection, hrefPrefix: string): Array<TableCell> {
+  static tableHeaders(
+    sortBy: TravelTimeSortField | TravelTimeSortField[],
+    sortDirection: SortDirection,
+    hrefPrefix: string,
+  ): Array<TableCell> {
     return [
       { text: 'Name' },
       sortHeader<TravelTimeSortField>('CRN', 'appointment.crn', sortBy, sortDirection, hrefPrefix, 'search-results'),

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -126,10 +126,24 @@ describe('CourseCompletionIndexPage', () => {
         'endDate-year': '2025',
       } as CourseCompletionPageInput)
 
-      expect(page.courseCompletionTableHeaders('lastName', 'asc', '/test')).toEqual([
-        sortHeader<CourseCompletionSortField>('Name', 'lastName', 'lastName', 'asc', '/test', 'search-results'),
+      expect(page.courseCompletionTableHeaders(['firstName', 'lastName'], 'asc', '/test')).toEqual([
+        sortHeader<CourseCompletionSortField>(
+          'Name',
+          ['firstName', 'lastName'],
+          ['firstName', 'lastName'],
+          'asc',
+          '/test',
+          'search-results',
+        ),
         { text: 'ID' },
-        sortHeader<CourseCompletionSortField>('Course', 'courseName', 'lastName', 'asc', '/test', 'search-results'),
+        sortHeader<CourseCompletionSortField>(
+          'Course',
+          'courseName',
+          ['firstName', 'lastName'],
+          'asc',
+          '/test',
+          'search-results',
+        ),
         sortHeader<CourseCompletionSortField>(
           'Date completed',
           'completionDateTime',

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -59,7 +59,7 @@ export default class CourseCompletionIndexPage {
   }
 
   courseCompletionTableHeaders(
-    sortBy: CourseCompletionSortField,
+    sortBy: CourseCompletionSortField | CourseCompletionSortField[],
     sortDirection: SortDirection,
     hrefPrefix: string,
   ): Array<TableCell> {

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -64,7 +64,14 @@ export default class CourseCompletionIndexPage {
     hrefPrefix: string,
   ): Array<TableCell> {
     return [
-      sortHeader<CourseCompletionSortField>('Name', 'lastName', sortBy, sortDirection, hrefPrefix, 'search-results'),
+      sortHeader<CourseCompletionSortField>(
+        'Name',
+        ['firstName', 'lastName'],
+        sortBy,
+        sortDirection,
+        hrefPrefix,
+        'search-results',
+      ),
       {
         text: 'ID',
       },

--- a/server/services/courseCompletionService.test.ts
+++ b/server/services/courseCompletionService.test.ts
@@ -86,6 +86,31 @@ describe('CourseCompletionService', () => {
     )
   })
 
+  it('should call getCourseCompletions with correct value for sort parameter when sorting by multiple fields', async () => {
+    const courseCompletionsPagedResponse = pagedModelCourseCompletionEventFactory.build()
+
+    courseCompletionClient.getCourseCompletions.mockResolvedValue(courseCompletionsPagedResponse)
+
+    await courseCompletionService.searchCourseCompletions({
+      username: 'some-username',
+      providerCode: 'A1234',
+      pduId: '123',
+      dateFrom: '2025-09-01',
+      dateTo: '2025-09-02',
+      page: 2,
+      sortBy: ['firstName', 'lastName'],
+      sortDirection: 'asc',
+    })
+
+    expect(courseCompletionClient.getCourseCompletions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: ['firstName,asc', 'lastName,asc'],
+        page: 1,
+        size: 10,
+      }),
+    )
+  })
+
   it('should call saveResolution on the api client', async () => {
     const courseCompletionData = courseCompletionResolutionFactory.build()
 

--- a/server/services/courseCompletionService.ts
+++ b/server/services/courseCompletionService.ts
@@ -16,7 +16,14 @@ export default class CourseCompletionService {
 
   async searchCourseCompletions(request: GetCourseCompletionsParams): Promise<PagedModelEteCourseCompletionEventDto> {
     const { page, sortBy, sortDirection, size, ...params } = request
-    const sort = [`${sortBy ?? 'completionDateTime'},${sortDirection ?? 'asc'}`]
+
+    let sort: string[]
+    if (Array.isArray(sortBy) && sortBy.length > 0) {
+      sort = sortBy.map(s => `${s ?? 'completionDateTime'},${sortDirection ?? 'asc'}`)
+    } else {
+      sort = [`${sortBy ?? 'completionDateTime'},${sortDirection ?? 'asc'}`]
+    }
+
     const courseCompletions = await this.courseCourseCompletionClient.getCourseCompletions({
       ...params,
       sort,

--- a/server/utils/paginationUtils.test.ts
+++ b/server/utils/paginationUtils.test.ts
@@ -250,6 +250,17 @@ describe('pagination utils', () => {
       })
     })
 
+    it('should provide multiple sortBy values when multiple sort fields are provided', () => {
+      const request = createMock<Request>({ query: { sortBy: ['firstName', 'lastName'], sortDirection: 'asc' } })
+
+      expect(getPaginationRequestParams(request, basePath, {}, ['firstName', 'lastName'])).toEqual({
+        pageNumber: undefined,
+        hrefPrefix: `${basePath}?sortBy=firstName&sortBy=lastName&sortDirection=asc&`,
+        sortBy: ['firstName', 'lastName'],
+        sortDirection: 'asc',
+      })
+    })
+
     it('should append additional parameters to the hrefPrefix', () => {
       const request = createMock<Request>({ query: { page: '1' } })
 

--- a/server/utils/paginationUtils.ts
+++ b/server/utils/paginationUtils.ts
@@ -116,14 +116,24 @@ export const getPaginationRequestParams = <T>(
   const pageNumber = request.query.page ? Number(request.query.page) : undefined
 
   const rawSortBy = request.query.sortBy
-  const sortBy: T | undefined =
-    typeof rawSortBy === 'string' && validSortFields.includes(rawSortBy) ? (rawSortBy as T) : undefined
+
+  let sortBy: T | T[] | undefined
+  if (Array.isArray(rawSortBy) && rawSortBy.length > 0) {
+    sortBy = rawSortBy
+      .map(s => (typeof s === 'string' && validSortFields.includes(s) ? (s as T) : undefined))
+      .filter(s => s !== undefined)
+  } else {
+    sortBy = typeof rawSortBy === 'string' && validSortFields.includes(rawSortBy) ? (rawSortBy as T) : undefined
+  }
 
   const rawSortDirection = request.query.sortDirection
   const sortDirection: SortDirection | undefined =
     rawSortDirection === 'asc' || rawSortDirection === 'desc' ? rawSortDirection : undefined
 
-  const queryString = createQueryString({ ...additionalParams, sortBy, sortDirection }, { addQueryPrefix: true })
+  const queryString = createQueryString(
+    { ...additionalParams, sortBy, sortDirection },
+    { addQueryPrefix: true, arrayFormat: 'repeat' },
+  )
   const queryStringSuffix = queryString.length > 0 ? '&' : '?'
   const hrefPrefix = `${basePath}${queryString}${queryStringSuffix}`
 

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -42,6 +42,21 @@ describe('sortHeader', () => {
     })
   })
 
+  it('should return a header when the target has multiple sort fields', () => {
+    expect(
+      sortHeader<SortHeaders>('Some text', ['myField', 'otherField'], ['myField', 'otherField'], 'asc', hrefPrefix),
+    ).toEqual({
+      html: `<a class="moj-sortable-table__button" href="${hrefPrefix}${createQueryString({
+        sortBy: ['myField', 'otherField'],
+        sortDirection: 'desc',
+      })}">Some text</a>`,
+      attributes: {
+        'aria-sort': 'ascending',
+        'data-cy-sort-field': ['myField', 'otherField'],
+      },
+    })
+  })
+
   it('should override and replace the existing parameters in the hrefPrefix', () => {
     const prefixWithParams = `${hrefPrefix}page=2&sortBy=otherField&sortDirection=asc`
     expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', 'desc', prefixWithParams)).toEqual({

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -2,10 +2,31 @@ import qs from 'qs'
 import { createQueryString } from './utils'
 import { AriaSortDirection, SortDirection, TableCell } from '../@types/user-defined'
 
+function fieldEquals<T extends string>(targetField: T | T[], currentSortField: T | T[]): boolean {
+  if (typeof targetField === 'string' && typeof currentSortField === 'string') {
+    return targetField === currentSortField
+  }
+  if (Array.isArray(targetField) && Array.isArray(currentSortField)) {
+    if (targetField.length !== currentSortField.length) {
+      return false
+    }
+
+    for (let i = 0; i < targetField.length; i += 1) {
+      if (targetField[i] !== currentSortField[i]) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  return false
+}
+
 export default function sortHeader<T extends string>(
   text: string,
-  targetField: T,
-  currentSortField: T,
+  targetField: T | T[],
+  currentSortField: T | T[],
   currentSortDirection: SortDirection,
   hrefPrefix: string,
   tableDivId?: string,
@@ -16,7 +37,7 @@ export default function sortHeader<T extends string>(
   const [basePath, queryString] = hrefPrefix.split('?')
   const qsArgs = qs.parse(queryString)
 
-  if (targetField === currentSortField) {
+  if (fieldEquals(targetField, currentSortField)) {
     if (currentSortDirection === 'desc') {
       sortDirection = 'asc'
       ariaSort = 'descending'
@@ -27,13 +48,17 @@ export default function sortHeader<T extends string>(
   }
 
   const tableLocator = tableDivId ? `#${tableDivId}` : ''
-
-  return {
-    html: `<a class="moj-sortable-table__button" href="${basePath}?${createQueryString({
+  const formattedQueryString = createQueryString(
+    {
       ...qsArgs,
       sortBy: targetField,
       sortDirection,
-    })}${tableLocator}">${text}</a>`,
+    },
+    { arrayFormat: 'repeat' },
+  )
+
+  return {
+    html: `<a class="moj-sortable-table__button" href="${basePath}?${formattedQueryString}${tableLocator}">${text}</a>`,
     attributes: {
       'aria-sort': ariaSort,
       'data-cy-sort-field': targetField,


### PR DESCRIPTION
## Context

This PR updates the Community Campus course completions page so that when sorting by the 'Name' column, it is sorted by the full name, not just by the last name.

In the API, the `ete_course_completion_events` table stores `first_name` and `last_name` as separate columns.

This means that to correctly sort by name, it's necessary for the UI to be able to sort by the first name AND by the last name. Sorting by first name is not enough, as when two people have an identical first name then the order in which
they will be returned is non-deterministic.

[CPB-895](https://dsdmoj.atlassian.net/browse/CPB-895)

## Changes in this PR

Two features responsible for creating page URLs involving pagination/sorting have been updated:
- the `sortHeader` function has been updated to accept either a `T` or an array of `T[]` as its `targetField` and `currentSortField` parameters.
- the `getPaginationRequestParams` function has been updated to support situations where the `sortBy` query parameter on the request is an array.

In both situations, the convention is to use the `'repeat'` array format when building query strings, as this simplifies the implementation and aligns with how the API processes the `sort` query parameter.

Additionally, the `CourseCompletionService` and `CourseCompletionIndexPage` classes have been updated to allow sorting by first name and last name.

As a result of the changes to the signature of the `sortHeader` function, the `GetAppointmentTasksParams` interface and `SearchTravelTimePage.tableHeaders` function have needed to be updated as well, although the behaviour has not been changed.

### Screenshots of UI changes

Full name in ascending order (A->Z):
<img width="2978" height="3132" alt="image" src="https://github.com/user-attachments/assets/33070910-ad1b-4cc2-8ad6-c01635566bc1" />

Full name in descending order (Z->A):
<img width="2978" height="3132" alt="image" src="https://github.com/user-attachments/assets/4178ab55-7427-4970-9f8a-d979df04b259" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-895]: https://dsdmoj.atlassian.net/browse/CPB-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ