### PR TITLE
CPB-866: Surface 400 validation error messages on appointment update request

### DIFF
--- a/integration_tests/mockApis/appointments.ts
+++ b/integration_tests/mockApis/appointments.ts
@@ -67,6 +67,35 @@ export default {
       },
     })
   },
+
+  stubUpdateAppointmentOutcomeWithError: ({
+    appointment,
+    userMessage,
+  }: {
+    appointment: AppointmentDto
+    userMessage: string
+  }): SuperAgentRequest => {
+    const pattern = paths.appointments.outcome({
+      projectCode: appointment.projectCode,
+      appointmentId: appointment.id.toString(),
+    })
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPathPattern: pattern,
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          status: 400,
+          userMessage,
+          developerMessage: 'Bad request',
+        },
+      },
+    })
+  },
+
   stubGetAppointmentTasks: ({
     appointments,
     providerCode,

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -79,4 +79,10 @@ export default class ConfirmDetailsPage extends Page {
   clickChange(label: string) {
     this.formDetails.clickActionWithLabel(label)
   }
+
+  override shouldShowErrorSummary(message: string) {
+    cy.get('[data-testid="error-summary"]').within(() => {
+      cy.get('li').contains(message)
+    })
+  }
 }

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -55,6 +55,12 @@
 //    And I am on the confirm page of an in progress update
 //    And I click confirm
 //    Then I can see the session page with error message
+//
+// Scenario: Should show any API validation errors
+//    Given I am on the confirm page of an in progress update
+//    And the API returns a 400 error
+//    And I click confirm
+//    Then I can see the error message
 
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
 import appointmentOutcomeFormFactory from '../../../server/testutils/factories/appointmentOutcomeFormFactory'
@@ -630,6 +636,36 @@ context('Confirm appointment details page', () => {
         'The arrival time has already been updated in the database, try again.',
         false,
       )
+    })
+
+    // Scenario: Should show any API validation errors
+    it('displays an error message when submission fails with a 400 error', function test() {
+      const appointment = appointmentFactory.build({ version: '1', alertActive: null })
+      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
+      const project = projectFactory.build({
+        projectCode: appointment.projectCode,
+      })
+
+      cy.task('stubFindProject', { project })
+
+      // Given I am on the confirm page of an in progress update
+      cy.task('stubFindAppointment', { appointment })
+      cy.task('stubGetAppointmentForm', form)
+
+      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+
+      // And the API returns a 400 error
+      const userMessage = 'Invalid appointment data'
+      cy.task('stubUpdateAppointmentOutcomeWithError', {
+        appointment,
+        userMessage,
+      })
+
+      // And I click confirm
+      page.clickSubmit('Confirm')
+
+      // Then I can see the error message
+      page.shouldShowErrorSummary(userMessage)
     })
   })
 })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -58,6 +58,36 @@ describe('ConfirmController', () => {
 
       expect(response.render).toHaveBeenCalledWith('appointments/update/confirm', pageViewData)
     })
+
+    it('should render the page with errorList when errorMessages are present', async () => {
+      const errorMessages = ['Start time is required', 'End time is required']
+      const responseWithErrors = createMock<Response>({
+        locals: { user: { username: 'user-name' }, errorMessages },
+      })
+
+      const form = appointmentOutcomeFormFactory.build()
+      const appointment = appointmentFactory.build()
+
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          viewData: () => pageViewData,
+          formId,
+        }
+      })
+
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = confirmController.show()
+      await requestHandler(request, responseWithErrors, next)
+
+      const expectedErrorList = [{ text: 'Start time is required' }, { text: 'End time is required' }]
+
+      expect(responseWithErrors.render).toHaveBeenCalledWith(
+        'appointments/update/confirm',
+        expect.objectContaining({ errorList: expectedErrorList }),
+      )
+    })
   })
 
   describe('submit', () => {

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import ConfirmController from './confirmController'
 import AppointmentService from '../../services/appointmentService'
@@ -8,6 +9,7 @@ import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import ProjectService from '../../services/projectService'
+import * as ErrorUtils from '../../utils/errorUtils'
 
 jest.mock('../../pages/appointments/confirmPage')
 
@@ -217,6 +219,49 @@ describe('ConfirmController', () => {
       expect(request.flash).toHaveBeenCalledWith(
         'error',
         'The arrival time has already been updated in the database, try again.',
+      )
+    })
+
+    it('calls catchApiValidationErrorOrPropagate when saveAppointment throws a SanitisedError', async () => {
+      jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+      const error: SanitisedError = {
+        name: 'SanitisedError',
+        message: 'API error',
+        responseStatus: 400,
+        data: {
+          userMessage: 'An error occurred',
+          developerMessage: 'Developer message',
+          status: 400,
+        },
+      }
+
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          isAlertSelected: true,
+          updatePath: () => '/update/path',
+        }
+      })
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+      const appointment = appointmentFactory.build({ version: appointmentVersion })
+      const contactOutcome = contactOutcomeFactory.build({ attended: true })
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+        deliusVersion: formAppointmentVersion,
+      })
+
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      appointmentFormService.getForm.mockResolvedValue(form)
+      appointmentService.saveAppointment.mockRejectedValue(error)
+
+      const requestHandler = confirmController.submit()
+      await requestHandler(request, response, next)
+
+      expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
+        request,
+        response,
+        error,
+        '/update/path',
       )
     })
   })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -5,6 +5,7 @@ import ConfirmPage from '../../pages/appointments/confirmPage'
 import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared'
 import { AppointmentOutcomeForm, AppointmentParams } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
+import { catchApiValidationErrorOrPropagate } from '../../utils/errorUtils'
 
 export default class ConfirmController {
   constructor(
@@ -64,10 +65,14 @@ export default class ConfirmController {
         date: appointment.date,
       }
 
-      await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
+      try {
+        await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
 
-      _req.flash('success', 'Attendance recorded')
-      return res.redirect(page.exitForm(appointment, project, form.originalSearch))
+        _req.flash('success', 'Attendance recorded')
+        return res.redirect(page.exitForm(appointment, project, form.originalSearch))
+      } catch (error) {
+        return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment))
+      }
     }
   }
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -5,7 +5,7 @@ import ConfirmPage from '../../pages/appointments/confirmPage'
 import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared'
 import { AppointmentOutcomeForm, AppointmentParams } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
-import { catchApiValidationErrorOrPropagate } from '../../utils/errorUtils'
+import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 
 export default class ConfirmController {
   constructor(
@@ -23,8 +23,9 @@ export default class ConfirmController {
 
       const page = new ConfirmPage(_req.query)
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const errorList = generateErrorTextList(res.locals.errorMessages)
 
-      res.render('appointments/update/confirm', page.viewData(appointment, form))
+      res.render('appointments/update/confirm', { ...page.viewData(appointment, form), errorList })
     }
   }
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -101,7 +101,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId }))
   }
 
-  protected updatePath(): string {
+  updatePath(): string {
     return this.pathWithFormId(
       paths.appointments.attendanceOutcome({
         projectCode: this.appointment.projectCode,

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -16,7 +16,7 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>): string
 
-  protected abstract updatePath(appointment: AppointmentDto): string
+  abstract updatePath(appointment: AppointmentDto): string
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -107,7 +107,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
   }
 
-  protected updatePath(appointment: AppointmentDto): string {
+  updatePath(appointment: AppointmentDto): string {
     return this.pathWithFormId(
       paths.appointments.appointmentDetails({
         appointmentId: appointment.id.toString(),

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -64,7 +64,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
   }
 
-  protected updatePath(appointment: AppointmentDto): string {
+  updatePath(appointment: AppointmentDto): string {
     return this.pathWithFormId(
       paths.appointments.confirm({
         projectCode: appointment.projectCode,

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -103,7 +103,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
   }
 
-  protected updatePath(appointment: AppointmentDto): string {
+  updatePath(appointment: AppointmentDto): string {
     return this.pathWithFormId(
       paths.appointments.logCompliance({
         projectCode: appointment.projectCode,

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -186,7 +186,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
   }
 
-  protected updatePath(appointment: AppointmentDto): string {
+  updatePath(appointment: AppointmentDto): string {
     return this.pathWithFormId(
       paths.appointments.logHours({
         projectCode: appointment.projectCode,

--- a/server/views/appointments/update/confirm.njk
+++ b/server/views/appointments/update/confirm.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {%- from "moj/components/alert/macro.njk" import mojAlert -%}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "./layout.njk" %}
 
@@ -8,6 +9,15 @@
 {% set formButtonText = "Confirm" %}
 
 {% block beforeForm %}
+  {% if errorList | length %}
+    {{ govukErrorSummary({
+      attributes: {
+        "data-testid": "error-summary"
+      },
+      titleText: "There is a problem",
+      errorList: errorList
+    }) }}
+  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
     {{ govukSummaryList({
@@ -42,4 +52,3 @@
   }) }}
   {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
## Context

This updates the appointment update form journey step to display API 400 validation errors to the user, aligning it with existing patterns used in other form journeys.

## Changes in this PR

- Render a GOV.UK error summary on the appointment update confirm page when API validation errors are present.
- Catch 400 validation errors on confirm submission and redirect back to the confirm page with a flashed error message.

### Screenshots of UI changes

<img width="1534" height="993" alt="Confirm appointment details page showing a validation error message from the API" src="https://github.com/user-attachments/assets/87bf0a40-736c-4265-921f-105174576214" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
