### PR TITLE
Fix e2e tests for group sessions with pagination

### DIFF
--- a/e2e-tests/pages/groupSessionPage.ts
+++ b/e2e-tests/pages/groupSessionPage.ts
@@ -43,16 +43,8 @@ export default class GroupSessionPage extends BasePage {
   }
 
   async clickOnProject(projectName: string) {
-    // If there's pagination, it's probably safe to assume the project
-    // we're trying to find is on the second page, so we need to click
-    // 'Next'.
-    const nextButton = this.page.getByRole('link', { name: 'Next' })
-
-    if ((await nextButton.count()) > 0) {
-      await nextButton.click()
-    }
-
-    await this.page.getByRole('link', { name: projectName }).first().click()
+    const row = await this.results.getRowByContent(projectName)
+    await row.getByRole('link', { name: projectName }).click()
   }
 
   async completeSearchForm(fromDate: Date, toDate: Date) {


### PR DESCRIPTION
Where we have paginated results on the group session search page, we need to put a bit more effort into finding the right page for the project, before we click on it.  The initial implementation was a bit naive, but `getRowByContent` in the DataTableComponent is much better.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
