### PR TITLE
Fix e2e tests for individual placements with pagination

### DIFF
--- a/e2e-tests/pages/projects/findIndividualPlacementsPage.ts
+++ b/e2e-tests/pages/projects/findIndividualPlacementsPage.ts
@@ -20,7 +20,8 @@ export default class FindIndividualPlacementsPage extends BasePage {
   }
 
   async clickOnProject(projectName: string) {
-    await this.page.getByRole('link', { name: projectName }).first().click()
+    const row = await this.individualPlacements.getRowByContent(projectName)
+    await row.getByRole('link', { name: projectName }).click()
   }
 }
 


### PR DESCRIPTION
Where we have paginated results on the individual placements search page, we need to use `getRowByContent` from the DataTableComponent to seek out the project from the available pages.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
