### PR TITLE
CPB-850: Persist course completion search during a form

### DIFF
--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -63,4 +63,5 @@ test('Process course completion - credit time on existing appointment', async ({
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
+  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
 })

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -61,4 +61,5 @@ test('Process course completion - create new appointment', async ({
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
+  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
 })

--- a/integration_tests/pages/courseCompletions/courseCompletionPage.ts
+++ b/integration_tests/pages/courseCompletions/courseCompletionPage.ts
@@ -3,6 +3,8 @@ import paths from '../../../server/paths'
 import SummaryListComponent from '../components/summaryListComponent'
 import Page from '../page'
 import dateTimeUtils from '../../../server/utils/dateTimeUtils'
+import { CourseCompletionPageInput } from '../../../server/pages/courseCompletionIndexPage'
+import { pathWithQuery } from '../../../server/utils/utils'
 
 export default class CourseCompletionPage extends Page {
   private courseCompletionDetails: SummaryListComponent
@@ -12,8 +14,11 @@ export default class CourseCompletionPage extends Page {
     this.courseCompletionDetails = new SummaryListComponent()
   }
 
-  static visit(courseCompletion: EteCourseCompletionEventDto): CourseCompletionPage {
-    const path = `${paths.courseCompletions.show({ id: courseCompletion.id })}`
+  static visit(
+    courseCompletion: EteCourseCompletionEventDto,
+    searchParams?: CourseCompletionPageInput,
+  ): CourseCompletionPage {
+    const path = pathWithQuery(paths.courseCompletions.show({ id: courseCompletion.id }), searchParams)
     cy.visit(path)
 
     return new CourseCompletionPage(courseCompletion)

--- a/integration_tests/pages/courseCompletions/process/crnPage.ts
+++ b/integration_tests/pages/courseCompletions/process/crnPage.ts
@@ -1,5 +1,7 @@
 import { EteCourseCompletionEventDto } from '../../../../server/@types/shared'
+import { CourseCompletionPageInput } from '../../../../server/pages/courseCompletionIndexPage'
 import paths from '../../../../server/paths'
+import { pathWithQuery } from '../../../../server/utils/utils'
 import BaseCourseCompletionsPage from './baseCourseCompletionsPage'
 
 export default class CrnPage extends BaseCourseCompletionsPage {
@@ -9,8 +11,15 @@ export default class CrnPage extends BaseCourseCompletionsPage {
     super('Match with CRN')
   }
 
-  static visit(courseCompletion: EteCourseCompletionEventDto) {
-    const path = paths.courseCompletions.process({ page: 'crn', id: courseCompletion.id })
+  static visit(
+    courseCompletion: EteCourseCompletionEventDto,
+    formId?: string,
+    originalSearch: CourseCompletionPageInput = {},
+  ) {
+    const path = pathWithQuery(paths.courseCompletions.process({ page: 'crn', id: courseCompletion.id }), {
+      ...originalSearch,
+      form: formId,
+    })
     cy.visit(path)
 
     return new CrnPage()

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -52,7 +52,7 @@
 //      Given I am on the confirm page of an in progress update
 //      When I select yes to sending an alert
 //      And I submit
-//      Then I can see the course completion search page with success message
+//      Then I can see the course completion search page with success message and search results
 //    Scenario: Should show any API validation errors
 //      Given I am on the confirm page of an in progress update
 //      When I submit
@@ -73,12 +73,16 @@ import ProjectPage from '../../../pages/courseCompletions/process/projectPage'
 import RequirementPage from '../../../pages/courseCompletions/process/requirementPage'
 import Page from '../../../pages/page'
 import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
-import { communityCampusPdusFactory } from '../../../../server/testutils/factories/communityCampusPduFactory'
+import {
+  communityCampusPduFactory,
+  communityCampusPdusFactory,
+} from '../../../../server/testutils/factories/communityCampusPduFactory'
 import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
 import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
 import DateTimeFormats from '../../../../server/utils/dateTimeUtils'
 import AppointmentPage from '../../../pages/courseCompletions/process/appointmentPage'
 import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
+import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 
 context('Confirm details page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -328,6 +332,8 @@ context('Confirm details page', () => {
   describe('submitting course completion resolution', () => {
     // Scenario: Shows a success message
     it('submits course completion and shows success message on course completion page', () => {
+      const pdu = communityCampusPduFactory.build({ id: form.originalSearch.pdu })
+      const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
       // Given I am on the confirm page of an in progress update
       const page = ConfirmDetailsPage.visit(courseCompletion, form)
 
@@ -342,6 +348,19 @@ context('Confirm details page', () => {
         providers: { providers: providerSummaryFactory.buildList(2) },
       })
 
+      const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+        content: [courseCompletion],
+      })
+
+      cy.task('stubGetCourseCompletions', {
+        request: {
+          providerCode: provider.code,
+          pduId: pdu.id,
+          username: 'some-name',
+        },
+        courseCompletions: courseCompletionResponse,
+      })
+
       // And I submit
       page.clickSubmit()
 
@@ -350,6 +369,8 @@ context('Confirm details page', () => {
       courseCompletionPage.shouldShowSuccessMessage(
         `The course completion for ${offender.forename} ${offender.surname} has been processed`,
       )
+      // And I should see the search results
+      courseCompletionPage.shouldShowSearchResults(courseCompletion)
     })
 
     // Scenario: Should show any API validation errors

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -13,12 +13,6 @@
 //    And I click back
 //    Then I can see the outcome page
 
-//  Scenario: Submitting a course completion resolution
-//    Given I am on the confirm page of an in progress update
-//    When I select yes to sending an alert
-//    And I submit
-//    Then I can see the course completion search page with success message
-
 //  Scenario: Changing submitted answers
 //    Scenario: Changing the CRN
 //      Given I am on the confirm page of an in progress update
@@ -52,6 +46,18 @@
 //      Given I am on the confirm page of an in progress update
 //      And I click change sensitivity
 //      Then I can see the outcome page
+
+//  Scenario: Submitting a course completion
+//    Scenario: Shows a success message
+//      Given I am on the confirm page of an in progress update
+//      When I select yes to sending an alert
+//      And I submit
+//      Then I can see the course completion search page with success message
+//    Scenario: Should show any API validation errors
+//      Given I am on the confirm page of an in progress update
+//      When I submit
+//      And the API returns a 400 error
+//      Then I can see the error message
 
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
@@ -320,11 +326,12 @@ context('Confirm details page', () => {
 
   // Scenario: Submitting a course completion resolution
   describe('submitting course completion resolution', () => {
+    // Scenario: Shows a success message
     it('submits course completion and shows success message on course completion page', () => {
       // Given I am on the confirm page of an in progress update
       const page = ConfirmDetailsPage.visit(courseCompletion, form)
 
-      //  When I select yes to sending an alert
+      // When I select yes to sending an alert
 
       page.alertPractitionerQuestion.checkOptionWithValue('yes')
 
@@ -335,22 +342,20 @@ context('Confirm details page', () => {
         providers: { providers: providerSummaryFactory.buildList(2) },
       })
 
-      //  And I submit
+      // And I submit
       page.clickSubmit()
 
-      //  Then I can see the course completion search page with success message
+      // Then I can see the course completion search page with success message
       const courseCompletionPage = Page.verifyOnPage(SearchCourseCompletionsPage)
       courseCompletionPage.shouldShowSuccessMessage(
         `The course completion for ${offender.forename} ${offender.surname} has been processed`,
       )
     })
 
+    // Scenario: Should show any API validation errors
     it('returns an error message when submission fails with a 400 error', () => {
       // Given I am on the confirm page of an in progress update
       const page = ConfirmDetailsPage.visit(courseCompletion, form)
-
-      // When I select yes to sending an alert
-      page.alertPractitionerQuestion.checkOptionWithValue('yes')
 
       // And the API returns a 400 error
       const userMessage = 'Invalid course completion data'

--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -12,12 +12,29 @@
 //    And I click "Enter another CRN"
 //    Then I should see the CRN page
 
+//  Scenario: Navigates back to search results
+//    Given I am on the page
+//    When I click back
+//    Then I should see the course completion details page
+//    And I click back again
+//    Then I should see the course completion details page
+//    And I click back again
+//    Then I should see the course completion search page
+
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
+import {
+  communityCampusPduFactory,
+  communityCampusPdusFactory,
+} from '../../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
 import offenderFullFactory from '../../../../server/testutils/factories/offenderFullFactory'
+import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
+import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
+import CourseCompletionPage from '../../../pages/courseCompletions/courseCompletionPage'
 import CrnPage from '../../../pages/courseCompletions/process/crnPage'
 import PersonPage from '../../../pages/courseCompletions/process/personPage'
+import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
 import Page from '../../../pages/page'
 
 context('Person Page', () => {
@@ -55,5 +72,49 @@ context('Person Page', () => {
 
     // Then I should see the CRN page
     Page.verifyOnPage(CrnPage)
+  })
+
+  // Scenario: Navigates back to search results
+  it('navigates back to search results', () => {
+    const pdu = communityCampusPduFactory.build({ id: form.originalSearch.pdu })
+    const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
+    cy.task('stubFindCourseCompletion', { courseCompletion })
+    //  Given I am on the page
+    const page = PersonPage.visit(courseCompletion, offender)
+
+    //  When I click back
+    page.clickBack()
+
+    // Then I should see the course completion details page
+    Page.verifyOnPage(CrnPage, courseCompletion)
+
+    //  And I click back again
+    page.clickBack()
+
+    // Then I should see the course completion details page
+    Page.verifyOnPage(CourseCompletionPage, courseCompletion)
+
+    // And I click back again
+    cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
+    cy.task('stubGetProviders', {
+      providers: { providers: providerSummaryFactory.buildList(2) },
+    })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
+
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: provider.code,
+        pduId: pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
+    page.clickBack()
+
+    // Then I should see the course completion search page
+    const searchPage = Page.verifyOnPage(SearchCourseCompletionsPage, courseCompletion)
+    searchPage.shouldShowSearchResults(courseCompletion)
   })
 })

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -13,23 +13,37 @@
 //    When I submit an invalid form
 //    Then I should see the page with errors
 
-//  Scenario: Navigating back
-//    Given I am on the form page
-//    When I click back
-//    Then I should see the course completion details page
-
 //  Scenario: CRN not found
 //    Given I am on the form page
 //    When I complete the form with an invalid CRN
 //    Then I should see the page with errors
 
+//  Scenario: Navigating back
+//    Given I am on the form page
+//    When I click back
+//    Then I should see the course completion details page
+
+//  Scenario: Navigates back to search results
+//    Given I am on the page
+//    When I click back
+//    Then I should see the course completion details page
+//    And I click back again
+//    Then I should see the course completion search page with results
+
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
+import {
+  communityCampusPduFactory,
+  communityCampusPdusFactory,
+} from '../../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
 import offenderFullFactory from '../../../../server/testutils/factories/offenderFullFactory'
+import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
+import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
 import CourseCompletionPage from '../../../pages/courseCompletions/courseCompletionPage'
 import CrnPage from '../../../pages/courseCompletions/process/crnPage'
 import PersonPage from '../../../pages/courseCompletions/process/personPage'
+import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
 import Page from '../../../pages/page'
 
 context('Crn Page', () => {
@@ -98,5 +112,43 @@ context('Crn Page', () => {
 
     // Then I should see the course completion details page
     Page.verifyOnPage(CourseCompletionPage, courseCompletion)
+  })
+
+  // Scenario: Navigates back to search results
+  it('navigates back to search results', () => {
+    const pdu = communityCampusPduFactory.build()
+    const provider = providerSummaryFactory.build()
+    cy.task('stubFindCourseCompletion', { courseCompletion })
+    // Given I am on the page
+    const page = CrnPage.visit(courseCompletion, undefined, { pdu: pdu.id, provider: provider.code })
+
+    // When I click back
+    page.clickBack()
+
+    // Then I should see the course completion details page
+    Page.verifyOnPage(CourseCompletionPage, courseCompletion)
+
+    // And I click back again
+    cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
+    cy.task('stubGetProviders', {
+      providers: { providers: providerSummaryFactory.buildList(2) },
+    })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
+
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: provider.code,
+        pduId: pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
+    page.clickBack()
+
+    // Then I should see the course completion search page with search results
+    const searchPage = Page.verifyOnPage(SearchCourseCompletionsPage, courseCompletion)
+    searchPage.shouldShowSearchResults(courseCompletion)
   })
 })

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -6,9 +6,16 @@
 //    When I click process
 //    Then I should see the first page of the form
 
+import {
+  communityCampusPduFactory,
+  communityCampusPdusFactory,
+} from '../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../server/testutils/factories/courseCompletionFactory'
+import pagedModelCourseCompletionEventFactory from '../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
+import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import CourseCompletionPage from '../../pages/courseCompletions/courseCompletionPage'
 import CrnPage from '../../pages/courseCompletions/process/crnPage'
+import SearchCourseCompletionsPage from '../../pages/courseCompletions/searchCourseCompletionsPage'
 import Page from '../../pages/page'
 
 context('Project page', () => {
@@ -32,5 +39,56 @@ context('Project page', () => {
 
     // Then I should see the first page of the form
     Page.verifyOnPage(CrnPage)
+  })
+
+  // Scenario: Navigating back
+  it('navigates back', () => {
+    const courseCompletion = courseCompletionFactory.build()
+    cy.task('stubFindCourseCompletion', { courseCompletion })
+    //  Given I am on the page
+    const page = CourseCompletionPage.visit(courseCompletion)
+
+    //  When I click back
+    cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
+    cy.task('stubGetProviders', {
+      providers: { providers: providerSummaryFactory.buildList(2) },
+    })
+    page.clickBack()
+
+    // Then I should see the course completion search page
+    Page.verifyOnPage(SearchCourseCompletionsPage, courseCompletion)
+  })
+
+  // Scenario: Navigating back with search params
+  it('navigates back to search results', () => {
+    const pdu = communityCampusPduFactory.build()
+    const provider = providerSummaryFactory.build()
+    const courseCompletion = courseCompletionFactory.build()
+    cy.task('stubFindCourseCompletion', { courseCompletion })
+    //  Given I am on the page
+    const page = CourseCompletionPage.visit(courseCompletion, { pdu: pdu.id, provider: provider.code })
+
+    //  When I click back
+    cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
+    cy.task('stubGetProviders', {
+      providers: { providers: providerSummaryFactory.buildList(2) },
+    })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
+
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: provider.code,
+        pduId: pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
+    page.clickBack()
+
+    // Then I should see the course completion search page
+    const searchPage = Page.verifyOnPage(SearchCourseCompletionsPage, courseCompletion)
+    searchPage.shouldShowSearchResults(courseCompletion)
   })
 })

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -7,6 +7,7 @@ import paths from '../../paths'
 import ReferenceDataService from '../../services/referenceDataService'
 import getProvidersAndPdus from '../shared/getProvidersAndPdus'
 import ProviderService from '../../services/providerService'
+import { pathWithQuery } from '../../utils/utils'
 
 const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime'] as const
 
@@ -35,14 +36,19 @@ export default class CourseCompletionsController {
   }
 
   show(): RequestHandler {
-    return async (_req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
       const courseCompletion = await this.courseCompletionService.getCourseCompletion({
         username: res.locals.user.username,
-        id: _req.params.id,
+        id: req.params.id,
       })
 
       res.render('courseCompletions/show', {
         courseCompletion,
+        backLink: this.indexLink(req.query as CourseCompletionPageInput),
+        processLink: pathWithQuery(
+          paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }),
+          req.query as CourseCompletionPageInput,
+        ),
       })
     }
   }
@@ -113,5 +119,13 @@ export default class CourseCompletionsController {
         searchForm: providersAndPdus,
       })
     }
+  }
+
+  private indexLink(query: CourseCompletionPageInput) {
+    if (Object.keys(query).length === 0) {
+      return paths.courseCompletions.index({})
+    }
+
+    return pathWithQuery(paths.courseCompletions.search({}), query)
   }
 }

--- a/server/controllers/courseCompletions/process/baseController.ts
+++ b/server/controllers/courseCompletions/process/baseController.ts
@@ -4,6 +4,7 @@ import CourseCompletionService from '../../../services/courseCompletionService'
 import CourseCompletionFormService, { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import { EteCourseCompletionEventDto } from '../../../@types/shared'
 import { ValidationErrors } from '../../../@types/user-defined'
+import { CourseCompletionPageInput } from '../../../pages/courseCompletionIndexPage'
 
 export type StepViewDataParams = {
   req: Request
@@ -31,7 +32,7 @@ export default abstract class BaseController<TPage extends BaseCourseCompletionF
       const { formId, formData } = await this.getForm(req, res)
 
       const viewData = {
-        ...this.page.viewData(courseCompletion, formId),
+        ...this.page.viewData(courseCompletion, formId, req.query as CourseCompletionPageInput),
         ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors: {} })),
       }
       return res.render(this.page.templatePath, viewData)
@@ -52,7 +53,7 @@ export default abstract class BaseController<TPage extends BaseCourseCompletionF
         })
 
         const viewData = {
-          ...this.page.viewData(courseCompletion, formId),
+          ...this.page.viewData(courseCompletion, formId, req.query as CourseCompletionPageInput),
           ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors })),
           errorSummary,
           errors,

--- a/server/controllers/courseCompletions/process/baseController.ts
+++ b/server/controllers/courseCompletions/process/baseController.ts
@@ -32,11 +32,18 @@ export default abstract class BaseController<TPage extends BaseCourseCompletionF
       const { formId, formData } = await this.getForm(req, res)
 
       const viewData = {
-        ...this.page.viewData(courseCompletion, formId, req.query as CourseCompletionPageInput),
+        ...this.page.viewData(courseCompletion, formId, this.getOriginalSearch(req, formData)),
         ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors: {} })),
       }
       return res.render(this.page.templatePath, viewData)
     }
+  }
+
+  private getOriginalSearch(req: Request, formData: CourseCompletionForm): CourseCompletionPageInput | undefined {
+    if (req.query.provider) {
+      return req.query as CourseCompletionPageInput
+    }
+    return formData.originalSearch
   }
 
   submit(): RequestHandler {
@@ -53,7 +60,7 @@ export default abstract class BaseController<TPage extends BaseCourseCompletionF
         })
 
         const viewData = {
-          ...this.page.viewData(courseCompletion, formId, req.query as CourseCompletionPageInput),
+          ...this.page.viewData(courseCompletion, formId, this.getOriginalSearch(req, formData)),
           ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors })),
           errorSummary,
           errors,

--- a/server/controllers/courseCompletions/process/confirmController.test.ts
+++ b/server/controllers/courseCompletions/process/confirmController.test.ts
@@ -19,6 +19,7 @@ import courseCompletionResolutionFactory from '../../../testutils/factories/cour
 import * as ErrorUtils from '../../../utils/errorUtils'
 import AppointmentService from '../../../services/appointmentService'
 import pagedModelAppointmentSummaryFactory from '../../../testutils/factories/pagedModelAppointmentSummaryFactory'
+import { pathWithQuery } from '../../../utils/utils'
 
 describe('ConfirmController', () => {
   const username = 'username'
@@ -34,7 +35,7 @@ describe('ConfirmController', () => {
   const appointmentService = createMock<AppointmentService>()
 
   const courseCompletion = courseCompletionFactory.build()
-  const form = courseCompletionFormFactory.build()
+  let form = courseCompletionFormFactory.build()
   const teamsResponse = { providers: providerTeamSummaryFactory.buildList(2) }
   const projectsResponse = pagedModelProjectOutcomeSummaryFactory.build()
   const offenderResponse = caseDetailsSummaryFactory.build()
@@ -122,12 +123,51 @@ describe('ConfirmController', () => {
   })
 
   describe('submit', () => {
-    it('saves course completion and redirects to the index page', async () => {
+    it('saves course completion and redirects to the search page', async () => {
       const resolution = courseCompletionResolutionFactory.build()
       const successMessage = 'Success'
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1', form: '2' } })
+      const query = { pdu: '2', form: '1' }
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
+
+      const requestHandler = confirmController.submit()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        pathWithQuery(paths.courseCompletions.search({}), form.originalSearch),
+      )
+      expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
+      expect(request.flash).toHaveBeenCalledWith('success', successMessage)
+    })
+
+    it('redirects to the index page if no original search', async () => {
+      const resolution = courseCompletionResolutionFactory.build()
+      form = courseCompletionFormFactory.build({ originalSearch: undefined })
+      formService.getForm.mockResolvedValue(form)
+      const successMessage = 'Success'
+      page.requestBody.mockReturnValue(resolution)
+      page.successMessage.mockReturnValue(successMessage)
+      const query = { pdu: '2', form: '1' }
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
+
+      const requestHandler = confirmController.submit()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(paths.courseCompletions.index({}))
+      expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
+      expect(request.flash).toHaveBeenCalledWith('success', successMessage)
+    })
+
+    it('redirects to the index page if no original search properties', async () => {
+      const resolution = courseCompletionResolutionFactory.build()
+      form = { originalSearch: {} }
+      formService.getForm.mockResolvedValue(form)
+      const successMessage = 'Success'
+      page.requestBody.mockReturnValue(resolution)
+      page.successMessage.mockReturnValue(successMessage)
+      const query = { pdu: '2', form: '1' }
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -9,10 +9,11 @@ import ProjectService from '../../../services/projectService'
 import OffenderService from '../../../services/offenderService'
 import { UnpaidWorkDetailsDto } from '../../../@types/shared'
 import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
-import paths from '../../../paths'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../../utils/errorUtils'
 import AppointmentService from '../../../services/appointmentService'
 import DateTimeFormats from '../../../utils/dateTimeUtils'
+import { pathWithQuery } from '../../../utils/utils'
+import paths from '../../../paths'
 
 export default class ConfirmController extends BaseController<ConfirmPage> {
   constructor(
@@ -48,11 +49,20 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
 
         req.flash('success', successMessage)
 
-        res.redirect(paths.courseCompletions.index({}))
+        res.redirect(this.buildNextPath(formData))
       } catch (error) {
         catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(courseCompletionId, formId))
       }
     }
+  }
+
+  private buildNextPath(formData: CourseCompletionForm) {
+    const { originalSearch } = formData
+
+    if (!originalSearch || Object.keys(originalSearch).length === 0) {
+      return paths.courseCompletions.index({})
+    }
+    return pathWithQuery(paths.courseCompletions.search({}), formData.originalSearch)
   }
 
   protected override async getStepViewData({ req, formData, formId, courseCompletion, res }: StepViewDataParams) {

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -51,7 +51,7 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
 
         res.redirect(this.buildNextPath(formData))
       } catch (error) {
-        catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(courseCompletionId, formId))
+        catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath({ courseCompletionId, formId }))
       }
     }
   }

--- a/server/controllers/courseCompletions/process/crnController.ts
+++ b/server/controllers/courseCompletions/process/crnController.ts
@@ -6,6 +6,7 @@ import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import CourseCompletionFormService, { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import OffenderService from '../../../services/offenderService'
+import { CourseCompletionPageInput } from '../../../pages/courseCompletionIndexPage'
 
 export default class CrnController extends BaseController<CrnPage> {
   constructor(
@@ -34,6 +35,7 @@ export default class CrnController extends BaseController<CrnPage> {
 
     if (!formId && isSubmit) {
       formId = randomUUID()
+      formData.originalSearch = req.query as CourseCompletionPageInput
     }
 
     return { formId, formData }

--- a/server/controllers/courseCompletions/process/projectController.test.ts
+++ b/server/controllers/courseCompletions/process/projectController.test.ts
@@ -54,7 +54,6 @@ describe('ProjectController', () => {
 
   describe('show', () => {
     it('should render the page', async () => {
-      const showPath = '/show'
       const formId = '12'
       const viewData = {
         backLink: '/back',
@@ -63,7 +62,6 @@ describe('ProjectController', () => {
         courseName: 'Customer service',
       }
       page.viewData.mockReturnValue(viewData)
-      page.updatePath.mockReturnValue(showPath)
 
       const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
 
@@ -74,7 +72,6 @@ describe('ProjectController', () => {
         ...viewData,
         teamItems,
         form: formId,
-        showPath,
         teamCode: undefined,
         projectItems: undefined,
       })
@@ -82,7 +79,6 @@ describe('ProjectController', () => {
     })
 
     it('returns selected team and projectItems if teamCode query not undefined', async () => {
-      const showPath = '/show'
       const formId = '12'
       const teamCode = '13'
       const viewData = {
@@ -92,7 +88,6 @@ describe('ProjectController', () => {
         courseName: 'Customer service',
       }
       page.viewData.mockReturnValue(viewData)
-      page.updatePath.mockReturnValue(showPath)
 
       const request = createMock<Request>({ params: { id: '1' }, query: { form: formId, team: teamCode } })
 
@@ -113,7 +108,6 @@ describe('ProjectController', () => {
         ...viewData,
         teamItems,
         form: formId,
-        showPath,
         teamCode,
         projectItems,
       })
@@ -122,7 +116,6 @@ describe('ProjectController', () => {
     })
 
     it('returns selected team and projectItems if teamCode on form not undefined', async () => {
-      const showPath = '/show'
       const formId = '12'
       const teamCode = '13'
       const formWithTeam = courseCompletionFormFactory.build({ team: teamCode })
@@ -135,7 +128,6 @@ describe('ProjectController', () => {
         courseName: 'Customer service',
       }
       page.viewData.mockReturnValue(viewData)
-      page.updatePath.mockReturnValue(showPath)
       const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
 
       const projects = pagedModelProjectOutcomeSummaryFactory.build()
@@ -155,7 +147,6 @@ describe('ProjectController', () => {
         ...viewData,
         teamItems,
         form: formId,
-        showPath,
         teamCode,
         projectItems,
       })
@@ -182,7 +173,6 @@ describe('ProjectController', () => {
 
     describe('has validation errors', () => {
       it('rerenders page', async () => {
-        const showPath = '/show'
         const formId = '12'
         const viewData = {
           backLink: '/back',
@@ -191,7 +181,6 @@ describe('ProjectController', () => {
           courseName: 'Customer service',
         }
         page.viewData.mockReturnValue(viewData)
-        page.updatePath.mockReturnValue(showPath)
 
         const errorSummary = [
           { text: 'Error 1', href: '#1', attributes: {} },
@@ -211,7 +200,6 @@ describe('ProjectController', () => {
           errors,
           errorSummary,
           form: formId,
-          showPath,
           teamCode: undefined,
           projectItems: undefined,
         })
@@ -219,7 +207,6 @@ describe('ProjectController', () => {
       })
 
       it('returns projectItems if teamCode body property not undefined', async () => {
-        const showPath = '/show'
         const formId = '12'
         const teamCode = '13'
         const viewData = {
@@ -229,7 +216,6 @@ describe('ProjectController', () => {
           courseName: 'Customer service',
         }
         page.viewData.mockReturnValue(viewData)
-        page.updatePath.mockReturnValue(showPath)
 
         const errorSummary = [
           { text: 'Error 1', href: '#1', attributes: {} },
@@ -257,7 +243,6 @@ describe('ProjectController', () => {
           ...viewData,
           teamItems,
           form: formId,
-          showPath,
           teamCode,
           errors,
           errorSummary,
@@ -274,7 +259,6 @@ describe('ProjectController', () => {
       })
 
       it('populates project code if project provided on body', async () => {
-        const showPath = '/show'
         const formId = '12'
         const teamCode = '13'
         const projectCode = '14'
@@ -285,7 +269,6 @@ describe('ProjectController', () => {
           courseName: 'Customer service',
         }
         page.viewData.mockReturnValue(viewData)
-        page.updatePath.mockReturnValue(showPath)
 
         const errorSummary = [
           { text: 'Error 1', href: '#1', attributes: {} },

--- a/server/controllers/courseCompletions/process/projectController.ts
+++ b/server/controllers/courseCompletions/process/projectController.ts
@@ -30,9 +30,8 @@ export default class ProjectController extends BaseController<ProjectPage> {
       response: res,
       teamCode,
     })
-    const showPath = this.page.updatePath(courseCompletion.id, undefined)
     const projectItems = await this.getProjects(res, providerCode, teamCode, projectCode)
-    return { teamItems, teamCode, projectItems, form: formId, showPath }
+    return { teamItems, teamCode, projectItems, form: formId }
   }
 
   private async getProjects(

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -4,6 +4,7 @@ import courseCompletionFactory from '../testutils/factories/courseCompletionFact
 import DateTimeFormats from '../utils/dateTimeUtils'
 import HtmlUtils from '../utils/htmlUtils'
 import sortHeader from '../utils/sortHeader'
+import { pathWithQuery } from '../utils/utils'
 import CourseCompletionIndexPage, { CourseCompletionPageInput } from './courseCompletionIndexPage'
 
 describe('CourseCompletionIndexPage', () => {
@@ -86,7 +87,7 @@ describe('CourseCompletionIndexPage', () => {
       const result = page.courseCompletionTableRows(courseCompletions)
       expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
         `Process ${mockHiddenText}`,
-        `/course-completions/${courseCompletions[0].id}`,
+        pathWithQuery(paths.courseCompletions.show({ id: courseCompletion.id }), query),
       )
 
       expect(result).toEqual([

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -7,110 +7,12 @@ import sortHeader from '../utils/sortHeader'
 import CourseCompletionIndexPage, { CourseCompletionPageInput } from './courseCompletionIndexPage'
 
 describe('CourseCompletionIndexPage', () => {
-  describe('items', () => {
-    it('returns date input items', () => {
-      const page = new CourseCompletionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
-      } as CourseCompletionPageInput)
-
-      expect(page.items()).toEqual({
-        endDateItems: [
-          {
-            classes: 'govuk-input--width-2',
-            name: 'day',
-            value: '13',
-          },
-          {
-            classes: 'govuk-input--width-2',
-            name: 'month',
-            value: '03',
-          },
-          {
-            classes: 'govuk-input--width-4',
-            name: 'year',
-            value: '2025',
-          },
-        ],
-        startDateItems: [
-          {
-            classes: 'govuk-input--width-2',
-            name: 'day',
-            value: '11',
-          },
-          {
-            classes: 'govuk-input--width-2',
-            name: 'month',
-            value: '03',
-          },
-          {
-            classes: 'govuk-input--width-4',
-            name: 'year',
-            value: '2025',
-          },
-        ],
-      })
-    })
-  })
-
-  describe('searchValues', () => {
-    it('returns search values in correct format', () => {
-      const page = new CourseCompletionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
-      } as CourseCompletionPageInput)
-
-      expect(page.searchValues()).toEqual({
-        dateFrom: '2025-03-11',
-        dateTo: '2025-03-13',
-      })
-    })
-  })
-
   describe('validationErrors', () => {
     it('returns an error if the provider is not selected', () => {
-      const page = new CourseCompletionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
-      } as CourseCompletionPageInput)
+      const page = new CourseCompletionIndexPage({} as CourseCompletionPageInput)
 
       expect(page.validationErrors()).toEqual({
         provider: { text: 'Select a region' },
-      })
-    })
-  })
-
-  describe('dateFields', () => {
-    it('returns only date related fields', () => {
-      const page = new CourseCompletionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
-        otherField: 'should be filtered out',
-      } as unknown as CourseCompletionPageInput)
-
-      expect(page.dateFields()).toEqual({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
       })
     })
   })
@@ -172,14 +74,11 @@ describe('CourseCompletionIndexPage', () => {
     })
 
     it('returns course completion results formatted into expected table rows', () => {
-      const page = new CourseCompletionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
-      } as CourseCompletionPageInput)
+      const query = {
+        pdu: '1',
+        provider: '2',
+      }
+      const page = new CourseCompletionIndexPage(query)
 
       const courseCompletion = courseCompletionFactory.build()
       const courseCompletions = [courseCompletion]

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -4,6 +4,7 @@ import paths from '../paths'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import HtmlUtils from '../utils/htmlUtils'
 import sortHeader from '../utils/sortHeader'
+import { pathWithQuery } from '../utils/utils'
 
 export type CourseCompletionPageInput = {
   provider?: string
@@ -68,7 +69,10 @@ export default class CourseCompletionIndexPage {
 
   courseCompletionTableRows(courseCompletions: Array<EteCourseCompletionEventDto>) {
     return courseCompletions.map(courseCompletion => {
-      const viewCourseCompletionPath = paths.courseCompletions.show({ id: courseCompletion.id.toString() })
+      const viewCourseCompletionPath = pathWithQuery(
+        paths.courseCompletions.show({ id: courseCompletion.id.toString() }),
+        this.query,
+      )
 
       const actionContent = `Process ${HtmlUtils.getHiddenText(`${courseCompletion.firstName} ${courseCompletion.lastName}`)}`
       const linkHtml = HtmlUtils.getAnchor(actionContent, viewCourseCompletionPath)

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -1,24 +1,13 @@
 import { EteCourseCompletionEventDto } from '../@types/shared'
 import { CourseCompletionSortField, SortDirection, TableCell, ValidationErrors } from '../@types/user-defined'
-import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
 import paths from '../paths'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import HtmlUtils from '../utils/htmlUtils'
 import sortHeader from '../utils/sortHeader'
 
-type DateFields = 'startDate' | 'endDate'
-type TimePeriods = 'day' | 'month' | 'year'
-type DateKeys = `${DateFields}-${TimePeriods}`
-
 export type CourseCompletionPageInput = {
-  provider: string
-} & {
-  [K in DateKeys]: string
-}
-
-interface SearchValues {
-  dateFrom: string
-  dateTo: string
+  provider?: string
+  pdu?: string
 }
 
 export default class CourseCompletionIndexPage {
@@ -36,26 +25,6 @@ export default class CourseCompletionIndexPage {
     }
 
     return errors
-  }
-
-  items() {
-    return {
-      startDateItems: GovukFrontendDateInput.getDateItems(this.query, 'startDate', false),
-      endDateItems: GovukFrontendDateInput.getDateItems(this.query, 'endDate', false),
-    }
-  }
-
-  searchValues(): SearchValues {
-    return {
-      dateFrom: `${this.query['startDate-year']}-${this.query['startDate-month']}-${this.query['startDate-day']}`,
-      dateTo: `${this.query['endDate-year']}-${this.query['endDate-month']}-${this.query['endDate-day']}`,
-    }
-  }
-
-  dateFields(): Partial<CourseCompletionPageInput> {
-    return Object.fromEntries(
-      Object.entries(this.query).filter(([key]) => key.includes('startDate-') || key.includes('endDate-')),
-    )
   }
 
   courseCompletionTableHeaders(

--- a/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
+++ b/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
@@ -2,6 +2,7 @@ import { EteCourseCompletionEventDto } from '../../../@types/shared'
 import paths from '../../../paths'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import { pathWithQuery } from '../../../utils/utils'
+import { CourseCompletionPageInput } from '../../courseCompletionIndexPage'
 import PageWithValidation from '../../pageWithValidation'
 import pathMap, { CourseCompletionPage } from './pathMap'
 
@@ -36,11 +37,15 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
     return this.exitPath(courseCompletionId)
   }
 
-  viewData(courseCompletion: EteCourseCompletionEventDto, formId?: string): CourseCompletionFormPageViewData {
+  viewData(
+    courseCompletion: EteCourseCompletionEventDto,
+    formId?: string,
+    originalSearch?: CourseCompletionPageInput,
+  ): CourseCompletionFormPageViewData {
     return {
       communityCampusPerson: this.buildPerson(courseCompletion),
       backLink: this.backPath(courseCompletion.id, formId),
-      updatePath: this.updatePath(courseCompletion.id, formId),
+      updatePath: this.updatePath({ courseCompletionId: courseCompletion.id, formId, originalSearch }),
       courseName: courseCompletion.courseName,
     }
   }
@@ -55,7 +60,14 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
     return this.exitPath(courseCompletionId)
   }
 
-  updatePath(courseCompletionId: string, formId?: string): string {
+  updatePath({
+    courseCompletionId,
+    formId,
+  }: {
+    courseCompletionId: string
+    formId?: string
+    originalSearch?: CourseCompletionPageInput
+  }): string {
     return this.pathWithFormId(paths.courseCompletions.process({ id: courseCompletionId, page: this.page }), formId)
   }
 

--- a/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
+++ b/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
@@ -44,13 +44,20 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
   ): CourseCompletionFormPageViewData {
     return {
       communityCampusPerson: this.buildPerson(courseCompletion),
-      backLink: this.backPath(courseCompletion.id, formId),
+      backLink: this.backPath({ courseCompletionId: courseCompletion.id, formId, originalSearch }),
       updatePath: this.updatePath({ courseCompletionId: courseCompletion.id, formId, originalSearch }),
       courseName: courseCompletion.courseName,
     }
   }
 
-  protected backPath(courseCompletionId: string, formId?: string): string {
+  protected backPath({
+    courseCompletionId,
+    formId,
+  }: {
+    courseCompletionId: string
+    formId?: string
+    originalSearch?: CourseCompletionPageInput
+  }): string {
     const backPage = pathMap[this.page].back
 
     if (backPage) {
@@ -78,7 +85,7 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
     }
   }
 
-  private exitPath(courseCompletionId: string): string {
+  protected exitPath(courseCompletionId: string): string {
     return paths.courseCompletions.show({ id: courseCompletionId })
   }
 

--- a/server/pages/courseCompletions/process/crnPage.test.ts
+++ b/server/pages/courseCompletions/process/crnPage.test.ts
@@ -209,4 +209,27 @@ describe('CrnPage', () => {
       expect(result).toBe(expectedPath)
     })
   })
+
+  describe('backPath', () => {
+    it.each([undefined, {}])(
+      'returns path when originalSearch is an empty object',
+      (originalSearch?: CourseCompletionPageInput) => {
+        const courseCompletion = courseCompletionFactory.build()
+        const result = page.viewData(courseCompletion, '2', originalSearch).backLink
+
+        expect(result).toBe(paths.courseCompletions.show({ id: courseCompletion.id }))
+      },
+    )
+
+    it('returns path with query parameters when originalSearch has properties', () => {
+      const courseCompletion = courseCompletionFactory.build()
+
+      const originalSearch = { provider: 'london', pdu: 'team-a' }
+      const expectedPath = pathWithQuery(paths.courseCompletions.show({ id: courseCompletion.id }), originalSearch)
+
+      const result = page.viewData(courseCompletion, '2', originalSearch).backLink
+
+      expect(result).toBe(expectedPath)
+    })
+  })
 })

--- a/server/pages/courseCompletions/process/crnPage.test.ts
+++ b/server/pages/courseCompletions/process/crnPage.test.ts
@@ -5,6 +5,7 @@ import pathMap from './pathMap'
 import * as ErrorUtils from '../../../utils/errorUtils'
 import { pathWithQuery } from '../../../utils/utils'
 import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
+import { CourseCompletionPageInput } from '../../courseCompletionIndexPage'
 
 describe('CrnPage', () => {
   const pageName = 'crn'
@@ -169,6 +170,43 @@ describe('CrnPage', () => {
           },
         },
       })
+    })
+  })
+  describe('updatePath', () => {
+    const courseCompletionId = '1'
+    const formId = '23'
+
+    it.each([undefined, {}])(
+      'returns path with formId when originalSearch is undefined or empty',
+      (originalSearch?: CourseCompletionPageInput) => {
+        const expectedPath = pathWithQuery(paths.courseCompletions.process({ id: courseCompletionId, page: 'crn' }), {
+          form: formId,
+        })
+        const result = page.updatePath({ courseCompletionId, formId, originalSearch })
+
+        expect(result).toBe(expectedPath)
+      },
+    )
+
+    it.each([undefined, {}])(
+      'returns path when originalSearch is an empty object',
+      (originalSearch?: CourseCompletionPageInput) => {
+        const result = page.updatePath({ courseCompletionId, originalSearch })
+
+        expect(result).toBe(paths.courseCompletions.process({ id: courseCompletionId, page: 'crn' }))
+      },
+    )
+
+    it('returns path with query parameters when originalSearch has properties', () => {
+      const originalSearch = { provider: 'london', pdu: 'team-a' }
+      const expectedPath = pathWithQuery(paths.courseCompletions.process({ id: courseCompletionId, page: 'crn' }), {
+        ...originalSearch,
+        form: formId,
+      })
+
+      const result = page.updatePath({ courseCompletionId, formId, originalSearch })
+
+      expect(result).toBe(expectedPath)
     })
   })
 })

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -78,6 +78,20 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
     })
   }
 
+  protected override backPath({
+    courseCompletionId,
+    originalSearch,
+  }: {
+    courseCompletionId: string
+    formId?: string
+    originalSearch?: CourseCompletionPageInput
+  }): string {
+    if (!originalSearch || Object.keys(originalSearch).length === 0) {
+      return this.exitPath(courseCompletionId)
+    }
+    return pathWithQuery(this.exitPath(courseCompletionId), originalSearch)
+  }
+
   private hintText(courseCompletion: EteCourseCompletionEventDto): string {
     const { name } = this.buildPerson(courseCompletion)
     return `Enter ${name}'s CRN to link the Community Campus account with nDelius.`

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -1,6 +1,9 @@
 import { EteCourseCompletionEventDto } from '../../../@types/shared'
 import { ValidationErrors } from '../../../@types/user-defined'
+import paths from '../../../paths'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import { pathWithQuery } from '../../../utils/utils'
+import { CourseCompletionPageInput } from '../../courseCompletionIndexPage'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
 import { ErrorSummaryItem, generateErrorSummary } from '../../../utils/errorUtils'
@@ -54,6 +57,25 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
       crn: body?.crn ?? form?.crn,
       hintText: this.hintText(courseCompletion),
     }
+  }
+
+  override updatePath({
+    courseCompletionId,
+    formId,
+    originalSearch,
+  }: {
+    courseCompletionId: string
+    formId?: string
+    originalSearch?: CourseCompletionPageInput
+  }): string {
+    if (!originalSearch || Object.keys(originalSearch).length === 0) {
+      return this.pathWithFormId(paths.courseCompletions.process({ id: courseCompletionId, page: this.page }), formId)
+    }
+
+    return pathWithQuery(paths.courseCompletions.process({ id: courseCompletionId, page: this.page }), {
+      ...originalSearch,
+      form: formId,
+    })
   }
 
   private hintText(courseCompletion: EteCourseCompletionEventDto): string {

--- a/server/services/forms/courseCompletionFormService.ts
+++ b/server/services/forms/courseCompletionFormService.ts
@@ -1,11 +1,13 @@
 import { CourseCompletionResolutionDto } from '../../@types/shared'
 import { YesOrNo } from '../../@types/user-defined'
 import FormClient from '../../data/formClient'
+import { CourseCompletionPageInput } from '../../pages/courseCompletionIndexPage'
 import BaseFormService from './baseFormService'
 
 export const COURSE_COMPLETION_PROCESS_FORM_TYPE = 'COURSE_COMPLETION_RESOLUTION'
 
 export type CourseCompletionForm = {
+  originalSearch?: CourseCompletionPageInput
   type?: CourseCompletionResolutionDto['type']
   crn?: string
   deliusEventNumber?: number

--- a/server/testutils/factories/courseCompletionFormFactory.ts
+++ b/server/testutils/factories/courseCompletionFormFactory.ts
@@ -17,4 +17,8 @@ export default Factory.define<CourseCompletionForm>(() => ({
   notes: faker.string.alpha(50),
   alertActive: faker.datatype.boolean(),
   isSensitive: faker.helpers.arrayElement(['yes', 'no']),
+  originalSearch: {
+    provider: faker.string.alpha(8),
+    pdu: faker.string.alpha(8),
+  },
 }))

--- a/server/views/courseCompletions/process/project.njk
+++ b/server/views/courseCompletions/process/project.njk
@@ -12,7 +12,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-       <form action="{{ showPath }}" method="get" class="govuk-!-margin-bottom-5">
+       <form action="{{ updatePath }}" method="get" class="govuk-!-margin-bottom-5">
         <input type="hidden" name="form" value="{{ form }}">
         <div class="search-and-filter__row">
           {{ govukSelect({

--- a/server/views/courseCompletions/show.njk
+++ b/server/views/courseCompletions/show.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: "/course-completions"
+    href: backLink
   }) }}
 {% endblock %}
 
@@ -23,7 +23,7 @@
 
     {{ govukButton({
       text: "Process",
-      href: paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' })
+      href: processLink
     }) }}
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">


### PR DESCRIPTION
## Context

This adds persistence for the original search performed to process course completions, ensuring the user doesn't need to perform their search again each time they process a course

[CPB-850](https://dsdmoj.atlassian.net/browse/CPB-850)

## Changes in this PR

- Pass search params to the course completion details page and the first page of the form
- Persist search params on temporary form object once this has been created for a form
- Populate back links and submit redirect link with search params from path or form object

### Screenshots of UI changes

<img width="1221" height="2284" alt="Screenshot 2026-04-24 at 11 43 26" src="https://github.com/user-attachments/assets/2d212984-fdbf-456f-a8a9-7049c3ca6155" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-850]: https://dsdmoj.atlassian.net/browse/CPB-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ