### PR TITLE
CPB-866: Render API validation errors on closing appointment tasks

### DIFF
--- a/integration_tests/mockApis/appointments.ts
+++ b/integration_tests/mockApis/appointments.ts
@@ -131,6 +131,30 @@ export default {
       },
     })
   },
+  stubCompleteAppointmentTaskWithError: ({
+    taskId,
+    userMessage,
+  }: {
+    taskId: string
+    userMessage: string
+  }): SuperAgentRequest => {
+    const pattern = paths.appointments.tasks.complete({ taskId })
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPath: pattern,
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          status: 400,
+          userMessage,
+          developerMessage: 'Bad request',
+        },
+      },
+    })
+  },
 }
 function buildAppointmentRequest(request: GetAppointmentsRequest): Record<string, unknown> {
   const query: Record<string, unknown> = {}

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -45,6 +45,12 @@
 //    When I click not eligible for travel time
 //    Then I see the travel time dashboard with a success message
 
+//  Scenario: Completing task returns error
+//    Given I am on the adjust travel time page for an appointment
+//    When I click not eligible for travel time
+//    And the API returns a 400 error
+//    Then I can see the error message
+
 import { ContactOutcomeDto, ProjectDto } from '../../../server/@types/shared'
 import { ProviderSummaryDto } from '../../../server/@types/shared/models/ProviderSummaryDto'
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
@@ -275,5 +281,28 @@ context('Update travel time page', () => {
     // Then I see the travel time dashboard with a success message
     const searchPage = Page.verifyOnPage(SearchAttendedPage)
     searchPage.shouldShowNotEligibleRecordedSuccessBanner(appointment)
+  })
+
+  // Scenario: Completing task returns error
+  it('renders an error message when completing task fails with a 400 error', () => {
+    const taskId = '12'
+    // Given I am on the adjust travel time page for an appointment
+    const page = UpdateTravelTimePage.visit(appointment, taskId)
+
+    cy.task('stubGetAdjustmentReasons')
+
+    const userMessage = 'Unable to complete task'
+    cy.task('stubCompleteAppointmentTaskWithError', {
+      taskId,
+      userMessage,
+    })
+
+    // When I click not eligible for travel time
+    // And the API returns a 400 error
+    page.clickNotEligible()
+
+    // Then I can see the error message
+    page.checkOnPage()
+    page.shouldShowErrorSummary(userMessage)
   })
 })

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -323,5 +323,39 @@ describe('AdjustTravelTimeController', () => {
       expect(response.redirect).toHaveBeenCalledWith(redirectPath)
       expect(page.exitPath).toHaveBeenCalledWith(query)
     })
+
+    it('calls catchApiValidationErrorOrPropagate when completeAppointmentTask throws a SanitisedError', async () => {
+      const appointmentId = '1'
+      const projectCode = '2'
+      const taskId = '123'
+      const params = { appointmentId, projectCode, taskId }
+      const query = { provider: '1' }
+
+      jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+      const error: SanitisedError = {
+        name: 'SanitisedError',
+        message: 'API error',
+        responseStatus: 400,
+        data: {
+          userMessage: 'An error occurred',
+          developerMessage: 'Developer message',
+          status: 400,
+        },
+      }
+
+      const appointment = appointmentFactory.build()
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      appointmentService.completeAppointmentTask.mockRejectedValue(error)
+
+      const path = '/update'
+      page.updatePath.mockReturnValue(path)
+
+      const request = createMock<Request>({ params, query })
+
+      const requestHandler = controller.completeTask()
+      await requestHandler(request, response, next)
+
+      expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(request, response, error, path)
+    })
   })
 })

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -188,13 +188,17 @@ export default class AdjustTravelTimeController {
         username: res.locals.user.username,
       })
 
-      await this.appointmentService.completeAppointmentTask(res.locals.user.username, taskId)
+      try {
+        await this.appointmentService.completeAppointmentTask(res.locals.user.username, taskId)
 
-      const successMessage = this.page.successMessage(appointment)
+        const successMessage = this.page.successMessage(appointment)
 
-      req.flash('success', successMessage)
+        req.flash('success', successMessage)
 
-      res.redirect(this.page.exitPath(req.query as SearchTravelTimePageInput))
+        return res.redirect(this.page.exitPath(req.query as SearchTravelTimePageInput))
+      } catch (error) {
+        return catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath(appointment, taskId, req.query))
+      }
     }
   }
 


### PR DESCRIPTION
## Context

We now catch and render any API validation errors on all submit routes, except for closing appointment tasks. Adding to this request for completeness.

[CPB-866](https://dsdmoj.atlassian.net/browse/CPB-866)

### Screenshots of UI changes


https://github.com/user-attachments/assets/abeff208-b3e1-434d-bf51-97c7a5025886

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-866]: https://dsdmoj.atlassian.net/browse/CPB-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ