### PR TITLE
Pin pipeline versions to last working version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
   # main node build workflow
   node_build:
     name: node build
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_build.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_build.yml@658ee37b404f39de63423d2bd7bdf1f2fce7da19 # v2.13.3
     secrets: inherit
     with:
       install_command: 'npm run setup'
@@ -61,7 +61,7 @@ jobs:
   # generic node unit tests - feel free to override with local tests if required
   node_unit_tests:
     name: node unit tests
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_unit_tests.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_unit_tests.yml@658ee37b404f39de63423d2bd7bdf1f2fce7da19 # v2.13.3
     needs: [node_build]
     secrets: inherit
   node_integration_tests:
@@ -74,14 +74,14 @@ jobs:
       matrix:
         environments: ['dev', 'preprod', 'prod']
     name: helm lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@658ee37b404f39de63423d2bd7bdf1f2fce7da19 # v2.13.3
     secrets: inherit
     with:
       environment: ${{ matrix.environments }}
   build:
     name: Build docker image from hmpps-github-actions
     if: github.ref == 'refs/heads/main'
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@658ee37b404f39de63423d2bd7bdf1f2fce7da19 # v2.13.3
     needs:
       - node_integration_tests
       - node_unit_tests
@@ -96,7 +96,7 @@ jobs:
     needs:
       - build
       - helm_lint
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@658ee37b404f39de63423d2bd7bdf1f2fce7da19 # v2.13.3
     secrets: inherit
     with:
       environment: 'dev'


### PR DESCRIPTION
## Context
A breaking update was released in the hmpps-github-actions repo[1]. This commit pins versions to the last working version (2.13.3)[2].

[1]
https://github.com/ministryofjustice/hmpps-github-actions/releases/tag/v2.14.0

[2]
https://github.com/ministryofjustice/hmpps-github-actions/releases/tag/v2.13.3

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
