### PR TITLE
CPB-865 Hide continue button for appointments with a contact outcome

### DIFF
--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -81,6 +81,10 @@ export default class CheckAppointmentDetailsPage extends Page {
       .should('contain.text', yesNoDisplayValue(this.appointment.sensitive))
   }
 
+  shouldNotShowContinueButton(): void {
+    cy.contains('button', 'Continue').should('not.exist')
+  }
+
   protected override customCheckOnPage(): void {
     cy.get('h2').eq(1).should('contain.text', 'Project details')
     cy.get('h2').eq(2).should('contain.text', 'Appointment details')

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -47,6 +47,11 @@
 //    Given I am on an appointment 'check your details' page
 //    Then I see a supervisor input with a saved value
 
+//  Scenario: Viewing the appointment details page with an existing outcome
+//    Given I am on the appointment details page
+//    And an outcome has previously been recorded
+//    Then I should not see the Continue button
+
 //  Scenario: Validating the check appointment details page
 //    Given I am on an appointment 'check appointment details' page
 //    And I do not select a supervisor
@@ -59,7 +64,10 @@ import ViewSessionPage from '../../pages/viewSessionPage'
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
 import supervisorSummaryFactory from '../../../server/testutils/factories/supervisorSummaryFactory'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
-import { contactOutcomesFactory } from '../../../server/testutils/factories/contactOutcomeFactory'
+import {
+  contactOutcomeFactory,
+  contactOutcomesFactory,
+} from '../../../server/testutils/factories/contactOutcomeFactory'
 import sessionFactory from '../../../server/testutils/factories/sessionFactory'
 import appointmentSummaryFactory from '../../../server/testutils/factories/appointmentSummaryFactory'
 import offenderLimitedFactory from '../../../server/testutils/factories/offenderLimitedFactory'
@@ -89,13 +97,24 @@ context('Session details', () => {
       id: 1001,
       projectCode: project.projectCode,
       pickUpData: { time, location: locationFactory.build() },
+      contactOutcomeCode: undefined,
     })
     cy.wrap(firstAppointment).as('appointment')
 
-    const secondAppointment = appointmentFactory.build({ id: 1002, projectCode: project.projectCode })
+    const secondAppointment = appointmentFactory.build({
+      id: 1002,
+      projectCode: project.projectCode,
+      contactOutcomeCode: undefined,
+    })
 
-    const firstAppointmentSummary = appointmentSummaryFactory.build({ id: firstAppointment.id })
-    const secondAppointmentSummary = appointmentSummaryFactory.build({ id: secondAppointment.id })
+    const firstAppointmentSummary = appointmentSummaryFactory.build({
+      id: firstAppointment.id,
+      contactOutcome: undefined,
+    })
+    const secondAppointmentSummary = appointmentSummaryFactory.build({
+      id: secondAppointment.id,
+      contactOutcome: undefined,
+    })
 
     const session = sessionFactory.build({
       date: firstAppointment.date,
@@ -173,19 +192,44 @@ context('Session details', () => {
 
   //  Scenario: Accessing the view appointment form
   it('shows an option to view an appointment on a session', function test() {
+    const appointment = appointmentFactory.build({
+      projectCode: this.project.projectCode,
+      pickUpData: { time: '09:00:30', location: locationFactory.build() },
+    })
+
+    const appointmentSummaries = appointmentSummaryFactory.buildList(1, {
+      id: appointment.id,
+      contactOutcome: contactOutcomeFactory.build(),
+      projectCode: appointment.projectCode,
+    })
+
+    const session = sessionFactory.build({
+      appointmentSummaries,
+      projectCode: this.project.projectCode,
+    })
+
+    cy.task('stubFindSession', { session })
     // Given I am on the view session page
-    const page = ViewSessionPage.visit(this.session)
+    const page = ViewSessionPage.visit(session)
     page.shouldShowAppointmentsList()
 
     // When I click view for a particular session
+    const provider = providerSummaryFactory.build({ code: appointment.providerCode })
+    cy.task('stubFindAppointment', { appointment })
+    cy.task('stubGetProviders', { providers: { providers: [provider] } })
+    cy.task('stubGetSupervisors', {
+      teamCode: appointment.supervisingTeamCode,
+      providerCode: appointment.providerCode,
+      supervisors: this.supervisors,
+    })
     page.clickViewAnAppointment()
 
     // Then I see the check appointment details page
     const checkAppointmentDetailsPage = Page.verifyOnPage(
       CheckAppointmentDetailsPage,
-      this.appointment,
+      appointment,
       this.project,
-      this.provider,
+      provider,
     )
     checkAppointmentDetailsPage.shouldContainProjectDetails()
     checkAppointmentDetailsPage.shouldContainAppointmentDetails()
@@ -398,6 +442,31 @@ context('Session details', () => {
   })
 
   describe('Continue', () => {
+    // Scenario: Viewing the appointment details page with an existing outcome
+    it('does not show the continue button if a contact outcome exists', function test() {
+      const contactOutcome = contactOutcomeFactory.build()
+
+      const appointmentWithContactOutcome = appointmentFactory.build({
+        contactOutcomeCode: contactOutcome.code,
+        projectCode: this.project.projectCode,
+      })
+      cy.task('stubFindAppointment', { appointment: appointmentWithContactOutcome })
+
+      cy.task('stubGetSupervisors', {
+        teamCode: appointmentWithContactOutcome.supervisingTeamCode,
+        providerCode: appointmentWithContactOutcome.providerCode,
+        supervisors: this.supervisors,
+      })
+
+      // Given I am on the appointment details page
+      const page = CheckAppointmentDetailsPage.visit(appointmentWithContactOutcome, this.project, this.provider)
+
+      // And an outcome has previously been recorded
+
+      // Then I should not see the Continue button
+      page.shouldNotShowContinueButton()
+    })
+
     //  Scenario: Validating the check appointment details page
     it('validates form data', function test() {
       // Given I am on an appointment 'check appointment details' page

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -151,6 +151,34 @@ describe('CheckAppointmentDetailsPage', () => {
       expect(result.supervisorItems).toBe(supervisorItems)
     })
 
+    describe('showContinueButton', () => {
+      it('should return true if no outcome is associated with the appointment', () => {
+        const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })
+        const projectDto = projectFactory.build()
+        const dateAndTime = '1 January 2025, 09:00 - 17:00'
+        const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
+        jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
+        jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
+
+        const result = page.viewData(appointmentWithNoOutcome, supervisors, form, projectDto, providerDto, {})
+
+        expect(result.showContinueButton).toBe(true)
+      })
+
+      it('should return false if an outcome is associated with the appointment', () => {
+        const appointmentWithOutcome = appointmentFactory.build({ contactOutcomeCode: 'OUTC' })
+        const projectDto = projectFactory.build()
+        const dateAndTime = '1 January 2025, 09:00 - 17:00'
+        const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
+        jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
+        jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
+
+        const result = page.viewData(appointmentWithOutcome, supervisors, form, projectDto, providerDto, {})
+
+        expect(result.showContinueButton).toBe(false)
+      })
+    })
+
     it('should pass the supervisor to the select input options formatter if any value', async () => {
       const code = 'supervisor'
       form = appointmentOutcomeFormFactory.build({ supervisor: { code } })

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -16,6 +16,7 @@ import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 interface ViewData extends AppointmentUpdatePageViewData {
   supervisorItems: GovUkSelectOption[]
   project: { name: string; type: string; supervisingTeam: string; dateAndTime: string; location: string }
+  showContinueButton: boolean
   appointment: {
     providerCode: string
     notes: string
@@ -23,6 +24,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
     pickUpPlace: string
     sensitive: string
     provider: string
+    contactOutcomeCode?: string
   }
 }
 
@@ -90,6 +92,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
         location: LocationUtils.locationToString(project.location, { withLineBreaks: false }),
         dateAndTime: DateTimeFormats.dateAndTimePeriod(appointment.date, appointment.startTime, appointment.endTime),
       },
+      showContinueButton: !appointment.contactOutcomeCode,
     }
   }
 

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -5,6 +5,8 @@
 
 {% set pageTitle = 'Appointment details' %}
 
+{% set showContinue = showContinueButton %}
+
 {% block beforeForm %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -11,6 +11,9 @@
   {% set formButtonText = "Continue" %}
 {% endif %}
 
+{% if showContinue is not defined %}
+  {% set showContinue = true %}
+{% endif %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -53,13 +56,15 @@
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="govuk-button-group">
-          {{ govukButton({
-            text: formButtonText,
-            type: "submit",
-            attributes: {
-              "form": "appointmentForm"
-            }
-          }) }}
+          {% if showContinue %}
+            {{ govukButton({
+              text: formButtonText,
+              type: "submit",
+              attributes: {
+                "form": "appointmentForm"
+              }
+            }) }}
+          {% endif %}
           {% block secondaryButton %}
           {% endblock %}
         </div>


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-865?atlOrigin=eyJpIjoiYTA4MzAxNjVjMmNhNDgwODhhZWZkMzQ2ODUwYzdhMjQiLCJwIjoiaiJ9)

## Context
This piece of work is the second of two PRs to stop users updating appointments which have already have an outcome associated. Here, we create a read-only experience of the appointment details page by hiding the continue button when a contact outcome exists.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

### Screenshots of UI changes
#### Appointment with contact outcome
<img width="1281" height="1087" alt="Screenshot 2026-05-05 at 16 36 15" src="https://github.com/user-attachments/assets/4616ca57-35be-42e9-9e89-af6918d1d627" />

#### Appointment without contact outcome
<img width="1314" height="1116" alt="Screenshot 2026-05-05 at 16 37 02" src="https://github.com/user-attachments/assets/cd3f6f59-00c1-4019-b638-76dbc7e21d9c" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
