### PR TITLE
CPB-878 - Use support email address in phase banner

### DIFF
--- a/server/views/pages/404.njk
+++ b/server/views/pages/404.njk
@@ -12,7 +12,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p class="govuk-body">
-        If the web address is correct or you selected a link or button, contact <a href="mailto:{{ supportEmailAddress }}">{{ supportEmailAddress }}</a> if you’re unable to log a session.
+        If the web address is correct or you selected a link or button, contact <a href="mailto:{{ supportEmailAddress }}">{{ supportEmailAddress }}</a>.
         </p>
     </div>
   </div>

--- a/server/views/pages/500.njk
+++ b/server/views/pages/500.njk
@@ -7,7 +7,7 @@
       <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">
-       Contact <a href="mailto:{{ supportEmailAddress }}">{{ supportEmailAddress }}</a> if you’re unable to log a session.
+       Contact <a href="mailto:{{ supportEmailAddress }}">{{ supportEmailAddress }}</a>.
         </p>
     </div>
   </div>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -10,13 +10,17 @@
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
 
+{% set emailHtml %}
+  This is a new service. To get help or report a bug, email <a href=mailto:"{{ supportEmailAddress }}">{{ supportEmailAddress }}</a>.
+{% endset %}
+
 {% block header %}
   {% include "./header.njk" %}
   {{ govukPhaseBanner({
     tag: {
       text: "Private beta"
     },
-    html: 'This is a new service. To get help or report a bug, email <a href="mailto:community-payback-digital-support@justice.gov.uk">community-payback-digital-support@justice.gov.uk</a>.'
+    html: emailHtml
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
## Context

We previously had a slightly different email address hardcoded in the phase banner, whilst the error pages used supportEmailAddress which comes from .env locally or is stored a secret in each actual environment. This homogenises our approach.

## Changes in this PR

### Screenshots of UI changes

<img width="1848" height="1417" alt="email-address-update" src="https://github.com/user-attachments/assets/78a8c868-bb57-41b1-b440-53028c944353" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
