### PR TITLE
CPB-877 Fix CRN form submission failure after validation

### DIFF
--- a/integration_tests/pages/courseCompletions/process/crnPage.ts
+++ b/integration_tests/pages/courseCompletions/process/crnPage.ts
@@ -13,7 +13,7 @@ export default class CrnPage extends BaseCourseCompletionsPage {
 
   static visit(
     courseCompletion: EteCourseCompletionEventDto,
-    formId?: string,
+    formId: string,
     originalSearch: CourseCompletionPageInput = {},
   ) {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'crn', id: courseCompletion.id }), {

--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -89,6 +89,7 @@ context('Person Page', () => {
     const page = PersonPage.visit(courseCompletion, offender)
 
     //  When I click back
+    cy.task('stubSaveCourseCompletionForm', form)
     page.clickBack()
 
     // Then I should see the course completion details page

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -56,7 +56,7 @@ context('Crn Page', () => {
   const courseCompletion = courseCompletionFactory.build()
   const offender = offenderFullFactory.build()
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender })
-  const form = courseCompletionFormFactory.build({ crn: offender.crn })
+  const form = courseCompletionFormFactory.build({ crn: undefined })
 
   beforeEach(() => {
     cy.task('reset')
@@ -64,17 +64,19 @@ context('Crn Page', () => {
     cy.signIn()
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubGetCourseCompletionForm', form)
-    cy.task('stubSaveCourseCompletionForm', courseCompletionFormFactory.build())
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
   })
 
   // Scenario: Submitting the form
   it('continues to the next page on submit', () => {
     //  Given I am on the form page
-    const page = CrnPage.visit(courseCompletion)
+    const page = CrnPage.visit(courseCompletion, '12')
 
     //  When I complete the form
     page.enterCrn(offender.crn)
+
+    cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
+    cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
     page.clickSubmit()
 
     // Then I should see the next page of the form
@@ -84,7 +86,7 @@ context('Crn Page', () => {
   // Scenario: Validating the form
   it('validates the form', () => {
     //  Given I am on the form page
-    const page = CrnPage.visit(courseCompletion)
+    const page = CrnPage.visit(courseCompletion, '12')
 
     //  When I submit an invalid form
     page.clickSubmit()
@@ -97,7 +99,7 @@ context('Crn Page', () => {
   // Scenario: CRN not found
   it('shows CRN not found error', () => {
     //  Given I am on the form page
-    const page = CrnPage.visit(courseCompletion)
+    const page = CrnPage.visit(courseCompletion, '12')
 
     //  When I complete the form with an invalid CRN
     page.enterCrn('invalid-crn')
@@ -111,8 +113,10 @@ context('Crn Page', () => {
   // Scenario: Navigating back
   it('navigates back', () => {
     //  Given I am on the form page
-    const page = CrnPage.visit(courseCompletion)
+    const page = CrnPage.visit(courseCompletion, '12')
 
+    cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
+    cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
     //  When I click back
     page.clickBack()
 
@@ -122,11 +126,14 @@ context('Crn Page', () => {
 
   // Scenario: Navigates back to search results
   it('navigates back to search results', () => {
+    cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
+    cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
+
     const pdu = communityCampusPduFactory.build()
     const provider = providerSummaryFactory.build()
     cy.task('stubFindCourseCompletion', { courseCompletion })
     // Given I am on the page
-    const page = CrnPage.visit(courseCompletion, undefined, { pdu: pdu.id, provider: provider.code })
+    const page = CrnPage.visit(courseCompletion, '12', { pdu: pdu.id, provider: provider.code })
 
     // When I click back
     page.clickBack()
@@ -161,7 +168,7 @@ context('Crn Page', () => {
   // Scenario: Navigating to unable to credit time page
   it('navigates to unable to credit time page', () => {
     //  Given I am on the form page
-    const page = CrnPage.visit(courseCompletion)
+    const page = CrnPage.visit(courseCompletion, '12')
 
     // When I click the unable to credit time link
     page.clickUnableToCreditTimeLink()

--- a/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
+++ b/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
@@ -55,6 +55,7 @@
 
 import { communityCampusPduFactory } from '../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../server/testutils/factories/courseCompletionFactory'
+import courseCompletionFormFactory from '../../../server/testutils/factories/courseCompletionFormFactory'
 import pagedMetadataFactory from '../../../server/testutils/factories/pagedMetadataFactory'
 import pagedModelCourseCompletionEventFactory from '../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
@@ -266,6 +267,7 @@ context('Search course completions', () => {
 
     // And I click the view link for a course completion
     cy.task('stubFindCourseCompletion', { courseCompletion })
+    cy.task('stubSaveCourseCompletionForm', courseCompletionFormFactory.build())
     page.clickCourseCompletion()
 
     // Then I am on the course completion details page

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -11,6 +11,7 @@ import {
   communityCampusPdusFactory,
 } from '../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../server/testutils/factories/courseCompletionFactory'
+import courseCompletionFormFactory from '../../../server/testutils/factories/courseCompletionFormFactory'
 import pagedModelCourseCompletionEventFactory from '../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import CourseCompletionPage from '../../pages/courseCompletions/courseCompletionPage'
@@ -18,11 +19,16 @@ import CrnPage from '../../pages/courseCompletions/process/crnPage'
 import SearchCourseCompletionsPage from '../../pages/courseCompletions/searchCourseCompletionsPage'
 import Page from '../../pages/page'
 
+const form = courseCompletionFormFactory.build()
+
 context('Project page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.signIn()
+
+    cy.task('stubSaveCourseCompletionForm', form)
+    cy.task('stubGetCourseCompletionForm', form)
   })
 
   // Scenario: Processing a course completion

--- a/server/controllers/courseCompletions/index.test.ts
+++ b/server/controllers/courseCompletions/index.test.ts
@@ -11,6 +11,10 @@ import { getPaginationRequestParams } from '../../utils/paginationUtils'
 import ProviderService from '../../services/providerService'
 import ReferenceDataService from '../../services/referenceDataService'
 import getProvidersAndPdus, { ProvidersAndPdus } from '../shared/getProvidersAndPdus'
+import CourseCompletionFormService from '../../services/forms/courseCompletionFormService'
+import { pathWithQuery } from '../../utils/utils'
+import paths from '../../paths'
+import courseCompletionFormFactory from '../../testutils/factories/courseCompletionFormFactory'
 
 jest.mock('../../pages/courseCompletionIndexPage')
 jest.mock('../../utils/paginationUtils')
@@ -24,6 +28,7 @@ describe('CourseCompletionsController', () => {
   const courseCompletionService = createMock<CourseCompletionService>()
   const providerService = createMock<ProviderService>()
   const referenceDataService = createMock<ReferenceDataService>()
+  const formService = createMock<CourseCompletionFormService>()
 
   const providersAndPdus = {
     provider: { value: 'X', text: 'Provider' },
@@ -64,17 +69,21 @@ describe('CourseCompletionsController', () => {
     { html: 'View' },
   ]
 
+  const form = courseCompletionFormFactory.build()
+
   beforeEach(() => {
     jest.resetAllMocks()
     courseCompletionsController = new CourseCompletionsController(
       courseCompletionService,
       providerService,
       referenceDataService,
+      formService,
     )
 
     mockTableHeaders.mockReturnValue(courseCompletionTableHeaders)
     mockTableRows.mockReturnValue(courseCompletionTableRows)
     mockValidationErrors.mockReturnValue({})
+    formService.createForm.mockResolvedValue({ formId: '1', formData: form })
 
     pageMock.mockImplementation(() => {
       return {
@@ -218,15 +227,24 @@ describe('CourseCompletionsController', () => {
 
       courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
 
-      const requestHandler = courseCompletionsController.show()
-      await requestHandler(request, response, next)
+      const req: DeepMocked<Request> = createMock<Request>({
+        query: {
+          provider: '1',
+          pdu: '123',
+        },
+      })
 
-      expect(response.render).toHaveBeenCalledWith(
-        'courseCompletions/show',
-        expect.objectContaining({
-          courseCompletion,
+      const requestHandler = courseCompletionsController.show()
+      await requestHandler(req, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('courseCompletions/show', {
+        courseCompletion,
+        backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
+        processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
+          ...req.query,
+          form: '1',
         }),
-      )
+      })
     })
   })
 })

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -8,6 +8,7 @@ import ReferenceDataService from '../../services/referenceDataService'
 import getProvidersAndPdus from '../shared/getProvidersAndPdus'
 import ProviderService from '../../services/providerService'
 import { pathWithQuery } from '../../utils/utils'
+import CourseCompletionFormService from '../../services/forms/courseCompletionFormService'
 
 const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime'] as const
 
@@ -16,6 +17,7 @@ export default class CourseCompletionsController {
     private readonly courseCompletionService: CourseCompletionService,
     private readonly providerService: ProviderService,
     private readonly referenceDataService: ReferenceDataService,
+    private readonly formService: CourseCompletionFormService,
   ) {}
 
   index(): RequestHandler {
@@ -42,13 +44,15 @@ export default class CourseCompletionsController {
         id: req.params.id,
       })
 
+      const { formId } = await this.formService.createForm(res.locals.user.username)
+
       res.render('courseCompletions/show', {
         courseCompletion,
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
-        processLink: pathWithQuery(
-          paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }),
-          req.query as CourseCompletionPageInput,
-        ),
+        processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
+          ...(req.query as CourseCompletionPageInput),
+          form: formId,
+        }),
       })
     }
   }

--- a/server/controllers/courseCompletions/process/crnController.test.ts
+++ b/server/controllers/courseCompletions/process/crnController.test.ts
@@ -49,13 +49,13 @@ describe('CrnController', () => {
       page.viewData.mockReturnValue(viewData)
       page.stepViewData.mockReturnValue(stepViewData)
 
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: {} })
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
 
       const requestHandler = crnController.show()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith(templatePath, { ...viewData, ...stepViewData })
-      expect(formService.getForm).not.toHaveBeenCalled()
+      expect(formService.getForm).toHaveBeenCalled()
     })
 
     it('fetches form data if form param', async () => {
@@ -86,13 +86,13 @@ describe('CrnController', () => {
         page.nextPath.mockReturnValue(nextPath)
         page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
 
-        const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: {} })
+        const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
 
         const requestHandler = crnController.submit()
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
-        expect(formService.getForm).not.toHaveBeenCalled()
+        expect(formService.getForm).toHaveBeenCalled()
         expect(formService.saveForm).toHaveBeenCalled()
       })
 
@@ -131,7 +131,7 @@ describe('CrnController', () => {
         const errors = { crn: { text: 'Error' } }
         page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
 
-        const request = createMock<Request>({ params: { id: '1' }, query: {} })
+        const request = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
 
         const requestHandler = crnController.submit()
         await requestHandler(request, response, next)
@@ -142,7 +142,7 @@ describe('CrnController', () => {
           errors,
           errorSummary,
         })
-        expect(formService.getForm).not.toHaveBeenCalled()
+        expect(formService.getForm).toHaveBeenCalled()
       })
 
       it('fetches form data if form param', async () => {
@@ -203,7 +203,7 @@ describe('CrnController', () => {
           page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
           page.getCrnNotFoundErrors.mockReturnValue(crnNotFoundErrors)
 
-          const request = createMock<Request>({ params: { id: '1' }, query: {} })
+          const request = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
 
           const requestHandler = crnController.submit()
           await requestHandler(request, response, next)
@@ -227,7 +227,7 @@ describe('CrnController', () => {
 
           page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
 
-          const request = createMock<Request>({ params: { id: '1' }, query: {} })
+          const request = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
 
           const requestHandler = crnController.submit()
           await expect(requestHandler(request, response, next)).rejects.toEqual(apiError)

--- a/server/controllers/courseCompletions/process/crnController.ts
+++ b/server/controllers/courseCompletions/process/crnController.ts
@@ -1,12 +1,10 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { randomUUID } from 'crypto'
 import CrnPage from '../../../pages/courseCompletions/process/crnPage'
 import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
-import CourseCompletionFormService, { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import OffenderService from '../../../services/offenderService'
-import { CourseCompletionPageInput } from '../../../pages/courseCompletionIndexPage'
 
 export default class CrnController extends BaseController<CrnPage> {
   constructor(
@@ -20,25 +18,6 @@ export default class CrnController extends BaseController<CrnPage> {
 
   protected override getStepViewData({ req, courseCompletion, formData }: StepViewDataParams) {
     return Promise.resolve(this.page.stepViewData(courseCompletion, req.body, formData))
-  }
-
-  protected override async getForm(
-    req: Request,
-    res: Response,
-    isSubmit: boolean = false,
-  ): Promise<{ formId: string; formData: CourseCompletionForm }> {
-    let formId = req.query.form?.toString()
-
-    const formData = formId
-      ? await this.courseCompletionFormService.getForm(formId, res.locals.user.username)
-      : ({} as CourseCompletionForm)
-
-    if (!formId && isSubmit) {
-      formId = randomUUID()
-      formData.originalSearch = req.query as CourseCompletionPageInput
-    }
-
-    return { formId, formData }
   }
 
   override submit(): RequestHandler {

--- a/server/controllers/courseCompletions/process/unableToCreditTimeController.test.ts
+++ b/server/controllers/courseCompletions/process/unableToCreditTimeController.test.ts
@@ -62,13 +62,13 @@ describe('UnableToCreditTimeController', () => {
       }
       page.viewData.mockReturnValue(viewData)
 
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: {}, body: {} })
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: { form: '12' }, body: {} })
 
       const requestHandler = unableToCreditTimeController.show()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith(templatePath, viewData)
-      expect(formService.getForm).not.toHaveBeenCalled()
+      expect(formService.getForm).toHaveBeenCalled()
     })
 
     it('fetches form data if form param exists', async () => {
@@ -193,8 +193,8 @@ describe('UnableToCreditTimeController', () => {
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
       const request: DeepMocked<Request> = createMock<Request>({
-        params: { id: '1', form: '2' },
-        query: { unableToCreditTimeNotes },
+        params: { id: '1' },
+        query: { unableToCreditTimeNotes, form: '2' },
       })
 
       const requestHandler = unableToCreditTimeController.submit()
@@ -222,7 +222,7 @@ describe('UnableToCreditTimeController', () => {
       page.updatePath.mockReturnValue(path)
       courseCompletionService.saveResolution.mockRejectedValue(error)
 
-      const request = createMock<Request>({ params: { id: '1', form: '2' } })
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: '2' } })
 
       const requestHandler = unableToCreditTimeController.submit()
       await requestHandler(request, response, next)

--- a/server/controllers/courseCompletions/process/unableToCreditTimeController.ts
+++ b/server/controllers/courseCompletions/process/unableToCreditTimeController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
-import { randomUUID } from 'node:crypto'
-import CourseCompletionFormService, { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import paths from '../../../paths'
@@ -27,24 +26,6 @@ export default class UnableToCreditTimeController extends BaseController<UnableT
   }: StepViewDataParams): Promise<{ unableToCreditTimeNotes: string }> {
     const unableToCreditTimeNotes = this.getPropertyValue({ propertyName: 'unableToCreditTimeNotes', req, formData })
     return { unableToCreditTimeNotes }
-  }
-
-  protected override async getForm(
-    req: Request,
-    res: Response,
-    isSubmit: boolean = false,
-  ): Promise<{ formId: string; formData: CourseCompletionForm }> {
-    let formId = req.query.form?.toString()
-
-    const formData = formId
-      ? await this.courseCompletionFormService.getForm(formId, res.locals.user.username)
-      : ({} as CourseCompletionForm)
-
-    if (!formId && isSubmit) {
-      formId = randomUUID()
-    }
-
-    return { formId, formData }
   }
 
   override show(): RequestHandler {

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -22,6 +22,7 @@ export const controllers = (services: Services) => {
     services.courseCompletionService,
     services.providerService,
     services.referenceDataService,
+    services.courseCompletionFormService,
   )
   const dataController = new DataController(services.providerService)
   const staticController = new StaticController()

--- a/server/services/forms/courseCompletionFormService.test.ts
+++ b/server/services/forms/courseCompletionFormService.test.ts
@@ -1,4 +1,5 @@
 import FormClient from '../../data/formClient'
+import { CourseCompletionPageInput } from '../../pages/courseCompletionIndexPage'
 import courseCompletionFormFactory from '../../testutils/factories/courseCompletionFormFactory'
 import CourseCompletionFormService, { COURSE_COMPLETION_PROCESS_FORM_TYPE } from './courseCompletionFormService'
 
@@ -43,6 +44,29 @@ describe('CourseCompletionFormService', () => {
         'some-name',
         form,
       )
+    })
+  })
+
+  describe('createForm', () => {
+    it('should create a new form', async () => {
+      const result = await courseCompletionFormService.createForm('some-name')
+
+      expect(result.formId).toBeTruthy()
+      expect(result.formData).toEqual({})
+      expect(formClient.save).toHaveBeenCalled()
+    })
+
+    it('should create a new form with original search query', async () => {
+      const originalSearch: CourseCompletionPageInput = {
+        pdu: '1',
+        provider: '2',
+      }
+
+      const result = await courseCompletionFormService.createForm('some-name', originalSearch)
+
+      expect(result.formId).toBeTruthy()
+      expect(result.formData).toEqual({ originalSearch })
+      expect(formClient.save).toHaveBeenCalled()
     })
   })
 })

--- a/server/services/forms/courseCompletionFormService.ts
+++ b/server/services/forms/courseCompletionFormService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { CourseCompletionResolutionDto } from '../../@types/shared'
 import { YesOrNo } from '../../@types/user-defined'
 import FormClient from '../../data/formClient'
@@ -31,5 +32,17 @@ export type CourseCompletionForm = {
 export default class CourseCompletionFormService extends BaseFormService<CourseCompletionForm> {
   constructor(formClient: FormClient) {
     super(formClient, COURSE_COMPLETION_PROCESS_FORM_TYPE)
+  }
+
+  async createForm(
+    username: string,
+    query?: CourseCompletionPageInput,
+  ): Promise<{ formId: string; formData: CourseCompletionForm }> {
+    const formId = randomUUID()
+    const formData = { originalSearch: query }
+
+    await this.saveForm(formId, username, formData)
+
+    return { formId, formData }
   }
 }


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-877?atlOrigin=eyJpIjoiOTFjYWRmNjE4N2FiNDc0NWEwZjYyMTBiMDNjNDJkNjgiLCJwIjoiaiJ9)

## Context
When rendering the CRN page, if a form doesn't exist, a UUID is generated. When
submitting the form on that page, the UUID is then used to create a form when
submission is successful.

However, if form submission is not successful then no form is created, on
subsequent submissions we attempt to fetch form data from a form that doesn't
exist, leading to an error.

To fix this, we instead create the form on the page before (course
completion/show), which ensures a form is always available for the CRN page.

As this page sits outside of the process journey, a new form will always be
created when this page is loaded. This simplifies the logic for form creation.
This means that when a user clicks "Process", the journey their previous
answers will be removed.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
