### PR TITLE
Fix course completion e2e tests

### DIFF
--- a/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/e2e-tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -31,6 +31,8 @@ export default class SearchCourseCompletionsPage extends BasePage {
 
   readonly pduFilter: PduFilterComponent
 
+  readonly noResultsMessage: Locator
+
   constructor(page: Page, expectedTitle: string) {
     super(page)
     this.expect = new SearchCourseCompletionsPageAssertions(this, expectedTitle)
@@ -45,6 +47,7 @@ export default class SearchCourseCompletionsPage extends BasePage {
     this.toYearFieldLocator = page.getByLabel('year').nth(1)
     this.searchButtonLocator = page.getByRole('button', { name: 'Apply filters' })
     this.applyRegionLocator = page.getByRole('button', { name: 'Apply', exact: true })
+    this.noResultsMessage = page.getByRole('heading', { name: 'No results found' })
   }
 
   async completeSearchForm(team: Team) {
@@ -80,7 +83,13 @@ class SearchCourseCompletionsPageAssertions {
     await expect(this.page.headingLocator).toContainText(this.expectedTitle)
   }
 
-  async toSeeCourseCompletions() {
-    await this.page.courseCompletions.expect.toHaveItems()
+  async toSeeSearchResults() {
+    try {
+      // First check to see if any results shown
+      await this.page.courseCompletions.expect.toHaveItems()
+    } catch {
+      // Otherwise we can validate a search result has been performed by checking for the no results message
+      await expect(this.page.noResultsMessage).toBeVisible()
+    }
   }
 }

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -23,7 +23,7 @@ test('Process course completion - credit time on existing appointment', async ({
   const homePage = await signIn(page, deliusUser)
   const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
 
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 
   const personName = personOnProbation.getFullName()
 
@@ -67,7 +67,7 @@ test('Process course completion - credit time on existing appointment', async ({
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 
   await deliusLogin(page)
   await verifyTimeCredited(page, {

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -22,7 +22,7 @@ test('Process course completion - create new appointment', async ({
   const homePage = await signIn(page, deliusUser)
   const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
 
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 
   const personName = personOnProbation.getFullName()
 
@@ -65,7 +65,7 @@ test('Process course completion - create new appointment', async ({
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 
   await deliusLogin(page)
   await verifyTimeCredited(page, {

--- a/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
+++ b/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
@@ -19,7 +19,7 @@ test('Process course completion - unable to credit time', async ({
   const homePage = await signIn(page, deliusUser)
   const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
 
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 
   const personName = personOnProbation.getFullName()
 
@@ -37,5 +37,5 @@ test('Process course completion - unable to credit time', async ({
   await courseCompletionFormPage.submit()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
-  await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
 })

--- a/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
@@ -28,6 +28,6 @@ test.describe('Without javascript', () => {
     await searchCourseCompletionsPage.pduFilter.selectPdu(team.pdu)
     await searchCourseCompletionsPage.submitForm()
 
-    await searchCourseCompletionsPage.expect.toSeeCourseCompletions()
+    await searchCourseCompletionsPage.expect.toSeeSearchResults()
   })
 })


### PR DESCRIPTION
## Context

At the end of our e2e tests for course completion, I had an assertion that a search has been performed when completing a resolution.

However, it is reasonable that there will be empty results, as any completed tasks should disappear from that list.

Updating the assertion to account for this. We can check for the presence of the no results message if there is no results table.

This should fix our latest [failing pipeline](https://github.com/ministryofjustice/hmpps-community-payback-ui/actions/runs/25160478646/job/73754591328).

I also plan to update these tests with an assertion to check that the event has disappeared from the list after completion, but wanted to merge a fix first.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
