### PR TITLE
CPB-829: Persist original search in travel time form

### DIFF
--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -2,6 +2,7 @@ import { AppointmentDto, ProjectDto } from '../../../server/@types/shared'
 import Offender from '../../../server/models/offender'
 import paths from '../../../server/paths'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import { pathWithQuery } from '../../../server/utils/utils'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 import SummaryListComponent from '../components/summaryListComponent'
 import Page from '../page'
@@ -16,12 +17,17 @@ export default class UpdateTravelTimePage extends Page {
     super(offender.name)
   }
 
-  static visit(appointment: AppointmentDto, taskId: string = '1'): UpdateTravelTimePage {
-    const path = paths.appointments.travelTime.update({
+  static visit(
+    appointment: AppointmentDto,
+    taskId: string = '1',
+    originalSearch?: { provider: string },
+  ): UpdateTravelTimePage {
+    const basePath = paths.appointments.travelTime.update({
       projectCode: appointment.projectCode,
       appointmentId: appointment.id.toString(),
       taskId,
     })
+    const path = originalSearch ? pathWithQuery(basePath, originalSearch) : basePath
 
     cy.visit(path)
 

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -256,4 +256,24 @@ context('Update travel time page', () => {
     const searchPage = Page.verifyOnPage(SearchAttendedPage)
     searchPage.shouldShowNotEligibleRecordedSuccessBanner(appointment)
   })
+
+  // Scenario: Saving not eligible for travel time and returning to search
+  it('completes the task and returns to the search results', () => {
+    const taskId = '12'
+    // Given I am on the adjust travel time page for an appointment
+    const page = UpdateTravelTimePage.visit(appointment, taskId, { provider: provider.code })
+
+    cy.task('stubCompleteAppointmentTask', { taskId })
+    const nextAppointmentTasks = appointmentTaskSummaryFactory.buildList(11)
+    const nextAppointmentResponse = pagedModelAppointmentTaskSummaryFactory.build({
+      content: nextAppointmentTasks,
+    })
+    cy.task('stubGetAppointmentTasks', { providerCode: provider.code, page: 2, appointments: nextAppointmentResponse })
+    // When I click not eligible for travel time
+    page.clickNotEligible()
+
+    // Then I see the travel time dashboard with a success message
+    const searchPage = Page.verifyOnPage(SearchAttendedPage)
+    searchPage.shouldShowNotEligibleRecordedSuccessBanner(appointment)
+  })
 })

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -175,6 +175,34 @@ context('Update travel time page', () => {
     searchPage.shouldShowSuccessBanner(appointment)
   })
 
+  // Scenario: Updating travel time and returning to search
+  it('submits travel time and returns to dashboard with search results', () => {
+    // Given I am on the adjust travel time page for an appointment
+    const page = UpdateTravelTimePage.visit(appointment, '1', { provider: provider.code })
+    page.shouldShowAppointmentDetails(contactOutcome.name, project)
+
+    //  When I complete the form
+    page.timeInput.enterTime()
+
+    // And I submit
+
+    cy.task('stubSaveAdjustment', { appointment })
+    cy.task('stubGetAdjustmentReasons')
+    const nextAppointmentTasks = appointmentTaskSummaryFactory.buildList(11)
+    const nextAppointmentResponse = pagedModelAppointmentTaskSummaryFactory.build({
+      content: nextAppointmentTasks,
+    })
+
+    cy.task('stubGetAppointmentTasks', { providerCode: provider.code, page: 2, appointments: nextAppointmentResponse })
+
+    page.clickSubmit()
+
+    // Then I see the travel time dashboard with a success message
+    const searchPage = Page.verifyOnPage(SearchAttendedPage)
+    searchPage.shouldShowSuccessBanner(appointment)
+    searchPage.shouldShowAttendedAppointments()
+  })
+
   // Scenario: Validating input
   it('shows validation errors', () => {
     // Given I am on the adjust travel time page for an appointment

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -3,7 +3,6 @@ import type { NextFunction, Request, Response } from 'express'
 import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
 import AdjustTravelTimeController from './adjustTravelTimeController'
-import paths from '../../paths'
 import AppointmentService from '../../services/appointmentService'
 import Offender from '../../models/offender'
 import ProviderService from '../../services/providerService'
@@ -300,25 +299,29 @@ describe('AdjustTravelTimeController', () => {
 
   describe('completeTask', () => {
     it('submits request and redirects with success message', async () => {
+      const redirectPath = '/next'
       const appointmentId = '1'
       const projectCode = '2'
       const taskId = '123'
       const params = { appointmentId, projectCode, taskId }
+      const query = { provider: '1' }
 
       const appointment = appointmentFactory.build()
       appointmentService.getAppointment.mockResolvedValue(appointment)
 
       const successMessage = 'success'
       page.successMessage.mockReturnValue(successMessage)
+      page.exitPath.mockReturnValue(redirectPath)
 
-      const request = createMock<Request>({ params })
+      const request = createMock<Request>({ params, query })
 
       const requestHandler = controller.completeTask()
       await requestHandler(request, response, next)
 
       expect(appointmentService.completeAppointmentTask).toHaveBeenLastCalledWith(username, taskId)
       expect(request.flash).toHaveBeenCalledWith('success', successMessage)
-      expect(response.redirect).toHaveBeenCalledWith(paths.appointments.travelTime.index({}))
+      expect(response.redirect).toHaveBeenCalledWith(redirectPath)
+      expect(page.exitPath).toHaveBeenCalledWith(query)
     })
   })
 })

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -215,6 +215,7 @@ describe('AdjustTravelTimeController', () => {
 
     describe('no errors', () => {
       it('submits and redirects to the next page', async () => {
+        const redirectPath = '/next'
         const appointment = appointmentFactory.build()
         appointmentService.getAppointment.mockResolvedValue(appointment)
 
@@ -223,7 +224,9 @@ describe('AdjustTravelTimeController', () => {
         page.requestBody.mockReturnValue(requestBody)
 
         const body = { hours: '1', minutes: '2' }
-        const request = createMock<Request>({ params, body })
+        const query = { provider: '1' }
+        page.exitPath.mockReturnValue(redirectPath)
+        const request = createMock<Request>({ params, body, query })
 
         const requestHandler = controller.submitUpdate()
         await requestHandler(request, response, next)
@@ -238,7 +241,8 @@ describe('AdjustTravelTimeController', () => {
           },
           requestBody,
         )
-        expect(response.redirect).toHaveBeenCalledWith(paths.appointments.travelTime.index({}))
+        expect(response.redirect).toHaveBeenCalledWith(redirectPath)
+        expect(page.exitPath).toHaveBeenCalledWith(query)
       })
 
       it('calls catchApiValidationErrorOrPropagate when saveResolution throws a SanitisedError', async () => {

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -194,7 +194,7 @@ export default class AdjustTravelTimeController {
 
       req.flash('success', successMessage)
 
-      res.redirect(paths.appointments.travelTime.index({}))
+      res.redirect(this.page.exitPath(req.query as SearchTravelTimePageInput))
     }
   }
 

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -4,7 +4,7 @@ import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
 import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
-import SearchTravelTimePage from '../../pages/appointments/searchTravelTimePage'
+import SearchTravelTimePage, { SearchTravelTimePageInput } from '../../pages/appointments/searchTravelTimePage'
 import OffenderService from '../../services/offenderService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 import ReferenceDataService from '../../services/referenceDataService'
@@ -155,7 +155,7 @@ export default class AdjustTravelTimeController {
         form,
         backLink: '/',
         tableHeaders,
-        rows: SearchTravelTimePage.getRows(tasks),
+        rows: SearchTravelTimePage.getRows(tasks, _req.query as SearchTravelTimePageInput),
         pageNumber: tasks.page.number,
         totalPages: tasks.page.totalPages,
         totalElements: tasks.page.totalElements,

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -48,7 +48,13 @@ export default class AdjustTravelTimeController {
       const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
       const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
-      const viewData = this.page.viewData({ appointment, taskId, contactOutcomes, project })
+      const viewData = this.page.viewData({
+        appointment,
+        taskId,
+        contactOutcomes,
+        project,
+        originalSearch: req.query as SearchTravelTimePageInput,
+      })
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('appointments/update/travelTime/update', { ...viewData, errorList })
@@ -81,7 +87,13 @@ export default class AdjustTravelTimeController {
         const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
         const viewData = {
-          ...this.page.viewData({ appointment, taskId, contactOutcomes, project }),
+          ...this.page.viewData({
+            appointment,
+            taskId,
+            contactOutcomes,
+            project,
+            originalSearch: req.query as SearchTravelTimePageInput,
+          }),
           errorSummary,
           errors,
           time,
@@ -108,7 +120,7 @@ export default class AdjustTravelTimeController {
 
         return res.redirect(paths.appointments.travelTime.index({}))
       } catch (error) {
-        return catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(appointment, taskId))
+        return catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(appointment, taskId, req.query))
       }
     }
   }

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -118,7 +118,7 @@ export default class AdjustTravelTimeController {
 
         req.flash('success', successMessage)
 
-        return res.redirect(paths.appointments.travelTime.index({}))
+        return res.redirect(this.page.exitPath(req.query as SearchTravelTimePageInput))
       } catch (error) {
         return catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(appointment, taskId, req.query))
       }

--- a/server/pages/appointments/searchTravelTimePage.test.ts
+++ b/server/pages/appointments/searchTravelTimePage.test.ts
@@ -4,6 +4,7 @@ import paths from '../../paths'
 import appointmentTaskSummaryFactory from '../../testutils/factories/appointmentTaskSummaryFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import HtmlUtils from '../../utils/htmlUtils'
+import { pathWithQuery } from '../../utils/utils'
 import SearchTravelTimePage from './searchTravelTimePage'
 
 jest.mock('../../models/offender')
@@ -48,7 +49,8 @@ describe('SearchTravelTimePage', () => {
       const date = '1 Apr 2026'
       dateSpy.mockReturnValue(date)
 
-      const row = SearchTravelTimePage.getRows(tasks as PagedModelAppointmentTaskSummaryDto)[0]
+      const searchParams = { provider: 'provider' }
+      const row = SearchTravelTimePage.getRows(tasks as PagedModelAppointmentTaskSummaryDto, searchParams)[0]
 
       expect(row[0].text).toEqual(new Offender(appointment.offender).name)
       expect(row[1].text).toEqual(appointment.offender.crn)
@@ -58,18 +60,21 @@ describe('SearchTravelTimePage', () => {
 
       expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
         'Update',
-        paths.appointments.travelTime.update({
-          projectCode: appointment.projectCode,
-          appointmentId: appointment.id.toString(),
-          taskId: task.taskId,
-        }),
+        pathWithQuery(
+          paths.appointments.travelTime.update({
+            projectCode: appointment.projectCode,
+            appointmentId: appointment.id.toString(),
+            taskId: task.taskId,
+          }),
+          searchParams,
+        ),
       )
     })
 
     it('returns empty array with no data', () => {
       const tasks = {}
 
-      expect(SearchTravelTimePage.getRows(tasks)).toEqual([])
+      expect(SearchTravelTimePage.getRows(tasks, { provider: '' })).toEqual([])
     })
   })
 })

--- a/server/pages/appointments/searchTravelTimePage.ts
+++ b/server/pages/appointments/searchTravelTimePage.ts
@@ -6,6 +6,7 @@ import DateTimeFormats from '../../utils/dateTimeUtils'
 import HtmlUtils from '../../utils/htmlUtils'
 import PageWithValidation from '../pageWithValidation'
 import sortHeader from '../../utils/sortHeader'
+import { pathWithQuery } from '../../utils/utils'
 
 export type SearchTravelTimePageInput = {
   provider: string
@@ -38,7 +39,7 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
     ]
   }
 
-  static getRows(tasks: PagedModelAppointmentTaskSummaryDto) {
+  static getRows(tasks: PagedModelAppointmentTaskSummaryDto, originalSearch: SearchTravelTimePageInput) {
     if (!tasks?.content?.length) {
       return []
     }
@@ -47,11 +48,14 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
       const { appointment } = row
       const link = HtmlUtils.getAnchor(
         'Update',
-        paths.appointments.travelTime.update({
-          appointmentId: appointment.id.toString(),
-          projectCode: appointment.projectCode,
-          taskId: row.taskId,
-        }),
+        pathWithQuery(
+          paths.appointments.travelTime.update({
+            appointmentId: appointment.id.toString(),
+            projectCode: appointment.projectCode,
+            taskId: row.taskId,
+          }),
+          originalSearch,
+        ),
       )
 
       return [

--- a/server/pages/appointments/searchTravelTimePage.ts
+++ b/server/pages/appointments/searchTravelTimePage.ts
@@ -9,7 +9,7 @@ import sortHeader from '../../utils/sortHeader'
 import { pathWithQuery } from '../../utils/utils'
 
 export type SearchTravelTimePageInput = {
-  provider: string
+  provider?: string
 }
 
 export default class SearchTravelTimePage extends PageWithValidation<SearchTravelTimePageInput> {

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -158,6 +158,32 @@ describe('UpdateTravelTimePage', () => {
 
       expect(result.backLink).toBe(pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch))
     })
+
+    it('returns completeTask path with params if any params', () => {
+      const appointment = appointmentFactory.build()
+      const originalSearch = { provider: 'provider' }
+
+      const project = projectFactory.build()
+
+      const result = page.viewData({
+        appointment,
+        taskId: '1',
+        contactOutcomes: contactOutcomeFactory.buildList(2),
+        project,
+        originalSearch,
+      })
+
+      expect(result.completeTaskPath).toBe(
+        pathWithQuery(
+          paths.appointments.travelTime.complete({
+            taskId: '1',
+            projectCode: appointment.projectCode,
+            appointmentId: appointment.id.toString(),
+          }),
+          originalSearch,
+        ),
+      )
+    })
   })
 
   describe('requestBody', () => {

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -5,6 +5,7 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import projectFactory from '../../testutils/factories/projectFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import { pathWithQuery } from '../../utils/utils'
 import UpdateTravelTimePage from './updateTravelTimePage'
 
 jest.mock('../../models/offender')
@@ -85,6 +86,7 @@ describe('UpdateTravelTimePage', () => {
         taskId,
         contactOutcomes,
         project,
+        originalSearch: {},
       })
 
       expect(result).toEqual({
@@ -134,9 +136,27 @@ describe('UpdateTravelTimePage', () => {
         taskId: '1',
         contactOutcomes,
         project,
+        originalSearch: {},
       })
 
       expect(result.appointment.contactOutcome).toBe(contactOutcomeName)
+    })
+
+    it('returns search back link if any search params', () => {
+      const appointment = appointmentFactory.build()
+      const originalSearch = { provider: 'provider' }
+
+      const project = projectFactory.build()
+
+      const result = page.viewData({
+        appointment,
+        taskId: '1',
+        contactOutcomes: contactOutcomeFactory.buildList(2),
+        project,
+        originalSearch,
+      })
+
+      expect(result.backLink).toBe(pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch))
     })
   })
 
@@ -158,7 +178,7 @@ describe('UpdateTravelTimePage', () => {
       const taskId = '1'
       const appointment = appointmentFactory.build()
 
-      const result = page.updatePath(appointment, taskId)
+      const result = page.updatePath(appointment, taskId, {})
 
       expect(result).toEqual(
         paths.appointments.travelTime.update({
@@ -166,6 +186,25 @@ describe('UpdateTravelTimePage', () => {
           appointmentId: appointment.id.toString(),
           taskId,
         }),
+      )
+    })
+
+    it('returns path with original search params', () => {
+      const taskId = '1'
+      const appointment = appointmentFactory.build()
+      const originalSearch = { provider: 'provider' }
+
+      const result = page.updatePath(appointment, taskId, originalSearch)
+
+      expect(result).toEqual(
+        pathWithQuery(
+          paths.appointments.travelTime.update({
+            projectCode: appointment.projectCode,
+            appointmentId: appointment.id.toString(),
+            taskId,
+          }),
+          originalSearch,
+        ),
       )
     })
   })

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -49,7 +49,10 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
       offender: new Offender(appointment.offender),
       backLink: this.exitPath(originalSearch),
       updatePath: this.updatePath(appointment, taskId, originalSearch),
-      completeTaskPath: paths.appointments.travelTime.complete(this.pathParams(appointment, taskId)),
+      completeTaskPath: pathWithQuery(
+        paths.appointments.travelTime.complete(this.pathParams(appointment, taskId)),
+        originalSearch,
+      ),
       appointment: {
         date: DateTimeFormats.isoDateToUIDate(appointment.date),
         startTime: DateTimeFormats.stripTime(appointment.startTime),

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -64,7 +64,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
   }
 
   private buildBackPath(originalSearch: SearchTravelTimePageInput): string {
-    if (Object.keys(originalSearch).length === 0) {
+    if (!originalSearch.provider) {
       return paths.appointments.travelTime.index({})
     }
     return pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch)

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -4,7 +4,9 @@ import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../forms/hou
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import { pathWithQuery } from '../../utils/utils'
 import PageWithValidation from '../pageWithValidation'
+import { SearchTravelTimePageInput } from './searchTravelTimePage'
 
 interface AppointmentDetails {
   date: string
@@ -35,16 +37,18 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     taskId,
     contactOutcomes,
     project,
+    originalSearch,
   }: {
     appointment: AppointmentDto
     taskId: string
     contactOutcomes: Array<ContactOutcomeDto>
     project: ProjectDto
+    originalSearch: SearchTravelTimePageInput
   }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
-      backLink: paths.appointments.travelTime.index({}),
-      updatePath: this.updatePath(appointment, taskId),
+      backLink: this.buildBackPath(originalSearch),
+      updatePath: this.updatePath(appointment, taskId, originalSearch),
       completeTaskPath: paths.appointments.travelTime.complete(this.pathParams(appointment, taskId)),
       appointment: {
         date: DateTimeFormats.isoDateToUIDate(appointment.date),
@@ -59,6 +63,13 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     }
   }
 
+  private buildBackPath(originalSearch: SearchTravelTimePageInput): string {
+    if (Object.keys(originalSearch).length === 0) {
+      return paths.appointments.travelTime.index({})
+    }
+    return pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch)
+  }
+
   requestBody(body: ObjectWithHoursAndMinutes, taskId: string): Pick<CreateAdjustmentDto, 'taskId' | 'minutes'> {
     return {
       taskId,
@@ -66,8 +77,8 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     }
   }
 
-  updatePath(appointment: AppointmentDto, taskId: string): string {
-    return paths.appointments.travelTime.update(this.pathParams(appointment, taskId))
+  updatePath(appointment: AppointmentDto, taskId: string, originalSearch: SearchTravelTimePageInput): string {
+    return pathWithQuery(paths.appointments.travelTime.update(this.pathParams(appointment, taskId)), originalSearch)
   }
 
   private pathParams(

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -47,7 +47,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
   }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
-      backLink: this.buildBackPath(originalSearch),
+      backLink: this.exitPath(originalSearch),
       updatePath: this.updatePath(appointment, taskId, originalSearch),
       completeTaskPath: paths.appointments.travelTime.complete(this.pathParams(appointment, taskId)),
       appointment: {
@@ -63,7 +63,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     }
   }
 
-  private buildBackPath(originalSearch: SearchTravelTimePageInput): string {
+  exitPath(originalSearch: SearchTravelTimePageInput): string {
     if (!originalSearch.provider) {
       return paths.appointments.travelTime.index({})
     }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -51,9 +51,14 @@ describe('path with query', () => {
     expect(result).toEqual('/path?foo=bar')
   })
 
-  it('returns a valid path without query string delimiter when query is an empty object', () => {
-    const result = pathWithQuery('/path', {})
+  it('returns a valid path without query string delimiter when no query params', () => {
+    const result = pathWithQuery('/path?', {})
     expect(result).toEqual('/path')
+  })
+
+  it.each([{}, undefined])('returns only path if no params', (params?: Record<string, string>) => {
+    const path = '/test'
+    expect(pathWithQuery(path, params)).toBe(path)
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -33,7 +33,7 @@ export const createQueryString = (
 
 export const pathWithQuery = (
   path: string,
-  params: Record<string, string>,
+  params?: Record<string, string>,
   options: IStringifyOptions = { encode: false, indices: false },
 ) => {
   const [basePath, pathParams = ''] = path.split('?')


### PR DESCRIPTION
## Context
When a user navigates from travel time search results into the update form, the original search query is preserved through update/complete actions and redirects back to the results.

## Changes in this PR

- Allow pathWithQuery to be called with no/empty params without producing an empty ? query string.
- Pass the original search query to the update, complete and back paths for the travel time update page.
- Redirect to the travel time filter path if any original search object

### Screenshots of UI changes

Search results persisted on submitting a travel time adjustment:
<img width="1221" height="2009" alt="" src="https://github.com/user-attachments/assets/c639b822-1ebc-48d7-9d88-d5efa149b7ab" />

Search persisted on recording an appointment as not eligible for travel time (no results)
<img width="1517" height="962" alt="" src="https://github.com/user-attachments/assets/4f9e92e7-b6d4-4e57-832f-43c23d52e6f4" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
