### PR TITLE
CPB-865 Change action link on appointments with an outcome

### DIFF
--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -31,6 +31,10 @@ export default class ViewSessionPage extends Page {
     cy.get('a').contains('Update').eq(0).click()
   }
 
+  clickViewAnAppointment() {
+    cy.get('a').contains('View').eq(0).click()
+  }
+
   shouldShowSessionDetails() {
     this.sessionDetails.getValueWithLabel('Date').should(
       'contain.text',
@@ -56,7 +60,7 @@ export default class ViewSessionPage extends Page {
             appointmentSummary.completedMinutes +
             appointmentSummary.adjustmentMinutes,
         ),
-        appointmentSummary.contactOutcome.name,
+        appointmentSummary.contactOutcome ? appointmentSummary.contactOutcome.name : 'Not entered',
       ]
     })
 

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -8,6 +8,11 @@
 //    When I click update next for a particular session
 //    Then I see the check appointment details page
 
+//  Scenario: Accessing the view appointment form
+//    Given I am on the view session page
+//    When I click view for a particular session
+//    Then I see the check appointment details page
+
 //  Scenario: Viewing a session with Limited Access Offenders
 //    Given I am viewing a session details page with limited access offenders
 //    Then I see limited offender details and no option to update
@@ -122,12 +127,58 @@ context('Session details', () => {
 
   //  Scenario: Accessing the update appointment form
   it('shows an option to update an appointment on a session', function test() {
+    const appointment = appointmentFactory.build({
+      projectCode: this.project.projectCode,
+      pickUpData: { time: '09:00:30', location: locationFactory.build() },
+    })
+
+    const appointmentSummaries = appointmentSummaryFactory.buildList(1, {
+      id: appointment.id,
+      contactOutcome: undefined,
+      projectCode: appointment.projectCode,
+    })
+
+    const session = sessionFactory.build({
+      appointmentSummaries,
+      projectCode: this.project.projectCode,
+    })
+
+    cy.task('stubFindSession', { session })
+
+    // Given I am on the view session page
+    const page = ViewSessionPage.visit(session)
+    page.shouldShowAppointmentsList()
+
+    // When I click update for a particular session
+    const provider = providerSummaryFactory.build({ code: appointment.providerCode })
+    cy.task('stubFindAppointment', { appointment })
+    cy.task('stubGetProviders', { providers: { providers: [provider] } })
+    cy.task('stubGetSupervisors', {
+      teamCode: appointment.supervisingTeamCode,
+      providerCode: appointment.providerCode,
+      supervisors: this.supervisors,
+    })
+    page.clickUpdateAnAppointment()
+
+    // Then I see the check appointment details page
+    const checkAppointmentDetailsPage = Page.verifyOnPage(
+      CheckAppointmentDetailsPage,
+      appointment,
+      this.project,
+      provider,
+    )
+    checkAppointmentDetailsPage.shouldContainProjectDetails()
+    checkAppointmentDetailsPage.shouldContainAppointmentDetails()
+  })
+
+  //  Scenario: Accessing the view appointment form
+  it('shows an option to view an appointment on a session', function test() {
     // Given I am on the view session page
     const page = ViewSessionPage.visit(this.session)
     page.shouldShowAppointmentsList()
 
-    // When I click update for a particular session
-    page.clickUpdateAnAppointment()
+    // When I click view for a particular session
+    page.clickViewAnAppointment()
 
     // Then I see the check appointment details page
     const checkAppointmentDetailsPage = Page.verifyOnPage(

--- a/server/pages/projectPage.ts
+++ b/server/pages/projectPage.ts
@@ -37,7 +37,7 @@ export default class ProjectPage {
           text: DateTimeFormats.stripTime(appointment.endTime),
         },
         { text: appointment.daysOverdue },
-        SessionUtils.getAppointmentActionCell(appointment.id, projectCode, offender, originalSearch),
+        SessionUtils.getAppointmentActionCell({ appointmentId: appointment.id, projectCode, offender, originalSearch }),
       ]
     })
   }

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -195,46 +195,94 @@ describe('SessionUtils', () => {
       expect(result).toEqual({ text: '' })
     })
 
-    it('returns html with link if offender is not limited', () => {
-      const appointmentId = 1
-      const projectCode = '1'
-      const mockHiddenText = '<span></span>'
-      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+    describe('when offender is not limited', () => {
+      it('returns html with update link if contact outcome does not exist', () => {
+        const appointmentId = 1
+        const projectCode = '1'
+        const mockHiddenText = '<span></span>'
+        const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
 
-      const offenderDto: OffenderDto = {
-        crn: 'CRN123',
-        objectType: 'Full',
-      }
-      offenderMock.mockImplementation(() => {
-        return {
-          name: 'Sam Smith',
+        const offenderDto: OffenderDto = {
           crn: 'CRN123',
-          isLimited: false,
+          objectType: 'Full',
         }
-      })
-      const offender = new Offender(offenderDto)
-      jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
-      jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+        offenderMock.mockImplementation(() => {
+          return {
+            name: 'Sam Smith',
+            crn: 'CRN123',
+            isLimited: false,
+          }
+        })
+        const offender = new Offender(offenderDto)
+        jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
+        jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+        jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
 
-      const result = SessionUtils.getAppointmentActionCell({
-        appointmentId,
-        projectCode,
-        offender,
-        originalSearch: search,
+        const result = SessionUtils.getAppointmentActionCell({
+          appointmentId,
+          projectCode,
+          offender,
+          originalSearch: search,
+        })
+
+        expect(result).toEqual({ html: fakeLink })
+        expect(HtmlUtils.getHiddenText).toHaveBeenCalledWith(offender.name)
+        expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
+          `Update ${mockHiddenText}`,
+          pathWithQuery(
+            paths.appointments.appointmentDetails({
+              projectCode,
+              appointmentId: appointmentId.toString(),
+            }),
+            search,
+          ),
+        )
       })
 
-      expect(result).toEqual({ html: fakeLink })
-      expect(HtmlUtils.getHiddenText).toHaveBeenCalledWith(offender.name)
-      expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
-        `Update ${mockHiddenText}`,
-        pathWithQuery(
-          paths.appointments.appointmentDetails({
-            projectCode,
-            appointmentId: appointmentId.toString(),
-          }),
-          search,
-        ),
-      )
+      it('returns html with view link if contact outcome exists', () => {
+        const contactOutcome = contactOutcomeFactory.build()
+        const appointmentId = 1
+        const projectCode = '1'
+        const mockHiddenText = '<span></span>'
+        const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+
+        const offenderDto: OffenderDto = {
+          crn: 'CRN123',
+          objectType: 'Full',
+        }
+        offenderMock.mockImplementation(() => {
+          return {
+            name: 'Sam Smith',
+            crn: 'CRN123',
+            isLimited: false,
+          }
+        })
+        const offender = new Offender(offenderDto)
+        jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
+        jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+        jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+
+        const result = SessionUtils.getAppointmentActionCell({
+          appointmentId,
+          projectCode,
+          offender,
+          originalSearch: search,
+          contactOutcome,
+        })
+
+        expect(result).toEqual({ html: fakeLink })
+        expect(HtmlUtils.getHiddenText).toHaveBeenCalledWith(offender.name)
+        expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
+          `View ${mockHiddenText}`,
+          pathWithQuery(
+            paths.appointments.appointmentDetails({
+              projectCode,
+              appointmentId: appointmentId.toString(),
+            }),
+            search,
+          ),
+        )
+      })
     })
   })
 

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -186,7 +186,12 @@ describe('SessionUtils', () => {
       })
       const offender = new Offender(offenderDto)
 
-      const result = SessionUtils.getAppointmentActionCell(1, '1', offender, search)
+      const result = SessionUtils.getAppointmentActionCell({
+        appointmentId: 1,
+        projectCode: '1',
+        offender,
+        originalSearch: search,
+      })
       expect(result).toEqual({ text: '' })
     })
 
@@ -211,7 +216,12 @@ describe('SessionUtils', () => {
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
 
-      const result = SessionUtils.getAppointmentActionCell(appointmentId, projectCode, offender, search)
+      const result = SessionUtils.getAppointmentActionCell({
+        appointmentId,
+        projectCode,
+        offender,
+        originalSearch: search,
+      })
 
       expect(result).toEqual({ html: fakeLink })
       expect(HtmlUtils.getHiddenText).toHaveBeenCalledWith(offender.name)

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -166,6 +166,46 @@ describe('SessionUtils', () => {
       expect(HtmlUtils.getStatusTag).toHaveBeenCalled()
       expect(sessionRow[sessionRow.length - 2].html).toMatch(/grey.+Not entered/)
     })
+
+    it('returns a session row with "update" action link when a contact outcome does not exist', () => {
+      const mockTag = '<strong>Status</strong>'
+      const mockHiddenText = '<span></span>'
+      jest.spyOn(HtmlUtils, 'getStatusTag').mockReturnValue(mockTag)
+      jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
+      jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+      jest.spyOn(DateTimeFormats, 'minutesToHoursAndMinutes').mockReturnValue('1:00')
+      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+
+      const appointments = [appointmentSummaryFactory.build({ contactOutcome: null })]
+      const session = sessionFactory.build({ appointmentSummaries: appointments })
+
+      SessionUtils.sessionListTableRows(session, search)
+
+      expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
+        `Update ${mockHiddenText}`,
+        '/appointment-details?provider=provider',
+      )
+    })
+
+    it('returns a session row with "view" action link when a contact outcome exists', () => {
+      const mockTag = '<strong>Status</strong>'
+      const mockHiddenText = '<span></span>'
+      jest.spyOn(HtmlUtils, 'getStatusTag').mockReturnValue(mockTag)
+      jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
+      jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+      jest.spyOn(DateTimeFormats, 'minutesToHoursAndMinutes').mockReturnValue('1:00')
+      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+
+      const appointments = [appointmentSummaryFactory.build({ contactOutcome: contactOutcomeFactory.build() })]
+      const session = sessionFactory.build({ appointmentSummaries: appointments })
+
+      SessionUtils.sessionListTableRows(session, search)
+
+      expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
+        `View ${mockHiddenText}`,
+        '/appointment-details?provider=provider',
+      )
+    })
   })
 
   describe('getAppointmentActionCell', () => {

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, SessionDto, SessionSummariesDto, SessionSummaryDto } from '../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, SessionDto, SessionSummariesDto, SessionSummaryDto } from '../@types/shared'
 import Offender from '../models/offender'
 import paths from '../paths'
 import DateTimeFormats from './dateTimeUtils'
@@ -12,6 +12,7 @@ type AppointmentActionCellParams = {
   projectCode: string
   offender: Offender
   originalSearch: Record<string, string>
+  contactOutcome?: ContactOutcomeDto
 }
 
 export default class SessionUtils {
@@ -65,12 +66,16 @@ export default class SessionUtils {
     projectCode,
     offender,
     originalSearch,
+    contactOutcome,
   }: AppointmentActionCellParams): GovUKValue {
     if (offender.isLimited) {
       return { text: '' }
     }
 
-    const actionContent = `Update ${HtmlUtils.getHiddenText(offender.name)}`
+    const actionContent = contactOutcome
+      ? `View ${HtmlUtils.getHiddenText(offender.name)}`
+      : `Update ${HtmlUtils.getHiddenText(offender.name)}`
+
     const linkHtml = HtmlUtils.getAnchor(
       actionContent,
       pathWithQuery(

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -51,6 +51,7 @@ export default class SessionUtils {
           projectCode: session.projectCode,
           offender,
           originalSearch,
+          contactOutcome: appointment.contactOutcome,
         }),
       ]
     })

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -7,6 +7,13 @@ import { GovUKValue } from '../@types/user-defined'
 import { pathWithQuery } from './utils'
 import { GroupSessionIndexPageInput } from '../pages/groupSessionIndexPage'
 
+type AppointmentActionCellParams = {
+  appointmentId: number
+  projectCode: string
+  offender: Offender
+  originalSearch: Record<string, string>
+}
+
 export default class SessionUtils {
   static sessionResultTableRows(sessions: SessionSummariesDto, query: GroupSessionIndexPageInput) {
     return sessions.content.map(session => {
@@ -38,7 +45,12 @@ export default class SessionUtils {
         { text: DateTimeFormats.minutesToHoursAndMinutes(appointment.completedMinutes) },
         { text: DateTimeFormats.minutesToHoursAndMinutes(minutesRemaining) },
         { html: appointment.contactOutcome?.name || SessionUtils.getNotEnteredTag() },
-        SessionUtils.getAppointmentActionCell(appointment.id, session.projectCode, offender, originalSearch),
+        SessionUtils.getAppointmentActionCell({
+          appointmentId: appointment.id,
+          projectCode: session.projectCode,
+          offender,
+          originalSearch,
+        }),
       ]
     })
   }
@@ -48,12 +60,12 @@ export default class SessionUtils {
     return pathWithQuery(paths.sessions.show({ projectCode, date }), query)
   }
 
-  static getAppointmentActionCell(
-    appointmentId: number,
-    projectCode: string,
-    offender: Offender,
-    originalSearch: Record<string, string>,
-  ): GovUKValue {
+  static getAppointmentActionCell({
+    appointmentId,
+    projectCode,
+    offender,
+    originalSearch,
+  }: AppointmentActionCellParams): GovUKValue {
     if (offender.isLimited) {
       return { text: '' }
     }


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-865?atlOrigin=eyJpIjoiNTg2YmRhMjViOWY1NGQ4NjgzMzgwZDhiZTQ2MWJhMTQiLCJwIjoiaiJ9)

## Context
This piece of work is one of two PRs to stop users updating appointments which have already have an outcome associated. Here, we change the "action" link to "View" if a contact outcome exists. The next PR will address hiding the continue button on the appointment details page to stop users from completing the update form.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->


<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

#### Appointment with no contact outcome
<img width="1280" height="545" alt="Screenshot 2026-05-05 at 14 16 57" src="https://github.com/user-attachments/assets/467c2a53-767b-41ca-aaee-3ff3c59fe03b" />

#### Appointment with existing contact outcome
<img width="1290" height="598" alt="Screenshot 2026-05-05 at 14 16 04" src="https://github.com/user-attachments/assets/4079cc6e-01d0-47b2-be70-4269476a7092" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
