### PR TITLE
Use generic success message on course completion submission

### DIFF
--- a/server/controllers/courseCompletions/process/unableToCreditTimeController.test.ts
+++ b/server/controllers/courseCompletions/process/unableToCreditTimeController.test.ts
@@ -103,8 +103,11 @@ describe('UnableToCreditTimeController', () => {
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
       const request: DeepMocked<Request> = createMock<Request>({
-        params: { id: '1', form: '2' },
-        query: originalSearch,
+        params: { id: '1' },
+        query: {
+          form: '2',
+          ...originalSearch,
+        },
       })
 
       const requestHandler = unableToCreditTimeController.submit()
@@ -125,7 +128,7 @@ describe('UnableToCreditTimeController', () => {
 
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1', form: '2' }, query: {} })
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: { form: '2' } })
 
       const requestHandler = unableToCreditTimeController.submit()
       await requestHandler(request, response, next)
@@ -133,6 +136,28 @@ describe('UnableToCreditTimeController', () => {
       expect(response.redirect).toHaveBeenCalledWith(paths.courseCompletions.index({}))
       expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
       expect(request.flash).toHaveBeenCalledWith('success', successMessage)
+    })
+
+    it('redirects to the search page with generic success message when no CRN is present', async () => {
+      const formWithoutCrn = courseCompletionFormFactory.build({ crn: undefined })
+      formService.getForm.mockResolvedValue(formWithoutCrn)
+
+      const resolution = courseCompletionResolutionFactory.build()
+
+      page.requestBody.mockReturnValue(resolution)
+      const request: DeepMocked<Request> = createMock<Request>({
+        params: { id: '1' },
+        query: {
+          form: '2',
+        },
+      })
+
+      const requestHandler = unableToCreditTimeController.submit()
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(paths.courseCompletions.index({}))
+      expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
+      expect(request.flash).toHaveBeenCalledWith('success', 'The course completion has been processed.')
     })
 
     it('renders the show page with errors when validation fails', async () => {

--- a/server/controllers/courseCompletions/process/unableToCreditTimeController.ts
+++ b/server/controllers/courseCompletions/process/unableToCreditTimeController.ts
@@ -9,6 +9,7 @@ import UnableToCreditTimePage from '../../../pages/courseCompletions/process/una
 import OffenderService from '../../../services/offenderService'
 import { pathWithQuery } from '../../../utils/utils'
 import { CourseCompletionPageInput } from '../../../pages/courseCompletionIndexPage'
+import { OffenderDto, OffenderFullDto } from '../../../@types/shared'
 
 export default class UnableToCreditTimeController extends BaseController<UnableToCreditTimePage> {
   constructor(
@@ -65,6 +66,8 @@ export default class UnableToCreditTimeController extends BaseController<UnableT
 
   override submit(): RequestHandler {
     return async (req: Request, res: Response) => {
+      let offender: OffenderDto | OffenderFullDto
+
       const courseCompletionId = req.params.id.toString()
       const { formData, formId } = await this.getForm(req, res, true)
       const { hasErrors, errorSummary, errors } = this.page.validationErrors(req.body)
@@ -84,10 +87,14 @@ export default class UnableToCreditTimeController extends BaseController<UnableT
         return res.render(this.page.templatePath, viewData)
       }
 
-      const { offender } = await this.offenderService.getOffenderSummary({
-        username: res.locals.user.username,
-        crn: formData.crn,
-      })
+      if (formData.crn) {
+        const caseDetailsSummary = await this.offenderService.getOffenderSummary({
+          username: res.locals.user.username,
+          crn: formData.crn,
+        })
+
+        offender = caseDetailsSummary.offender
+      }
 
       const updatedFormData = this.page.getFormData(formData, req.body)
       const payload = this.page.requestBody(updatedFormData)
@@ -97,7 +104,7 @@ export default class UnableToCreditTimeController extends BaseController<UnableT
           { id: courseCompletionId, username: res.locals.user.username },
           payload,
         )
-        const successMessage = this.page.successMessage(offender)
+        const successMessage = this.getSuccessMessage(offender)
 
         req.flash('success', successMessage)
 
@@ -117,5 +124,13 @@ export default class UnableToCreditTimeController extends BaseController<UnableT
       provider: query.provider,
       pdu: query.pdu,
     })
+  }
+
+  private getSuccessMessage(offender?: OffenderDto | OffenderFullDto): string {
+    if (offender) {
+      return this.page.successMessage(offender)
+    }
+
+    return `The course completion has been processed.`
   }
 }


### PR DESCRIPTION
## Context
When a CRN has not been matched, the unable to credit time submission will cause an error as we attempt to fetch offender details for displaying the success message.

Instead, use a generic message when CRN is not present.

Note: The accompanying update to the e2e tests that caught this were mistakenly added in a [previous change](https://github.com/ministryofjustice/hmpps-community-payback-ui/commit/bc18b2849f39f80e893a07bd4c96e69ab04118a8#diff-759a7c5e3ebc73d99c2aea84d0bd9cbc6168ca243c54f37d88c3bd1d63f492f5R39) which caused the e2e tests to fail on CI. These changes should fix that.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1305" height="570" alt="image" src="https://github.com/user-attachments/assets/34390896-d70d-4276-9c5e-016d6256f9fa" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
