### PR TITLE
CPB-792: Allow for dates without leading 0s in date inputs

### DIFF
--- a/server/utils/dateTimeUtils.test.ts
+++ b/server/utils/dateTimeUtils.test.ts
@@ -73,7 +73,19 @@ describe('DateTimeFormats', () => {
 
       const result = DateTimeFormats.dateAndTimeInputsToIsoString(obj, 'date')
 
-      expect(result.date.toString()).toEqual('twothousandtwentytwo-2-foo')
+      expect(result.date.toString()).toEqual('twothousandtwentytwo-02-foo')
+    })
+
+    it('allows for days and months without padded 0s', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2025',
+        'date-month': '2',
+        'date-day': '1',
+      }
+
+      const result = DateTimeFormats.dateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date.toString()).toEqual('2025-02-01')
     })
   })
 

--- a/server/utils/dateTimeUtils.ts
+++ b/server/utils/dateTimeUtils.ts
@@ -46,8 +46,8 @@ export default class DateTimeFormats {
    * @returns an ISO8601 date string.
    */
   static dateAndTimeInputsToIsoString<K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K) {
-    const day = `${dateInputObj[`${key}-day`]}`
-    const month = `${dateInputObj[`${key}-month`]}`
+    const day = `${dateInputObj[`${key}-day`]}`.padStart(2, '0')
+    const month = `${dateInputObj[`${key}-month`]}`.padStart(2, '0')
     const year = dateInputObj[`${key}-year`]
     const time = dateInputObj[`${key}-time`]
 


### PR DESCRIPTION
## Context

Currently when entering an appointment date as part of the [Record an outcome](https://dsdmoj.atlassian.net/browse/CPB-697) journey step, the user is required to enter a date in the format ‘01 02 2026’, with leading zeros if a date under 10. 
A validation error is surfaced if entering a date such as ‘1 2 2026’.

This can be handled by the application rather than surfacing a user error (we need to send the padded date in the API request, but we can add the required 0s before sending).

[CPB-792](https://dsdmoj.atlassian.net/browse/CPB-792)

## Changes in this PR

Pad date and month values with leading 0s when converting object to ISO string. 

### Screenshots of UI changes


https://github.com/user-attachments/assets/660f9077-3cf1-431c-a10e-ddc7e69ee19a

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-792]: https://dsdmoj.atlassian.net/browse/CPB-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ