### PR TITLE
Improve community campus e2e tests

### DIFF
--- a/e2e-tests/pages/components/dataTableComponent.ts
+++ b/e2e-tests/pages/components/dataTableComponent.ts
@@ -39,4 +39,15 @@ class DataTableAssertions {
     const resultCount = await this.component.resultCount()
     expect(resultCount).toBeGreaterThan(1)
   }
+
+  async notToHaveRowWithContent(content: string): Promise<void> {
+    const rowLocator = this.component.itemsLocator.filter({ hasText: content })
+    if (await this.component.nextPageButtonLocator.isVisible()) {
+      await expect(rowLocator).not.toBeVisible()
+      await this.component.nextPageButtonLocator.click()
+      return this.notToHaveRowWithContent(content)
+    }
+
+    return expect(rowLocator).not.toBeVisible()
+  }
 }

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -68,6 +68,7 @@ test('Process course completion - credit time on existing appointment', async ({
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
 
   await deliusLogin(page)
   await verifyTimeCredited(page, {

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -66,6 +66,7 @@ test('Process course completion - create new appointment', async ({
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
 
   await deliusLogin(page)
   await verifyTimeCredited(page, {

--- a/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
+++ b/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
@@ -38,4 +38,5 @@ test('Process course completion - unable to credit time', async ({
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
 })


### PR DESCRIPTION
## Context

In #513 I removed an assertion for course completions being present in the search results after a completion, as in fact any completed events will disappear from the list.

This change introduces a new assertion to check that the completed course completion events are indeed **not** in the search results.

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
