### PR TITLE
Fix original search not being persisted

### DIFF
--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -44,7 +44,10 @@ export default class CourseCompletionsController {
         id: req.params.id,
       })
 
-      const { formId } = await this.formService.createForm(res.locals.user.username)
+      const { formId } = await this.formService.createForm(
+        res.locals.user.username,
+        req.query as CourseCompletionPageInput,
+      )
 
       res.render('courseCompletions/show', {
         courseCompletion,


### PR DESCRIPTION
We need to pass path query object to the `createForm` method to ensure the form is persisted.

Fixes a bug introduced in #510 with retaining the original search (implemented in #503)