### PR TITLE
CPB-847: Persist group or project search

### DIFF
--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -6,7 +6,7 @@ import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import Page from '../page'
 import Offender from '../../../server/models/offender'
 import LocationUtils from '../../../server/utils/locationUtils'
-import { yesNoDisplayValue } from '../../../server/utils/utils'
+import { pathWithQuery, yesNoDisplayValue } from '../../../server/utils/utils'
 
 export default class CheckAppointmentDetailsPage extends Page {
   private readonly projectDetails: SummaryListComponent
@@ -37,11 +37,15 @@ export default class CheckAppointmentDetailsPage extends Page {
     appointment: AppointmentDto,
     project: ProjectDto,
     provider: ProviderSummaryDto,
+    originalSearch?: Record<string, string>,
   ): CheckAppointmentDetailsPage {
-    const path = paths.appointments.appointmentDetails({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    const path = pathWithQuery(
+      paths.appointments.appointmentDetails({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+      originalSearch,
+    )
     cy.visit(path)
 
     return new CheckAppointmentDetailsPage(appointment, project, provider)

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -2,6 +2,7 @@ import Page from './page'
 import paths from '../../server/paths'
 import { ProviderSummaryDto, ProviderTeamSummaryDto, SessionSummaryDto } from '../../server/@types/shared'
 import SelectInput from './components/selectComponent'
+import DateTimeFormats from '../../server/utils/dateTimeUtils'
 
 export default class FindASessionPage extends Page {
   regionSelect = new SelectInput('provider')
@@ -68,7 +69,7 @@ export default class FindASessionPage extends Page {
   shouldShowSearchResults(result: SessionSummaryDto) {
     cy.get('td').eq(0).should('contain.text', result.projectName)
     cy.get('td').eq(0).should('contain.text', result.projectCode)
-    cy.get('td').eq(1).should('have.text', '7 September 2025')
+    cy.get('td').eq(1).should('have.text', DateTimeFormats.isoDateToUIDate(result.date))
     cy.get('td').eq(2).should('have.text', result.numberOfOffendersAllocated)
     cy.get('td').eq(3).should('have.text', result.numberOfOffendersWithOutcomes)
     cy.get('td').eq(4).should('have.text', result.numberOfOffendersWithEA)

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -12,15 +12,27 @@
 //    Given I am viewing a session details page with limited access offenders
 //    Then I see limited offender details and no option to update
 
-// Scenario: Returning to a session page if group placement
-//    Given I am on an appointment 'check appointment details' page
-//    When I click back
-//    Then I see the details of the session for that appointment
+//  Scenario: Navigating back => group session
+//    Scenario: Returning to a session page if group placement
+//      Given I am on an appointment 'check appointment details' page
+//      When I click back
+//      Then I see the details of the session for that appointment
+//    Scenario: Returning to session search from appointment details
+//      Given I am on an appointment 'check appointment details' page
+//      When I click back
+//      And I click back again
+//      Then I see the original search results
 
-// Scenario: Returning to a session page if individual placement
-//    Given I am on an appointment 'check appointment details' page
-//    When I click back
-//    Then I see the details of the project for that appointment
+//  Scenario: Navigating back => individual placement
+//    Scenario: Returning to a session page if individual placement
+//      Given I am on an appointment 'check appointment details' page
+//      When I click back
+//      Then I see the details of the project for that appointment
+//    Scenario: Returning to project search from appointment details
+//      Given I am on an appointment 'check appointment details' page
+//      When I click back
+//      And I click back again
+//      Then I see the original search results
 
 // Scenario: Supervisor for an appointment has no previously saved value
 //    Given I am on an appointment 'check appointment details' page
@@ -53,6 +65,11 @@ import projectFactory from '../../../server/testutils/factories/projectFactory'
 import { baseProjectAppointmentRequest } from '../../mockApis/projects'
 import locationFactory from '../../../server/testutils/factories/locationFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
+import providerTeamSummaryFactory from '../../../server/testutils/factories/providerTeamSummaryFactory'
+import FindASessionPage from '../../pages/findASessionPage'
+import FindIndividualPlacementPage from '../../pages/projects/findIndividualPlacementPage'
+import pagedModelProjectOutcomeSummaryFactory from '../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
+import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
 
 context('Session details', () => {
   beforeEach(() => {
@@ -140,53 +157,151 @@ context('Session details', () => {
     page.shouldNotHaveUpdateLinksForOffenders()
   })
 
-  // Scenario: Returning to a session page
-  it('enables navigation back to session page', function test() {
-    // Given I am on an appointment 'check your details' page
-    const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider)
+  describe('navigating back => group session', () => {
+    // Scenario: Returning to a session page
+    it('enables navigation back to session page', function test() {
+      // Given I am on an appointment 'check your details' page
+      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider)
 
-    // When I click back
-    cy.task('stubFindSession', { session: this.session })
-    page.clickBack()
+      // When I click back
+      cy.task('stubFindSession', { session: this.session })
+      page.clickBack()
 
-    // Then I see the details of the session for that appointment
-    Page.verifyOnPage(ViewSessionPage, this.session)
-  })
-
-  // Scenario: Returning to a project page if individual placement
-  it('enables navigation back to project page', function test() {
-    // Given I am on an appointment 'check your details' page
-    const project = projectFactory.build({
-      projectType: { group: 'INDIVIDUAL' },
-    })
-    const appointment = appointmentFactory.build({
-      // match the supervisor request
-      supervisingTeamCode: this.appointment.supervisingTeamCode,
-      providerCode: this.appointment.providerCode,
-      projectCode: project.projectCode,
+      // Then I see the details of the session for that appointment
+      Page.verifyOnPage(ViewSessionPage, this.session)
     })
 
-    cy.task('stubFindAppointment', { appointment })
-    cy.task('stubFindProject', { project })
+    // Scenario: Returning to session search from appointment details
+    it('enables navigation back to session page', function test() {
+      const provider = providerSummaryFactory.build()
+      const team = providerTeamSummaryFactory.build()
+      const originalSearch = {
+        provider: provider.code,
+        team: team.code,
+        'startDate-day': '18',
+        'startDate-month': '09',
+        'startDate-year': '2025',
+        'endDate-day': '20',
+        'endDate-month': '09',
+        'endDate-year': '2025',
+      }
+      // Given I am on an appointment 'check your details' page
+      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider, originalSearch)
 
-    const page = CheckAppointmentDetailsPage.visit(appointment, project, this.provider)
+      // When I click back
+      cy.task('stubFindSession', { session: this.session })
+      page.clickBack()
+      const sessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
 
-    // When I click back
-    const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+      // And I click back again
+      // And I search for sessions
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      const session = sessionSummaryFactory.build()
+      cy.task('stubGetSessions', {
+        request: {
+          providerCode: provider.code,
+          teamCode: team.code,
+          startDate: '2025-09-18',
+          endDate: '2025-09-20',
+          username: 'some-name',
+        },
+        sessions: {
+          content: [session],
+        },
+      })
 
-    const request = {
-      ...baseProjectAppointmentRequest(),
-      projectCodes: [project.projectCode],
-    }
-    cy.task('stubGetAppointments', { request, pagedAppointments })
-    page.clickBack()
+      sessionPage.clickBack()
 
-    // Then I see the details of the session for that appointment
-    Page.verifyOnPage(ProjectPage, project)
+      // Then I see the original search results
+      const searchPage = Page.verifyOnPage(FindASessionPage)
+      searchPage.shouldShowSearchResults(session)
+    })
   })
-  //    Given I am on an appointment 'check appointment details' page
-  //    When I click back
-  //    Then I see the details of the project for that appointment
+
+  describe('navigating back => individual placement', () => {
+    // Scenario: Returning to a project page if individual placement
+    it('enables navigation back to project page', function test() {
+      // Given I am on an appointment 'check your details' page
+      const project = projectFactory.build({
+        projectType: { group: 'INDIVIDUAL' },
+      })
+      const appointment = appointmentFactory.build({
+        // match the supervisor request
+        supervisingTeamCode: this.appointment.supervisingTeamCode,
+        providerCode: this.appointment.providerCode,
+        projectCode: project.projectCode,
+      })
+
+      cy.task('stubFindAppointment', { appointment })
+      cy.task('stubFindProject', { project })
+
+      const page = CheckAppointmentDetailsPage.visit(appointment, project, this.provider)
+
+      // When I click back
+      const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+
+      const request = {
+        ...baseProjectAppointmentRequest(),
+        projectCodes: [project.projectCode],
+      }
+      cy.task('stubGetAppointments', { request, pagedAppointments })
+      page.clickBack()
+
+      // Then I see the details of the project for that appointment
+      Page.verifyOnPage(ProjectPage, project)
+    })
+
+    // Scenario: Returning to project search from appointment details
+    it('enables navigation back to original project search', function test() {
+      // Given I am on an appointment 'check your details' page
+      const project = projectFactory.build({
+        projectType: { group: 'INDIVIDUAL' },
+      })
+      const appointment = appointmentFactory.build({
+        // match the supervisor request
+        supervisingTeamCode: this.appointment.supervisingTeamCode,
+        providerCode: this.appointment.providerCode,
+        projectCode: project.projectCode,
+      })
+
+      cy.task('stubFindAppointment', { appointment })
+      cy.task('stubFindProject', { project })
+
+      const page = CheckAppointmentDetailsPage.visit(appointment, project, this.provider, {
+        provider: this.appointment.providerCode,
+        team: this.appointment.supervisingTeamCode,
+      })
+
+      // When I click back
+      const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+
+      const request = {
+        ...baseProjectAppointmentRequest(),
+        projectCodes: [project.projectCode],
+      }
+      cy.task('stubGetAppointments', { request, pagedAppointments })
+      page.clickBack()
+
+      // And I click back again
+      cy.task('stubGetTeams', {
+        teams: { providers: [providerTeamSummaryFactory.build({ code: this.appointment.supervisingTeamCode })] },
+        providerCode: this.appointment.providerCode,
+      })
+      const projects = pagedModelProjectOutcomeSummaryFactory.build()
+      cy.task('stubGetProjects', {
+        teamCode: this.appointment.supervisingTeamCode,
+        providerCode: this.appointment.providerCode,
+        projects,
+      })
+      const projectPage = Page.verifyOnPage(ProjectPage, project)
+      projectPage.clickBack()
+
+      // Then I see the original search results
+      const searchPage = Page.verifyOnPage(FindIndividualPlacementPage, projects.content)
+      searchPage.shouldShowIndividualPlacementsSortedDescendingByMissingOutcomes()
+    })
+  })
 
   describe('Supervisor input', function describe() {
     // Scenario: Supervisor for an appointment has no previously saved value

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -40,11 +40,15 @@
 //    Given I am on the confirm page of an in progress update
 //    And I click confirm
 //    Then I can see the session page with success message
+//    And when can navigate back to my previous search
+//    Then I see the original search results
 //
 // Scenario: submitting appointment update for individual placement
 //    Given I am on the confirm page of an in progress update
 //    And I click confirm
 //    Then I can see the project page with success message
+//    And when I navigate back to my previous search
+//    Then I see the original search results
 //
 // Scenario: submitting appointment update that has been changed in Delius
 //    Given the appointment version and the version saved on the form do not match
@@ -60,9 +64,12 @@ import {
   contactOutcomesFactory,
 } from '../../../server/testutils/factories/contactOutcomeFactory'
 import pagedModelAppointmentSummaryFactory from '../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
+import pagedModelProjectOutcomeSummaryFactory from '../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
 import projectFactory from '../../../server/testutils/factories/projectFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
+import providerTeamSummaryFactory from '../../../server/testutils/factories/providerTeamSummaryFactory'
 import sessionFactory from '../../../server/testutils/factories/sessionFactory'
+import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
 import supervisorSummaryFactory from '../../../server/testutils/factories/supervisorSummaryFactory'
 import { baseProjectAppointmentRequest } from '../../mockApis/projects'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
@@ -70,7 +77,9 @@ import CheckAppointmentDetailsPage from '../../pages/appointments/checkAppointme
 import ConfirmDetailsPage from '../../pages/appointments/confirmDetailsPage'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
+import FindASessionPage from '../../pages/findASessionPage'
 import Page from '../../pages/page'
+import FindIndividualPlacementPage from '../../pages/projects/findIndividualPlacementPage'
 import ProjectPage from '../../pages/projects/projectPage'
 import ViewSessionPage from '../../pages/viewSessionPage'
 
@@ -394,7 +403,19 @@ context('Confirm appointment details page', () => {
   describe('submitting appointment update', function describe() {
     //  Scenario: submitting appointment update for a group placement
     it('Group placement appointment => submits update to application and shows success message on session page', function test() {
-      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
+      const provider = providerSummaryFactory.build()
+      const team = providerTeamSummaryFactory.build()
+      const originalSearch = {
+        'startDate-day': '18',
+        'startDate-month': '09',
+        'startDate-year': '2025',
+        'endDate-day': '20',
+        'endDate-month': '09',
+        'endDate-year': '2025',
+        provider: provider.code,
+        team: team.code,
+      }
+      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1', originalSearch })
       const appointment = appointmentFactory.build({ version: '1', alertActive: null })
       const project = projectFactory.build({
         projectCode: appointment.projectCode,
@@ -430,12 +451,43 @@ context('Confirm appointment details page', () => {
       // Then I can see the session page with success message
       const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
       viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+
+      // And when I navigate back to my previous search
+
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      const sessionSummary = sessionSummaryFactory.build()
+      cy.task('stubGetSessions', {
+        request: {
+          providerCode: provider.code,
+          teamCode: team.code,
+          startDate: '2025-09-18',
+          endDate: '2025-09-20',
+          username: 'some-name',
+        },
+        sessions: {
+          content: [sessionSummary],
+        },
+      })
+
+      viewSessionPage.clickBack()
+
+      // Then I see the original search results
+      const searchPage = Page.verifyOnPage(FindASessionPage)
+      searchPage.shouldShowSearchResults(sessionSummary)
     })
 
     // Scenario: submitting appointment update for an individual placement
     it('Individual placement appointment => submits update to application and shows success message on project page', function test() {
-      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
       const appointment = appointmentFactory.build({ version: '1', alertActive: null })
+
+      const provider = providerSummaryFactory.build({ code: appointment.providerCode })
+      const team = providerTeamSummaryFactory.build({ code: appointment.supervisingTeamCode })
+      const originalSearch = {
+        provider: provider.code,
+        team: team.code,
+      }
+      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1', originalSearch })
 
       // Given I am on the confirm page of an in progress update
       cy.task('stubFindAppointment', { appointment })
@@ -472,6 +524,22 @@ context('Confirm appointment details page', () => {
       // Then I can see the project page with success message
       const viewProjectPage = Page.verifyOnPage(ProjectPage, project)
       viewProjectPage.shouldShowSuccessMessage('Attendance recorded')
+
+      // And when I navigate back to my previous search
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      const projects = pagedModelProjectOutcomeSummaryFactory.build()
+      cy.task('stubGetProjects', {
+        teamCode: appointment.supervisingTeamCode,
+        providerCode: appointment.providerCode,
+        projects,
+      })
+
+      viewProjectPage.clickBack()
+
+      // Then I see the original search results
+      const searchPage = Page.verifyOnPage(FindIndividualPlacementPage, projects.content)
+      searchPage.shouldShowIndividualPlacementsSortedDescendingByMissingOutcomes()
     })
   })
 

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -32,6 +32,7 @@ export type AppointmentOutcomeForm = {
   attendanceData?: AttendanceDataDto
   enforcement?: EnforcementOutcomeForm
   sensitive?: boolean
+  originalSearch: Record<string, string>
 }
 
 export interface BaseRequest {

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -44,7 +44,11 @@ export default class AppointmentDetailsController {
         // A form might exist if user has navigated back to this page
         form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
       } else {
-        const { data, key } = await this.appointmentFormService.createForm(appointment, res.locals.user.username)
+        const { data, key } = await this.appointmentFormService.createForm(
+          appointment,
+          res.locals.user.username,
+          _req.query as Record<string, string>,
+        )
         form = data
         page.setFormId(key.id)
       }

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -54,7 +54,7 @@ export default class AppointmentDetailsController {
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData(appointment, supervisors, form, project, provider),
+        ...page.viewData(appointment, supervisors, form, project, provider, form.originalSearch),
       })
     }
   }
@@ -88,7 +88,7 @@ export default class AppointmentDetailsController {
 
       if (page.hasErrors) {
         return res.render('appointments/update/appointmentDetails', {
-          ...page.viewData(appointment, supervisors, form, project, provider),
+          ...page.viewData(appointment, supervisors, form, project, provider, form.originalSearch),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -45,7 +45,7 @@ export default class ConfirmController {
 
       if (this.appointmentHasChangedSinceLoaded(form, appointment)) {
         _req.flash('error', 'The arrival time has already been updated in the database, try again.')
-        return res.redirect(page.exitForm(appointment, project))
+        return res.redirect(page.exitForm(appointment, project, form.originalSearch))
       }
 
       const didAttend = form.contactOutcome.attended
@@ -67,7 +67,7 @@ export default class ConfirmController {
       await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
 
       _req.flash('success', 'Attendance recorded')
-      return res.redirect(page.exitForm(appointment, project))
+      return res.redirect(page.exitForm(appointment, project, form.originalSearch))
     }
   }
 

--- a/server/controllers/projectsController.test.ts
+++ b/server/controllers/projectsController.test.ts
@@ -7,6 +7,8 @@ import ProjectService from '../services/projectService'
 import AppointmentService from '../services/appointmentService'
 import ProjectIndexPage from '../pages/projectIndexPage'
 import pagedModelProjectOutcomeSummaryFactory from '../testutils/factories/pagedModelProjectOutcomeSummaryFactory'
+import { pathWithQuery } from '../utils/utils'
+import paths from '../paths'
 
 jest.mock('./shared/getProvidersAndTeams')
 
@@ -22,7 +24,6 @@ describe('ProjectsController', () => {
   const appointmentService = createMock<AppointmentService>()
 
   const providersAndTeams = {
-    provider: { value: 'X', text: 'Provider' },
     teamItems: [
       { text: 'Team 1', value: '1' },
       { text: 'Team 2', value: '2' },
@@ -172,6 +173,33 @@ describe('ProjectsController', () => {
       })
 
       expect(projectService.getIndividualPlacementProjects).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('show', () => {
+    it('renders the page with index back path if no search query in request', async () => {
+      jest.spyOn(ProjectIndexPage, 'objectContainsSearchProperty').mockReturnValue(false)
+
+      const backPath = paths.projects.index({})
+
+      const requestHandler = projectsController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('projects/show', expect.objectContaining({ backPath }))
+    })
+
+    it('renders the page with filter back path if any search query in request', async () => {
+      const search = { provider: 'provider ' }
+      jest.spyOn(ProjectIndexPage, 'objectContainsSearchProperty').mockReturnValue(true)
+
+      const backPath = pathWithQuery(paths.projects.filter({}), search)
+
+      const requestHandler = projectsController.show()
+      const requestWithQuery = createMock<Request>({ query: search })
+
+      await requestHandler(requestWithQuery, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('projects/show', expect.objectContaining({ backPath }))
     })
   })
 })

--- a/server/controllers/projectsController.ts
+++ b/server/controllers/projectsController.ts
@@ -87,7 +87,9 @@ export default class ProjectsController {
       const formattedProject = ProjectPage.projectDetails(project)
       const query = _req.query as ProjectIndexPageInput
       const appointmentList = ProjectPage.appointmentList(appointments.content, projectCode, query)
-      const backPath = pathWithQuery(paths.projects.filter({}), query as ProjectIndexPageInput)
+      const backPath = ProjectIndexPage.objectContainsSearchProperty(query)
+        ? pathWithQuery(paths.projects.filter({}), query)
+        : paths.projects.index({})
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('projects/show', {

--- a/server/controllers/projectsController.ts
+++ b/server/controllers/projectsController.ts
@@ -85,9 +85,9 @@ export default class ProjectsController {
       const appointments = await this.appointmentService.getProjectAppointmentsWithMissingOutcomes(request)
 
       const formattedProject = ProjectPage.projectDetails(project)
-
-      const appointmentList = ProjectPage.appointmentList(appointments.content, projectCode)
-      const backPath = pathWithQuery(paths.projects.filter({}), _req.query as ProjectIndexPageInput)
+      const query = _req.query as ProjectIndexPageInput
+      const appointmentList = ProjectPage.appointmentList(appointments.content, projectCode, query)
+      const backPath = pathWithQuery(paths.projects.filter({}), query as ProjectIndexPageInput)
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('projects/show', {

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -117,10 +117,10 @@ describe('SessionsController', () => {
         form: { ...providersAndTeams, startDateItems: [], endDateItems: [] },
         errors,
         errorSummary: [
-          {
+          expect.objectContaining({
             text: errors.someError.text,
             href: '#someError',
-          },
+          }),
         ],
         sessionRows: [],
       })

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -16,13 +16,15 @@ import getProvidersAndTeams, { ProvidersAndTeams } from './shared/getProvidersAn
 import sessionFactory from '../testutils/factories/sessionFactory'
 import pagedMetadataFactory from '../testutils/factories/pagedMetadataFactory'
 import { getPaginationRequestParams } from '../utils/paginationUtils'
+import paths from '../paths'
+import { pathWithQuery } from '../utils/utils'
 
 jest.mock('../pages/groupSessionIndexPage')
 jest.mock('./shared/getProvidersAndTeams')
 jest.mock('../utils/paginationUtils')
 
 describe('SessionsController', () => {
-  const request: DeepMocked<Request> = createMock<Request>({})
+  const request: DeepMocked<Request> = createMock<Request>({ query: {} })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   let sessionsController: SessionsController
@@ -75,7 +77,6 @@ describe('SessionsController', () => {
   describe('index', () => {
     it('should render the dashboard page', async () => {
       const response = createMock<Response>()
-      request.query = { provider: 'x' }
 
       const requestHandler = sessionsController.index()
       await requestHandler(request, response, next)
@@ -218,7 +219,7 @@ describe('SessionsController', () => {
       const errorList = [{ text: 'Some error' }]
       jest.spyOn(ErrorUtils, 'generateErrorTextList').mockReturnValue(errorList)
 
-      const backPath = `/sessions/search?provider=${providersAndTeams.provider.value.toLocaleLowerCase()}`
+      const backPath = paths.sessions.index({})
 
       const requestHandler = sessionsController.show()
       const response = createMock<Response>()
@@ -235,6 +236,21 @@ describe('SessionsController', () => {
         backPath,
         errorList,
       })
+    })
+
+    it('should pass search back link to view if provider param', async () => {
+      const search = { provider: 'provider ' }
+      jest.spyOn(GroupSessionIndexPage, 'objectContainsSearchProperty').mockReturnValue(true)
+
+      const backPath = pathWithQuery(paths.sessions.search({}), search)
+
+      const requestHandler = sessionsController.show()
+      const response = createMock<Response>()
+      const requestWithQuery = createMock<Request>({ query: search })
+
+      await requestHandler(requestWithQuery, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('sessions/show', expect.objectContaining({ backPath }))
     })
   })
 })

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -118,7 +118,10 @@ export default class SessionsController {
       const sessionList = SessionUtils.sessionListTableRows(session, query)
       const formattedDate = DateTimeFormats.isoDateToUIDate(date)
       const formattedLocation = LocationUtils.locationToString(session.location)
-      const backPath = pathWithQuery(paths.sessions.search({}), _req.query as GroupSessionIndexPageInput)
+
+      const backPath = GroupSessionIndexPage.objectContainsSearchProperty(query)
+        ? pathWithQuery(paths.sessions.search({}), query)
+        : paths.sessions.index({})
       const errorList = generateErrorTextList(res.locals.errorMessages)
 
       res.render('sessions/show', {

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -6,7 +6,7 @@ import GroupSessionIndexPage, { GroupSessionIndexPageInput } from '../pages/grou
 import DateTimeFormats from '../utils/dateTimeUtils'
 import LocationUtils from '../utils/locationUtils'
 import getProvidersAndTeams from './shared/getProvidersAndTeams'
-import { generateErrorTextList } from '../utils/errorUtils'
+import { generateErrorSummary, generateErrorTextList } from '../utils/errorUtils'
 import { pathWithQuery } from '../utils/utils'
 import paths from '../paths'
 import { SessionsSortField } from '../@types/user-defined'
@@ -51,10 +51,7 @@ export default class SessionsController {
       const validationErrors = indexPage.validationErrors()
 
       if (Object.keys(validationErrors).length !== 0) {
-        const errorSummary = Object.keys(validationErrors).map(k => ({
-          text: validationErrors[k as keyof GroupSessionIndexPageInput].text,
-          href: `#${k}`,
-        }))
+        const errorSummary = generateErrorSummary(validationErrors)
 
         return res.render('sessions/index', {
           errorSummary,

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -116,9 +116,9 @@ export default class SessionsController {
         projectCode,
         date,
       }
-
+      const query = _req.query as GroupSessionIndexPageInput
       const session = await this.sessionService.getSession(request)
-      const sessionList = SessionUtils.sessionListTableRows(session)
+      const sessionList = SessionUtils.sessionListTableRows(session, query)
       const formattedDate = DateTimeFormats.isoDateToUIDate(date)
       const formattedLocation = LocationUtils.locationToString(session.location)
       const backPath = pathWithQuery(paths.sessions.search({}), _req.query as GroupSessionIndexPageInput)

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -83,27 +83,31 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   protected backPath(): string {
-    return paths.appointments.appointmentDetails({
-      projectCode: this.appointment.projectCode,
-      appointmentId: this.appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.appointmentDetails({
+        projectCode: this.appointment.projectCode,
+        appointmentId: this.appointment.id.toString(),
+      }),
+    )
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {
     const contactOutcome = this.contactOutcomes.find(outcome => outcome.code === this.query.attendanceOutcome)
 
     if (!contactOutcome?.attended) {
-      return paths.appointments.confirm({ projectCode, appointmentId })
+      return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
     }
 
-    return paths.appointments.logHours({ projectCode, appointmentId })
+    return this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId }))
   }
 
   protected updatePath(): string {
-    return paths.appointments.attendanceOutcome({
-      projectCode: this.appointment.projectCode,
-      appointmentId: this.appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.attendanceOutcome({
+        projectCode: this.appointment.projectCode,
+        appointmentId: this.appointment.id.toString(),
+      }),
+    )
   }
 
   private items(form: AppointmentOutcomeForm, hasErrors: boolean): { text: string; value: string }[] {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -48,8 +48,8 @@ export default abstract class BaseAppointmentUpdatePage {
   ): AppointmentUpdatePageViewData {
     return {
       offender: new Offender(appointment.offender),
-      backLink: this.pathWithFormId(this.backPath(appointment, originalSearch)),
-      updatePath: this.pathWithFormId(this.updatePath(appointment)),
+      backLink: this.backPath(appointment, originalSearch),
+      updatePath: this.updatePath(appointment),
       form: this.formId,
     }
   }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -14,7 +14,7 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract nextPath(projectCode: string, appointmentId: string | AppointmentDto): string
 
-  protected abstract backPath(appointment: AppointmentDto): string
+  protected abstract backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>): string
 
   protected abstract updatePath(appointment: AppointmentDto): string
 
@@ -26,11 +26,11 @@ export default abstract class BaseAppointmentUpdatePage {
     this.formId = query.form?.toString()
   }
 
-  exitForm(appointment: AppointmentDto, project: ProjectDto): string {
+  exitForm(appointment: AppointmentDto, project: ProjectDto, originalSearch: Record<string, string>): string {
     if (project.projectType.group === 'GROUP') {
-      return SessionUtils.getSessionPath(appointment)
+      return SessionUtils.getSessionPath(appointment, originalSearch)
     }
-    return paths.projects.show({ projectCode: appointment.projectCode })
+    return pathWithQuery(paths.projects.show({ projectCode: appointment.projectCode }), originalSearch)
   }
 
   next(projectCode: string, appointmentId: string) {
@@ -42,10 +42,13 @@ export default abstract class BaseAppointmentUpdatePage {
     return this.form
   }
 
-  protected commonViewData(appointment: AppointmentDto): AppointmentUpdatePageViewData {
+  protected commonViewData(
+    appointment: AppointmentDto,
+    originalSearch?: Record<string, string>,
+  ): AppointmentUpdatePageViewData {
     return {
       offender: new Offender(appointment.offender),
-      backLink: this.pathWithFormId(this.backPath(appointment)),
+      backLink: this.pathWithFormId(this.backPath(appointment, originalSearch)),
       updatePath: this.pathWithFormId(this.updatePath(appointment)),
       form: this.formId,
     }

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -106,7 +106,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
       const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, search)
       expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, search)
-      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.backLink).toBe(backLink)
     })
 
     it('should return an object containing a back link to the project page if appointment type is INDIVIDUAL', async () => {
@@ -114,9 +114,10 @@ describe('CheckAppointmentDetailsPage', () => {
       jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
       page = new CheckAppointmentDetailsPage({}, project)
-      const result = page.viewData(appointment, supervisors, form, project, providerDto, {})
+      const search = { provider: 'provider' }
+      const result = page.viewData(appointment, supervisors, form, project, providerDto, search)
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
-      expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, { form: page.formId })
+      expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, search)
       expect(result.backLink).toBe(pathWithQuery)
     })
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -48,7 +48,7 @@ describe('CheckAppointmentDetailsPage', () => {
       jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
       jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
 
-      const result = page.viewData(appointment, supervisors, form, projectDto, providerDto)
+      const result = page.viewData(appointment, supervisors, form, projectDto, providerDto, {})
 
       const project = {
         name: projectDto.projectName,
@@ -69,7 +69,7 @@ describe('CheckAppointmentDetailsPage', () => {
       jest.spyOn(DateTimeFormats, 'stripTime').mockReturnValue(time)
       jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
 
-      const result = page.viewData(appointmentDto, supervisors, form, projectFactory.build(), providerDto)
+      const result = page.viewData(appointmentDto, supervisors, form, projectFactory.build(), providerDto, {})
 
       const appointmentDetails = {
         pickUpPlace: location,
@@ -94,17 +94,18 @@ describe('CheckAppointmentDetailsPage', () => {
         return offender
       })
 
-      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto)
+      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, {})
 
       expect(result.offender).toBe(offender)
     })
 
     it('should return an object containing a back link to the session page', async () => {
       const backLink = '/session/1'
+      const search = { provider: 'provider' }
       jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
 
-      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto)
-      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment)
+      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, search)
+      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, search)
       expect(result.backLink).toBe(pathWithQuery)
     })
 
@@ -113,14 +114,14 @@ describe('CheckAppointmentDetailsPage', () => {
       jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
       page = new CheckAppointmentDetailsPage({}, project)
-      const result = page.viewData(appointment, supervisors, form, project, providerDto)
+      const result = page.viewData(appointment, supervisors, form, project, providerDto, {})
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
       expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, { form: page.formId })
       expect(result.backLink).toBe(pathWithQuery)
     })
 
     it('should return an object containing an update link for the form', async () => {
-      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto)
+      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, {})
       expect(paths.appointments.appointmentDetails).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
@@ -136,7 +137,7 @@ describe('CheckAppointmentDetailsPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto)
+      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, {})
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
         supervisors,
@@ -158,7 +159,7 @@ describe('CheckAppointmentDetailsPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto)
+      const result = page.viewData(appointment, supervisors, form, projectFactory.build(), providerDto, {})
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
         supervisors,
@@ -188,6 +189,7 @@ describe('CheckAppointmentDetailsPage', () => {
         appointmentOutcomeFormFactory.build(),
         projectFactory.build(),
         providerDto,
+        {},
       )
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -66,11 +66,12 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     form: AppointmentOutcomeForm,
     project: ProjectDto,
     provider: ProviderSummaryDto,
+    originalSearch: Record<string, string>,
   ): ViewData {
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData(appointment),
+      ...this.commonViewData(appointment, originalSearch),
       appointment: {
         providerCode: appointment.providerCode,
         notes: appointment.notes,
@@ -98,8 +99,8 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     }
   }
 
-  protected backPath(appointment: AppointmentDto): string {
-    return this.exitForm(appointment, this.project)
+  protected backPath(appointment: AppointmentDto, originalSearch: Record<string, string>): string {
+    return this.exitForm(appointment, this.project, originalSearch)
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -104,13 +104,15 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {
-    return paths.appointments.attendanceOutcome({ projectCode, appointmentId })
+    return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
   }
 
   protected updatePath(appointment: AppointmentDto): string {
-    return paths.appointments.appointmentDetails({
-      appointmentId: appointment.id.toString(),
-      projectCode: appointment.projectCode,
-    })
+    return this.pathWithFormId(
+      paths.appointments.appointmentDetails({
+        appointmentId: appointment.id.toString(),
+        projectCode: appointment.projectCode,
+      }),
+    )
   }
 }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -493,10 +493,11 @@ describe('ConfirmPage', () => {
       const projectCode = '2'
       const path = '/path'
       const page = new ConfirmPage({})
+      const search = { provider: 'provider' }
 
       jest.spyOn(paths.sessions, 'show').mockReturnValue(path)
       const appointment = appointmentFactory.build({ projectCode })
-      expect(page.exitForm(appointment, projectFactory.build())).toBe(path)
+      expect(page.exitForm(appointment, projectFactory.build(), search)).toBe(Utils.pathWithQuery(path, search))
       expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode, date: appointment.date })
     })
 
@@ -504,11 +505,12 @@ describe('ConfirmPage', () => {
       const projectCode = '2'
       const path = '/path'
       const page = new ConfirmPage({})
+      const search = { provider: 'provider' }
 
       jest.spyOn(paths.projects, 'show').mockReturnValue(path)
       const appointment = appointmentFactory.build({ projectCode })
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
-      expect(page.exitForm(appointment, project)).toBe(path)
+      expect(page.exitForm(appointment, project, search)).toBe(Utils.pathWithQuery(path, search))
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode })
     })
   })

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -59,16 +59,18 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     const { projectCode } = appointment
 
     if (this.form && this.form.contactOutcome?.attended) {
-      return paths.appointments.logCompliance({ projectCode, appointmentId })
+      return this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId }))
     }
-    return paths.appointments.attendanceOutcome({ projectCode, appointmentId })
+    return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
   }
 
   protected updatePath(appointment: AppointmentDto): string {
-    return paths.appointments.confirm({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.confirm({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+    )
   }
 
   private getStartAndEndTime(form: AppointmentOutcomeForm) {

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -91,21 +91,25 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   }
 
   protected backPath(appointment: AppointmentDto): string {
-    return paths.appointments.logHours({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.logHours({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+    )
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {
-    return paths.appointments.confirm({ projectCode, appointmentId })
+    return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
   }
 
   protected updatePath(appointment: AppointmentDto): string {
-    return paths.appointments.logCompliance({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.logCompliance({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+    )
   }
 
   private getItems(checkedValue?: string) {

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -170,24 +170,28 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
   }
 
   protected backPath(appointment: AppointmentDto): string {
-    return paths.appointments.attendanceOutcome({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.attendanceOutcome({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+    )
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {
     if (this.form.contactOutcome && this.form.contactOutcome.attended) {
-      return paths.appointments.logCompliance({ projectCode, appointmentId })
+      return this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId }))
     }
 
-    return paths.appointments.confirm({ projectCode, appointmentId })
+    return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
   }
 
   protected updatePath(appointment: AppointmentDto): string {
-    return paths.appointments.logHours({
-      projectCode: appointment.projectCode,
-      appointmentId: appointment.id.toString(),
-    })
+    return this.pathWithFormId(
+      paths.appointments.logHours({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      }),
+    )
   }
 }

--- a/server/pages/groupSessionIndexPage.test.ts
+++ b/server/pages/groupSessionIndexPage.test.ts
@@ -166,4 +166,50 @@ describe('GroupSessionIndexPage', () => {
       })
     })
   })
+
+  describe('objectContainsSearchProperty', () => {
+    describe('object contains property', () => {
+      it.each([
+        [{ team: 'TEAM1' }],
+        [{ provider: 'PROVIDER1' }],
+        [{ 'startDate-day': '01' }],
+        [{ 'startDate-month': '01' }],
+        [{ 'startDate-year': '2024' }],
+        [{ 'endDate-day': '31' }],
+        [{ 'endDate-month': '12' }],
+        [{ 'endDate-year': '2024' }],
+        [{ team: 'TEAM1', provider: 'PROVIDER1', 'startDate-day': '01' }],
+        [
+          {
+            team: 'TEAM1',
+            provider: 'PROVIDER1',
+            'startDate-day': '01',
+            'startDate-month': '01',
+            'startDate-year': '2024',
+            'endDate-day': '31',
+            'endDate-month': '12',
+            'endDate-year': '2024',
+          },
+        ],
+        [{ team: '' }],
+        [{ 'startDate-day': '31' }],
+      ])('should return true given %s', queryObject => {
+        const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('object does not contain property', () => {
+      it.each([
+        [{}],
+        [{ other: 'value' }],
+        [{ notASearchProperty: 'value', anotherOne: 'test' }],
+        [{ team: undefined }],
+        [{ provider: undefined, 'startDate-day': undefined }],
+      ])('should return false given %s', queryObject => {
+        const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
+        expect(result).toBe(false)
+      })
+    })
+  })
 })

--- a/server/pages/groupSessionIndexPage.ts
+++ b/server/pages/groupSessionIndexPage.ts
@@ -1,18 +1,23 @@
+import { ParsedQs } from 'qs'
 import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
 import { SessionsSortField, SortDirection, TableCell, ValidationErrors } from '../@types/user-defined'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import sortHeader from '../utils/sortHeader'
 
 type DateFields = 'startDate' | 'endDate'
-type TimePeriods = 'day' | 'month' | 'year'
-type DateKeys = `${DateFields}-${TimePeriods}`
 
-export type GroupSessionIndexPageInput = {
-  [K in DateKeys]: string
-} & {
-  team?: string
-  provider?: string
-}
+const groupSessionIndexPageInputProperties = [
+  'team',
+  'provider',
+  'startDate-day',
+  'startDate-month',
+  'startDate-year',
+  'endDate-day',
+  'endDate-month',
+  'endDate-year',
+]
+
+export type GroupSessionIndexPageInput = { [key in (typeof groupSessionIndexPageInputProperties)[number]]?: string }
 
 interface SearchValues {
   teamCode: string
@@ -78,6 +83,10 @@ export default class GroupSessionIndexPage {
       sortHeader<SessionsSortField>('Outcomes', 'outcomeCount', sortBy, sortDirection, hrefPrefix, 'search-results'),
       { text: 'Enforcements' },
     ]
+  }
+
+  static objectContainsSearchProperty(queryObject: ParsedQs): boolean {
+    return groupSessionIndexPageInputProperties.some(property => queryObject[property] !== undefined)
   }
 
   private checkDateIsAcceptable(date: InputDate) {

--- a/server/pages/projectIndexPage.test.ts
+++ b/server/pages/projectIndexPage.test.ts
@@ -102,4 +102,32 @@ describe('ProjectIndexPage', () => {
       expect(ErrorUtils.generateErrorSummary).toHaveBeenCalledWith({})
     })
   })
+
+  describe('objectContainsSearchProperty', () => {
+    describe('object contains property', () => {
+      it.each([
+        [{ team: 'TEAM1' }],
+        [{ provider: 'PROVIDER1' }],
+        [{ team: 'TEAM1', provider: 'PROVIDER1' }],
+        [{ team: '' }],
+        [{ provider: '0' }],
+      ])('should return true given %s', queryObject => {
+        const result = ProjectIndexPage.objectContainsSearchProperty(queryObject)
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('object does not contain property', () => {
+      it.each([
+        [{}],
+        [{ other: 'value' }],
+        [{ team: undefined }],
+        [{ provider: undefined }],
+        [{ team: undefined, provider: undefined }],
+      ])('should return false given %s', queryObject => {
+        const result = ProjectIndexPage.objectContainsSearchProperty(queryObject)
+        expect(result).toBe(false)
+      })
+    })
+  })
 })

--- a/server/pages/projectIndexPage.ts
+++ b/server/pages/projectIndexPage.ts
@@ -1,3 +1,4 @@
+import { ParsedQs } from 'qs'
 import { PagedModelProjectOutcomeSummaryDto } from '../@types/shared'
 import { ValidationErrors } from '../@types/user-defined'
 import paths from '../paths'
@@ -6,10 +7,9 @@ import HtmlUtils from '../utils/htmlUtils'
 import LocationUtils from '../utils/locationUtils'
 import { pathWithQuery } from '../utils/utils'
 
-export type ProjectIndexPageInput = {
-  team?: string
-  provider?: string
-}
+const pageInputProperties = ['team', 'provider']
+
+export type ProjectIndexPageInput = { [key in (typeof pageInputProperties)[number]]?: string }
 
 export default class ProjectIndexPage {
   static projectSummaryList(projectOutcomeSummaries: PagedModelProjectOutcomeSummaryDto, query: ProjectIndexPageInput) {
@@ -42,5 +42,9 @@ export default class ProjectIndexPage {
     const errorSummary = generateErrorSummary(errors)
 
     return { errors, hasErrors: Object.keys(errors).length > 0, errorSummary }
+  }
+
+  static objectContainsSearchProperty(queryObject: ParsedQs): boolean {
+    return pageInputProperties.some(property => queryObject[property] !== undefined)
   }
 }

--- a/server/pages/projectPage.test.ts
+++ b/server/pages/projectPage.test.ts
@@ -27,6 +27,7 @@ describe('ProjectPage', () => {
     })
 
     it('returns appointment list formatted into table rows', () => {
+      const search = { provider: 'provider' }
       const mockDates = ['12 January 2026', '13 January 2025']
       const mockTimes = ['09:00', '10:00', '12:00', '13:00']
       const mockDatesAsSeconds = [123, 345]
@@ -43,7 +44,7 @@ describe('ProjectPage', () => {
       jest.spyOn(SessionUtils, 'getAppointmentActionCell').mockReturnValue(mockLinkHtml)
       const appointments = appointmentSummaryFactory.buildList(2)
 
-      const result = ProjectPage.appointmentList(appointments, 'someCode')
+      const result = ProjectPage.appointmentList(appointments, 'someCode', search)
 
       expect(result).toEqual([
         [

--- a/server/pages/projectPage.ts
+++ b/server/pages/projectPage.ts
@@ -15,7 +15,11 @@ interface ProjectViewData {
 }
 
 export default class ProjectPage {
-  static appointmentList(appointments: Array<AppointmentSummaryDto>, projectCode: string) {
+  static appointmentList(
+    appointments: Array<AppointmentSummaryDto>,
+    projectCode: string,
+    originalSearch: Record<string, string>,
+  ) {
     return appointments.map(appointment => {
       const offender = new Offender(appointment.offender)
       return [
@@ -33,7 +37,7 @@ export default class ProjectPage {
           text: DateTimeFormats.stripTime(appointment.endTime),
         },
         { text: appointment.daysOverdue },
-        SessionUtils.getAppointmentActionCell(appointment.id, projectCode, offender),
+        SessionUtils.getAppointmentActionCell(appointment.id, projectCode, offender, originalSearch),
       ]
     })
   }

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -47,8 +47,9 @@ describe('AppointmentFormService', () => {
   describe('createForm', () => {
     it('should return form with new id and appointment data', async () => {
       const user = 'some-user'
+      const search = { provider: 'provider' }
       const appointment = appointmentFactory.build()
-      const result = await appointmentFormService.createForm(appointment, user)
+      const result = await appointmentFormService.createForm(appointment, user, search)
 
       const expectedForm = {
         deliusVersion: appointment.version,
@@ -62,6 +63,7 @@ describe('AppointmentFormService', () => {
           code: appointment.supervisorOfficerCode,
         },
         sensitive: appointment.sensitive,
+        originalSearch: search,
       }
 
       expect(formClient.save).toHaveBeenCalledWith(

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -16,7 +16,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
     super(formClient, APPOINTMENT_UPDATE_FORM_TYPE)
   }
 
-  async createForm(appointment: AppointmentDto, username: string): Promise<Form> {
+  async createForm(appointment: AppointmentDto, username: string, query: Record<string, string>): Promise<Form> {
     const form = {
       key: this.getFormKey(randomUUID()),
       data: {
@@ -31,6 +31,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
           code: appointment.supervisorOfficerCode,
         } as SupervisorSummaryDto,
         sensitive: appointment.sensitive,
+        originalSearch: query,
       },
     }
 

--- a/server/testutils/factories/appointmentOutcomeFormFactory.ts
+++ b/server/testutils/factories/appointmentOutcomeFormFactory.ts
@@ -1,4 +1,5 @@
 import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
 import attendanceDataFactory from './attendanceDataFactory'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import { contactOutcomeFactory } from './contactOutcomeFactory'
@@ -14,5 +15,9 @@ export default Factory.define<AppointmentOutcomeForm>(
       supervisor: supervisorSummaryFactory.build(),
       notes: null,
       sensitive: null,
+      originalSearch: {
+        provider: faker.string.alpha(8),
+        team: faker.string.alpha(8),
+      },
     }) satisfies AppointmentOutcomeForm,
 )

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -11,6 +11,7 @@ import sessionSummaryFactory from '../testutils/factories/sessionSummaryFactory'
 import DateTimeFormats from './dateTimeUtils'
 import HtmlUtils from './htmlUtils'
 import SessionUtils from './sessionUtils'
+import { pathWithQuery } from './utils'
 
 jest.mock('../models/offender')
 
@@ -67,6 +68,7 @@ describe('SessionUtils', () => {
 
   describe('sessionListTableRows', () => {
     const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+    const search = { provider: 'provider' }
 
     beforeEach(() => {
       offenderMock.mockImplementation(() => {
@@ -91,7 +93,7 @@ describe('SessionUtils', () => {
       const appointments = [appointmentSummaryFactory.build({ contactOutcome: null })]
       const session = sessionFactory.build({ appointmentSummaries: appointments })
 
-      const result = SessionUtils.sessionListTableRows(session)
+      const result = SessionUtils.sessionListTableRows(session, search)
       expect(result).toEqual([
         [
           { text: 'Sam Smith' },
@@ -114,7 +116,7 @@ describe('SessionUtils', () => {
 
       const session = sessionFactory.build({ appointmentSummaries: appointments })
 
-      const result = SessionUtils.sessionListTableRows(session)
+      const result = SessionUtils.sessionListTableRows(session, search)
 
       expect(DateTimeFormats.minutesToHoursAndMinutes).toHaveBeenNthCalledWith(1, 120)
       expect(DateTimeFormats.minutesToHoursAndMinutes).toHaveBeenNthCalledWith(2, 90)
@@ -137,7 +139,7 @@ describe('SessionUtils', () => {
 
       const session = sessionFactory.build({ appointmentSummaries: appointments })
 
-      const result = SessionUtils.sessionListTableRows(session)
+      const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
       expect(sessionRow[sessionRow.length - 2].html).toEqual(attendanceName)
       expect(HtmlUtils.getStatusTag).not.toHaveBeenCalled()
@@ -159,7 +161,7 @@ describe('SessionUtils', () => {
 
       const session = sessionFactory.build({ appointmentSummaries: appointments })
 
-      const result = SessionUtils.sessionListTableRows(session)
+      const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
       expect(HtmlUtils.getStatusTag).toHaveBeenCalled()
       expect(sessionRow[sessionRow.length - 2].html).toMatch(/grey.+Not entered/)
@@ -167,6 +169,7 @@ describe('SessionUtils', () => {
   })
 
   describe('getAppointmentActionCell', () => {
+    const search = { provider: 'provider' }
     it('returns empty text if offender is limited', () => {
       const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
 
@@ -183,7 +186,7 @@ describe('SessionUtils', () => {
       })
       const offender = new Offender(offenderDto)
 
-      const result = SessionUtils.getAppointmentActionCell(1, '1', offender)
+      const result = SessionUtils.getAppointmentActionCell(1, '1', offender, search)
       expect(result).toEqual({ text: '' })
     })
 
@@ -208,16 +211,19 @@ describe('SessionUtils', () => {
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
 
-      const result = SessionUtils.getAppointmentActionCell(appointmentId, projectCode, offender)
+      const result = SessionUtils.getAppointmentActionCell(appointmentId, projectCode, offender, search)
 
       expect(result).toEqual({ html: fakeLink })
       expect(HtmlUtils.getHiddenText).toHaveBeenCalledWith(offender.name)
       expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
         `Update ${mockHiddenText}`,
-        paths.appointments.appointmentDetails({
-          projectCode,
-          appointmentId: appointmentId.toString(),
-        }),
+        pathWithQuery(
+          paths.appointments.appointmentDetails({
+            projectCode,
+            appointmentId: appointmentId.toString(),
+          }),
+          search,
+        ),
       )
     })
   })
@@ -233,7 +239,7 @@ describe('SessionUtils', () => {
 
     it('returns expected path given a SessionSummaryDto', () => {
       const session = sessionSummaryFactory.build()
-      const path = SessionUtils.getSessionPath(session)
+      const path = SessionUtils.getSessionPath(session, {})
 
       expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: session.projectCode, date: session.date })
       expect(path).toBe(`/sessions/${session.projectCode}/${session.date}`)
@@ -241,10 +247,21 @@ describe('SessionUtils', () => {
 
     it('returns expected path given an AppointmentDto', () => {
       const appointment = appointmentFactory.build()
-      const path = SessionUtils.getSessionPath(appointment)
+      const path = SessionUtils.getSessionPath(appointment, {})
 
       expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode, date: appointment.date })
       expect(path).toBe(`/sessions/${appointment.projectCode}/${appointment.date}`)
+    })
+
+    it('returns path with original search params', () => {
+      const search = { provider: 'provider', team: 'team' }
+      const session = sessionSummaryFactory.build()
+      const path = SessionUtils.getSessionPath(session, search)
+
+      expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: session.projectCode, date: session.date })
+      expect(path).toBe(
+        pathWithQuery(paths.sessions.show({ projectCode: session.projectCode, date: session.date }), search),
+      )
     })
   })
 })

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -10,9 +10,8 @@ import { GroupSessionIndexPageInput } from '../pages/groupSessionIndexPage'
 export default class SessionUtils {
   static sessionResultTableRows(sessions: SessionSummariesDto, query: GroupSessionIndexPageInput) {
     return sessions.content.map(session => {
-      const showPath = SessionUtils.getSessionPath(session)
-      const showPathWithQuery = pathWithQuery(showPath, query)
-      const projectLink = HtmlUtils.getAnchor(session.projectName, showPathWithQuery)
+      const showPath = SessionUtils.getSessionPath(session, query)
+      const projectLink = HtmlUtils.getAnchor(session.projectName, showPath)
 
       return [
         {
@@ -26,7 +25,7 @@ export default class SessionUtils {
     })
   }
 
-  static sessionListTableRows(session: SessionDto) {
+  static sessionListTableRows(session: SessionDto, originalSearch: Record<string, string>) {
     return session.appointmentSummaries.map(appointment => {
       const offender = new Offender(appointment.offender)
       const minutesRemaining =
@@ -39,17 +38,22 @@ export default class SessionUtils {
         { text: DateTimeFormats.minutesToHoursAndMinutes(appointment.completedMinutes) },
         { text: DateTimeFormats.minutesToHoursAndMinutes(minutesRemaining) },
         { html: appointment.contactOutcome?.name || SessionUtils.getNotEnteredTag() },
-        SessionUtils.getAppointmentActionCell(appointment.id, session.projectCode, offender),
+        SessionUtils.getAppointmentActionCell(appointment.id, session.projectCode, offender, originalSearch),
       ]
     })
   }
 
-  static getSessionPath(session: SessionSummaryDto | AppointmentDto) {
+  static getSessionPath(session: SessionSummaryDto | AppointmentDto, query: Record<string, string>) {
     const { date, projectCode } = session
-    return `${paths.sessions.show({ projectCode, date })}`
+    return pathWithQuery(paths.sessions.show({ projectCode, date }), query)
   }
 
-  static getAppointmentActionCell(appointmentId: number, projectCode: string, offender: Offender): GovUKValue {
+  static getAppointmentActionCell(
+    appointmentId: number,
+    projectCode: string,
+    offender: Offender,
+    originalSearch: Record<string, string>,
+  ): GovUKValue {
     if (offender.isLimited) {
       return { text: '' }
     }
@@ -57,7 +61,10 @@ export default class SessionUtils {
     const actionContent = `Update ${HtmlUtils.getHiddenText(offender.name)}`
     const linkHtml = HtmlUtils.getAnchor(
       actionContent,
-      paths.appointments.appointmentDetails({ appointmentId: appointmentId.toString(), projectCode }),
+      pathWithQuery(
+        paths.appointments.appointmentDetails({ appointmentId: appointmentId.toString(), projectCode }),
+        originalSearch,
+      ),
     )
 
     return { html: linkHtml }


### PR DESCRIPTION
## Context

Persists original “find sessions / find projects” search parameters through navigation into appointment update flows, so users can return back to their filtered results from session/project pages after updating outcomes.

[CPB-847](https://dsdmoj.atlassian.net/browse/CPB-847)

## Changes in this PR

- Pass original search query params from the view project/session paths to appointment update links, and store on the appointment update form object.
- Updates appointment update page routing to consistently preserve form and search query parameters across back/next/update paths.
- Remove handling of path with formId at base page level, and instead control the use of this in the implementing path methods (to ensure the form Id is not passed along when exiting the form.

### Screenshots of UI changes

Navigating back to search from an appointment update to group session search and seeing previous search results:

https://github.com/user-attachments/assets/6f1544c5-0e43-4ba7-a855-8db96599337c

Navigating back to previous search for group sessions after submitting an appointment update, and seeing search results:


https://github.com/user-attachments/assets/278e53d6-4106-4ed1-ba2f-dd892fae0ee5


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-847]: https://dsdmoj.atlassian.net/browse/CPB-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ