### PR TITLE
CPB-912: Prevent users from reverting sensitive value on appointments

### DIFF
--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -85,4 +85,12 @@ export default class ConfirmDetailsPage extends Page {
       cy.get('li').contains(message)
     })
   }
+
+  shouldNotShowChangeLink(label: string) {
+    this.formDetails.shouldNotContainAction(label)
+  }
+
+  shouldShowSensitiveValue(value: string) {
+    this.formDetails.getValueWithLabel('Sensitive').should('contain.text', value)
+  }
 }

--- a/integration_tests/pages/components/notesQuestionComponent.ts
+++ b/integration_tests/pages/components/notesQuestionComponent.ts
@@ -22,4 +22,13 @@ export default class NotesQuestionComponent {
   shouldShowIsSensitiveValue(value: YesOrNo = 'yes') {
     this.isSensitiveOptions.shouldHaveSelectedValue(value)
   }
+
+  shouldShowUncheckedSensitiveQuestion() {
+    this.isSensitiveOptions.getOptionWithValue('yes').should('not.be.checked')
+    this.isSensitiveOptions.getOptionWithValue('no').should('not.be.checked')
+  }
+
+  shouldNotShowIsSensitiveQuestion() {
+    this.isSensitiveOptions.shouldNotBeVisible()
+  }
 }

--- a/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
+++ b/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
@@ -66,9 +66,7 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
       .getValueWithLabel('Appointment date')
       .should('contain.text', GovUkFrontendDateInput.getStructuredDate(this.form, 'date', true).formattedDate)
     this.formDetails.getValueWithLabel('Notes').should('contain.text', this.form.notes)
-    this.formDetails
-      .getValueWithLabel('Sensitive')
-      .should('contain.text', this.form.isSensitive.charAt(0).toUpperCase() + this.form.isSensitive.slice(1))
+    this.shouldShowSensitiveValue(this.form.isSensitive.charAt(0).toUpperCase() + this.form.isSensitive.slice(1))
   }
 
   shouldShowAppointmentType(type: 'existing' | 'new') {
@@ -82,6 +80,10 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
 
   shouldNotShowChangeLink(label: string) {
     this.formDetails.shouldNotContainAction(label)
+  }
+
+  shouldShowSensitiveValue(value: string) {
+    this.formDetails.getValueWithLabel('Sensitive').should('contain.text', value)
   }
 
   override shouldShowErrorSummary(message: string) {

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -77,6 +77,7 @@ import providerTeamSummaryFactory from '../../../server/testutils/factories/prov
 import sessionFactory from '../../../server/testutils/factories/sessionFactory'
 import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
 import supervisorSummaryFactory from '../../../server/testutils/factories/supervisorSummaryFactory'
+import { properCase } from '../../../server/utils/utils'
 import { baseProjectAppointmentRequest } from '../../mockApis/projects'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
@@ -200,6 +201,44 @@ context('Confirm appointment details page', () => {
       page.alertPractitionerQuestion.checkOptionWithValue('yes')
       page.alertPractitionerQuestion.checkOptionWithValue('no')
       page.shouldNotShowAlertPractitionerMessage()
+    })
+  })
+
+  describe('showing sensitivity', () => {
+    it('shows appointment sensitive value if true and does not have a change link', () => {
+      const appointmentWithSensitive = appointmentFactory.build({
+        sensitive: true,
+      })
+
+      cy.task('stubFindAppointment', { appointment: appointmentWithSensitive })
+
+      const form = appointmentOutcomeFormFactory.build()
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(appointmentWithSensitive, form, '1')
+      page.shouldShowSensitiveValue('Yes')
+      page.shouldNotShowChangeLink('Sensitive')
+    })
+
+    it('shows form sensitive value if appointment sensitive value is not true', () => {
+      const appointmentWithoutSensitive = appointmentFactory.build({
+        sensitive: false,
+      })
+
+      cy.task('stubFindAppointment', { appointment: appointmentWithoutSensitive })
+
+      const form = appointmentOutcomeFormFactory.build()
+      cy.task('stubGetAppointmentForm', form)
+
+      const contactOutcomes = contactOutcomesFactory.build()
+      cy.task('stubGetContactOutcomes', { contactOutcomes })
+
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(appointmentWithoutSensitive, form, '1')
+      page.shouldShowSensitiveValue(properCase(form.isSensitive))
+      page.clickChange('Sensitive')
+      Page.verifyOnPage(AttendanceOutcomePage, appointmentWithoutSensitive)
     })
   })
 

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -95,7 +95,7 @@ context('Confirm appointment details page', () => {
     cy.task('stubSignIn')
     cy.signIn()
 
-    const appointment = appointmentFactory.build({ id: 1001 })
+    const appointment = appointmentFactory.build({ id: 1001, sensitive: undefined })
     cy.wrap(appointment).as('appointment')
   })
 

--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -62,7 +62,7 @@ context('Attendance outcome', () => {
     cy.task('stubSignIn')
     cy.signIn()
 
-    const appointment = appointmentFactory.build({ id: 1001 })
+    const appointment = appointmentFactory.build({ id: 1001, sensitive: undefined })
     cy.wrap(appointment).as('appointment')
 
     const attendedOutcome = contactOutcomeFactory.build({ attended: true })
@@ -108,6 +108,7 @@ context('Attendance outcome', () => {
     // Given I am on the attendance outcome page for an appointment in the future
     const appointmentInTheFuture = appointmentFactory.build({
       date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
+      sensitive: undefined,
     })
 
     cy.task('stubFindAppointment', { appointment: appointmentInTheFuture })
@@ -134,6 +135,7 @@ context('Attendance outcome', () => {
     // Given I am on the attendance outcome page for an appointment in the future
     const appointmentInTheFuture = appointmentFactory.build({
       date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
+      sensitive: undefined,
     })
 
     cy.task('stubFindAppointment', { appointment: appointmentInTheFuture })
@@ -211,5 +213,31 @@ context('Attendance outcome', () => {
 
     // Then I see the choose supervisor page
     Page.verifyOnPage(ChooseSupervisorPage, this.appointment)
+  })
+
+  describe('Is sensitive questions', () => {
+    it('does not show sensitivity options if appointment already has sensitive value', function test() {
+      const appointment = appointmentFactory.build({ sensitive: true })
+      cy.task('stubFindAppointment', { appointment })
+
+      // Given I am on the attendance outcome page for an appointment
+      const page = AttendanceOutcomePage.visit(appointment)
+
+      // Then I should not see the is sensitive question
+      page.notesQuestions.shouldNotShowIsSensitiveQuestion()
+    })
+
+    it('does show sensitivity options if appointment sensitive value is false', function test() {
+      const appointment = appointmentFactory.build({ sensitive: false })
+      cy.task('stubFindAppointment', { appointment })
+      const form = appointmentOutcomeFormFactory.build({ isSensitive: 'no' })
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the attendance outcome page for an appointment
+      const page = AttendanceOutcomePage.visit(appointment)
+
+      // Then I should not see the is sensitive question
+      page.notesQuestions.shouldShowIsSensitiveValue('no')
+    })
   })
 })

--- a/integration_tests/tests/courseCompletions/process/appointment.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/appointment.cy.ts
@@ -63,6 +63,7 @@ context('Appointment Page', () => {
       'stubGetCourseCompletionForm',
       courseCompletionFormFactory.build({
         crn: caseDetailsSummary.offender.crn,
+        appointmentIdToUpdate: undefined,
       }),
     )
     cy.task('stubSaveCourseCompletionForm')

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -96,6 +96,7 @@ import appointmentSummaryFactory from '../../../../server/testutils/factories/ap
 import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import UnableToCreditTimePage from '../../../pages/courseCompletions/process/unableToCreditTimePage'
 import appointmentFactory from '../../../../server/testutils/factories/appointmentFactory'
+import { properCase } from '../../../../server/utils/utils'
 
 context('Confirm details page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -173,6 +174,39 @@ context('Confirm details page', () => {
 
       // Then I can see my submitted answers
       page.shouldShowAppointmentType('new')
+    })
+  })
+
+  describe('showing sensitivity', () => {
+    it('shows appointment sensitive value if true and does not have a change link', () => {
+      const appointmentWithSensitive = appointmentFactory.build({
+        projectCode: form.project,
+        id: form.appointmentIdToUpdate,
+        sensitive: true,
+      })
+
+      cy.task('stubFindAppointment', { appointment: appointmentWithSensitive })
+
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(courseCompletion, form)
+      page.shouldShowSensitiveValue('Yes')
+      page.shouldNotShowChangeLink('Sensitive')
+    })
+
+    it('shows form sensitive value if appointment sensitive value is not true', () => {
+      const appointmentWithoutSensitive = appointmentFactory.build({
+        projectCode: form.project,
+        id: form.appointmentIdToUpdate,
+        sensitive: false,
+      })
+
+      cy.task('stubFindAppointment', { appointment: appointmentWithoutSensitive })
+
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(courseCompletion, form)
+      page.shouldShowSensitiveValue(properCase(form.isSensitive))
+      page.clickChange('Sensitive')
+      Page.verifyOnPage(OutcomePage)
     })
   })
 

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -95,6 +95,7 @@ import AppointmentPage from '../../../pages/courseCompletions/process/appointmen
 import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
 import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import UnableToCreditTimePage from '../../../pages/courseCompletions/process/unableToCreditTimePage'
+import appointmentFactory from '../../../../server/testutils/factories/appointmentFactory'
 
 context('Confirm details page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -120,6 +121,12 @@ context('Confirm details page', () => {
     fromDate: DateTimeFormats.dateObjToIsoString(new Date()),
   }
 
+  const appointment = appointmentFactory.build({
+    projectCode: project.projectCode,
+    id: form.appointmentIdToUpdate,
+    sensitive: undefined,
+  })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -133,6 +140,7 @@ context('Confirm details page', () => {
       caseDetailsSummary,
     })
     cy.task('stubGetAppointments', { request, pagedAppointments })
+    cy.task('stubFindAppointment', { appointment })
   })
 
   // Scenario: Confirming a course completion update
@@ -173,13 +181,6 @@ context('Confirm details page', () => {
     it('navigates back to the outcome page', () => {
       // Given I am on the confirm page of an in progress update
       const page = ConfirmDetailsPage.visit(courseCompletion, form)
-      cy.task(
-        'stubGetCourseCompletionForm',
-        courseCompletionFormFactory.build({
-          deliusEventNumber: upwDetails.eventNumber,
-          crn: caseDetailsSummary.offender.crn,
-        }),
-      )
 
       // And I click back
       page.clickBack()

--- a/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
@@ -23,6 +23,7 @@
 //    When I click the unable to credit time link
 //    Then I should see the unable to credit time page
 
+import appointmentFactory from '../../../../server/testutils/factories/appointmentFactory'
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
@@ -54,23 +55,30 @@ context('Outcome Page', () => {
     isSensitive: undefined,
   }
 
+  const courseCompletionForm = courseCompletionFormFactory.build({
+    ...emptyFields,
+    deliusEventNumber: upwDetails.eventNumber,
+    crn: caseDetailsSummary.offender.crn,
+  })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.signIn()
     cy.task('stubFindCourseCompletion', { courseCompletion })
-    cy.task(
-      'stubGetCourseCompletionForm',
-      courseCompletionFormFactory.build({
-        ...emptyFields,
-        deliusEventNumber: upwDetails.eventNumber,
-        crn: caseDetailsSummary.offender.crn,
-      }),
-    )
+
+    cy.task('stubGetCourseCompletionForm', courseCompletionForm)
     cy.task('stubSaveCourseCompletionForm')
     cy.task('stubGetOffenderSummary', {
       caseDetailsSummary,
     })
+    const appointment = appointmentFactory.build({
+      sensitive: undefined,
+      projectCode: courseCompletionForm.project,
+      id: courseCompletionForm.appointmentIdToUpdate,
+    })
+
+    cy.task('stubFindAppointment', { appointment })
   })
 
   // Scenario: Submitting the form
@@ -96,6 +104,7 @@ context('Outcome Page', () => {
         crn: caseDetailsSummary.offender.crn,
         project: project.projectCode,
         team: team.code,
+        appointmentIdToUpdate: undefined,
       }),
     )
     cy.task('stubGetProjects', { teamCode: team.code, providerCode, projects })
@@ -159,6 +168,7 @@ context('Outcome Page', () => {
         crn: caseDetailsSummary.offender.crn,
         project: project.projectCode,
         team: team.code,
+        appointmentIdToUpdate: undefined,
       }),
     )
     cy.task('stubGetAppointments', { request, pagedAppointments: pagedModelAppointmentSummaryFactory.build() })
@@ -189,5 +199,38 @@ context('Outcome Page', () => {
 
     // Then I should see the unable to credit time page
     Page.verifyOnPage(UnableToCreditTimePage, courseCompletion)
+  })
+
+  describe('Is sensitive questions', () => {
+    it('does not show sensitivity options if appointment already has sensitive value', function test() {
+      const appointment = appointmentFactory.build({
+        sensitive: true,
+        projectCode: courseCompletionForm.project,
+        id: courseCompletionForm.appointmentIdToUpdate,
+      })
+      cy.task('stubFindAppointment', { appointment })
+
+      // Given I am on the attendance outcome page for an appointment
+      const page = OutcomePage.visit(courseCompletion)
+
+      // Then I should not see the is sensitive question
+      page.notesQuestions.shouldNotShowIsSensitiveQuestion()
+    })
+
+    it('shows unchecked sensitivity options if no selected appointment', function test() {
+      const form = courseCompletionFormFactory.build({
+        ...emptyFields,
+        appointmentIdToUpdate: undefined,
+        deliusEventNumber: upwDetails.eventNumber,
+        crn: caseDetailsSummary.offender.crn,
+      })
+      cy.task('stubGetCourseCompletionForm', form)
+
+      // Given I am on the attendance outcome page for an appointment
+      const page = OutcomePage.visit(courseCompletion)
+
+      // Then I should not see the is sensitive question
+      page.notesQuestions.shouldShowUncheckedSensitiveQuestion()
+    })
   })
 })

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -201,6 +201,7 @@ export interface SummaryCard {
 export type ViewDataWithNotes = {
   notes?: string
   isSensitiveItems?: Array<GovUkRadioOption>
+  showIsSensitiveQuestion: boolean
 }
 
 export type ViewDataWithTimeToCredit = {

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -224,6 +224,49 @@ describe('ConfirmController', () => {
       )
     })
 
+    describe('sensitive', () => {
+      it('sends the appointment value if the appointment value is true', async () => {
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: '1', sensitive: true })
+        const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(request, response, next)
+
+        expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+          appointment.projectCode,
+          expect.objectContaining({ sensitive: true }),
+          'user-name',
+        )
+      })
+
+      it.each([false, undefined, null])(
+        'sends the form value if the appointment value is not true',
+        async (appointmentIsSensitive?: boolean) => {
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointment = appointmentFactory.build({ version: '1', sensitive: appointmentIsSensitive })
+          const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1', isSensitive: 'yes' })
+
+          appointmentService.getAppointment.mockResolvedValue(appointment)
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(request, response, next)
+
+          expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+            appointment.projectCode,
+            expect.objectContaining({ sensitive: true }),
+            'user-name',
+          )
+        },
+      )
+    })
+
     it('redirects to next page if appointment was updated elsewhere', async () => {
       const nextPath = 'next'
       confirmPageMock.mockImplementationOnce(() => {

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -55,7 +55,7 @@ export default class ConfirmController {
       const didAttend = form.contactOutcome.attended
 
       const payload: UpdateAppointmentOutcomeDto = {
-        ...NotesUtils.requestBody(form),
+        ...NotesUtils.requestBody(form, appointment.sensitive),
         deliusId: appointment.id,
         deliusVersionToUpdate: appointment.version,
         alertActive: page.isAlertSelected ?? appointment.alertActive,

--- a/server/controllers/courseCompletions/process/confirmController.test.ts
+++ b/server/controllers/courseCompletions/process/confirmController.test.ts
@@ -190,7 +190,7 @@ describe('ConfirmController', () => {
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
       const query = { pdu: '2', form: '1' }
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query, body: {} })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)
@@ -200,6 +200,8 @@ describe('ConfirmController', () => {
       )
       expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
       expect(request.flash).toHaveBeenCalledWith('success', successMessage)
+      expect(appointmentService.getAppointment).not.toHaveBeenCalled()
+      expect(page.requestBody).toHaveBeenCalledWith(form, {}, undefined)
     })
 
     it('redirects to the index page if no original search', async () => {
@@ -264,5 +266,33 @@ describe('ConfirmController', () => {
 
       expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(request, response, error, path)
     })
+
+    it.each([true, false, undefined])(
+      'fetches any selected appointment and passes the sensitive value to the requestBody method',
+      async (appointmentIsSensitive?: boolean) => {
+        const appointment = appointmentFactory.build({ sensitive: appointmentIsSensitive })
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        form = courseCompletionFormFactory.build({ appointmentIdToUpdate: 1 })
+        formService.getForm.mockResolvedValue(form)
+
+        const resolution = courseCompletionResolutionFactory.build()
+        const successMessage = 'Success'
+        page.requestBody.mockReturnValue(resolution)
+        page.successMessage.mockReturnValue(successMessage)
+        const query = { pdu: '2', form: '1' }
+        const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query, body: {} })
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          pathWithQuery(paths.courseCompletions.search({}), form.originalSearch),
+        )
+        expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
+        expect(request.flash).toHaveBeenCalledWith('success', successMessage)
+
+        expect(page.requestBody).toHaveBeenCalledWith(form, {}, appointmentIsSensitive)
+      },
+    )
   })
 })

--- a/server/controllers/courseCompletions/process/confirmController.test.ts
+++ b/server/controllers/courseCompletions/process/confirmController.test.ts
@@ -20,6 +20,7 @@ import * as ErrorUtils from '../../../utils/errorUtils'
 import AppointmentService from '../../../services/appointmentService'
 import pagedModelAppointmentSummaryFactory from '../../../testutils/factories/pagedModelAppointmentSummaryFactory'
 import { pathWithQuery } from '../../../utils/utils'
+import appointmentFactory from '../../../testutils/factories/appointmentFactory'
 
 describe('ConfirmController', () => {
   const username = 'username'
@@ -35,7 +36,7 @@ describe('ConfirmController', () => {
   const appointmentService = createMock<AppointmentService>()
 
   const courseCompletion = courseCompletionFactory.build()
-  let form = courseCompletionFormFactory.build()
+  let form = courseCompletionFormFactory.build({ appointmentIdToUpdate: undefined })
   const teamsResponse = { providers: providerTeamSummaryFactory.buildList(2) }
   const projectsResponse = pagedModelProjectOutcomeSummaryFactory.build()
   const offenderResponse = caseDetailsSummaryFactory.build()
@@ -101,6 +102,65 @@ describe('ConfirmController', () => {
         alertPractitionerItems,
       })
       expect(formService.getForm).toHaveBeenCalledTimes(1)
+      expect(page.appointmentItems).toHaveBeenCalledWith({
+        courseCompletionId: '1',
+        form,
+        formId: '12',
+        teams: teamsResponse.providers,
+        projects: projectsResponse.content,
+        canChangeAppointment: true,
+      })
+    })
+
+    it('fetch selected appointment and pass it to the page method', async () => {
+      const viewData = {
+        backLink: '/back',
+        updatePath: '/update',
+        communityCampusPerson: { name: 'Mary Smith' },
+        courseName: 'Customer service',
+        unableToCreditTimePath: '/unable-to-credit-time',
+      }
+      page.viewData.mockReturnValue(viewData)
+
+      const personItems = [
+        { key: { text: 'CRN' }, value: { text: 'some crn' } },
+        { key: { text: 'Requirement' }, value: { text: 'requirement data' } },
+      ]
+
+      const appointmentItems = [
+        { key: { text: 'Project team' }, value: { text: 'Some project team' } },
+        { key: { text: 'Project' }, value: { text: 'Some project' } },
+      ]
+      page.personItems.mockReturnValue(personItems)
+      page.appointmentItems.mockReturnValue(appointmentItems)
+
+      const alertPractitionerItems = [{ text: 'Yes', value: 'yes' }]
+      jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(alertPractitionerItems)
+
+      const appointment = appointmentFactory.build()
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      const formWithAppointment = courseCompletionFormFactory.build({ appointmentIdToUpdate: 1 })
+      formService.getForm.mockResolvedValue(formWithAppointment)
+      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query: { form: '12' } })
+
+      const requestHandler = confirmController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(templatePath, {
+        ...viewData,
+        personItems,
+        appointmentItems,
+        alertPractitionerItems,
+      })
+      expect(page.appointmentItems).toHaveBeenCalledWith({
+        courseCompletionId: '1',
+        form: formWithAppointment,
+        formId: '12',
+        teams: teamsResponse.providers,
+        projects: projectsResponse.content,
+        canChangeAppointment: true,
+        appointment,
+      })
     })
 
     it('should render the page with errorList when errorMessages are present', async () => {

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -38,7 +38,15 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
         crn: formData.crn,
       })
 
-      const payload = this.page.requestBody(formData, req.body)
+      const appointment = formData.appointmentIdToUpdate
+        ? await this.appointmentService.getAppointment({
+            appointmentId: formData.appointmentIdToUpdate?.toString(),
+            projectCode: formData.project,
+            username: res.locals.user.username,
+          })
+        : undefined
+
+      const payload = this.page.requestBody(formData, req.body, appointment?.sensitive)
 
       try {
         await this.courseCompletionService.saveResolution(

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -89,6 +89,14 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
       fromDate: DateTimeFormats.dateObjToIsoString(new Date()),
     })
 
+    const appointment = formData.appointmentIdToUpdate
+      ? await this.appointmentService.getAppointment({
+          appointmentId: formData.appointmentIdToUpdate?.toString(),
+          projectCode: formData.project,
+          username: res.locals.user.username,
+        })
+      : undefined
+
     const personItems = this.page.personItems({
       courseCompletionId: req.params.id,
       form: formData,
@@ -103,6 +111,7 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
       teams: teams.providers,
       projects,
       canChangeAppointment: appointments.content.length > 0,
+      appointment,
     })
 
     const alertPractitionerItems = GovUkRadioGroup.yesNoItems({})

--- a/server/controllers/courseCompletions/process/index.ts
+++ b/server/controllers/courseCompletions/process/index.ts
@@ -68,6 +68,7 @@ const controllers = (services: Services) => {
     courseCompletionService,
     courseCompletionFormService,
     offenderService,
+    appointmentService,
   )
   const projectController = new ProjectController(
     new ProjectPage(),

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -11,8 +11,10 @@ import CourseCompletionUtils from '../../../utils/courseCompletionUtils'
 import OffenderService from '../../../services/offenderService'
 import unpaidWorkDetailsFactory from '../../../testutils/factories/unpaidWorkDetailsFactory'
 import offenderFullFactory from '../../../testutils/factories/offenderFullFactory'
+import appointmentFactory from '../../../testutils/factories/appointmentFactory'
 import NotesUtils from '../../../utils/notesUtils'
 import { YesOrNo } from '../../../@types/user-defined'
+import AppointmentService from '../../../services/appointmentService'
 
 describe('OutcomeController', () => {
   const username = 'username'
@@ -23,6 +25,7 @@ describe('OutcomeController', () => {
   const courseCompletionService = createMock<CourseCompletionService>()
   const formService = createMock<CourseCompletionFormService>()
   const offenderService = createMock<OffenderService>()
+  const appointmentService = createMock<AppointmentService>()
   const courseCompletion = courseCompletionFactory.build()
   const unpaidWorkDetails = unpaidWorkDetailsFactory.buildList(2)
 
@@ -44,10 +47,18 @@ describe('OutcomeController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    outcomeController = new OutcomeController(page, courseCompletionService, formService, offenderService)
+    outcomeController = new OutcomeController(
+      page,
+      courseCompletionService,
+      formService,
+      offenderService,
+      appointmentService,
+    )
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue({})
-    jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: undefined, isSensitiveItems: [] })
+    jest
+      .spyOn(NotesUtils, 'questionItems')
+      .mockReturnValue({ notes: undefined, isSensitiveItems: [], showIsSensitiveQuestion: false })
     jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue([])
     jest.spyOn(CourseCompletionUtils, 'formattedCourseDetails').mockReturnValue(courseDetailsItems)
 
@@ -83,6 +94,7 @@ describe('OutcomeController', () => {
         dateItems: [],
         notes: undefined,
         isSensitiveItems: [],
+        showIsSensitiveQuestion: false,
         courseDetailsItems,
         requirementDetailsItems,
       })
@@ -96,7 +108,7 @@ describe('OutcomeController', () => {
       const showPath = '/show'
       const formId = '12'
       const timeToCredit = { hours: '1', minutes: '30' }
-      const form = courseCompletionFormFactory.build({ timeToCredit })
+      const form = courseCompletionFormFactory.build({ timeToCredit, appointmentIdToUpdate: undefined })
       formService.getForm.mockResolvedValue(form)
       const dateItems = [
         { name: 'day', classes: '', value: '01' },
@@ -104,7 +116,8 @@ describe('OutcomeController', () => {
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
       const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
-      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ isSensitiveItems, notes: form.notes })
+      const notesItems = { isSensitiveItems, notes: form.notes, showIsSensitiveQuestion: true }
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const viewData = {
         backLink: '/back',
@@ -122,10 +135,9 @@ describe('OutcomeController', () => {
 
       expect(response.render).toHaveBeenCalledWith(templatePath, {
         ...viewData,
+        ...notesItems,
         timeToCredit,
         dateItems,
-        isSensitiveItems,
-        notes: form.notes,
         courseDetailsItems,
         requirementDetailsItems,
       })
@@ -139,7 +151,42 @@ describe('OutcomeController', () => {
         false,
       )
 
-      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, form)
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, form, undefined)
+    })
+
+    it('fetches appointment if form has appointmentIdToUpdate', async () => {
+      const appointmentId = 123
+      const projectCode = 'PROJECT123'
+      const form = courseCompletionFormFactory.build({
+        appointmentIdToUpdate: appointmentId,
+        project: projectCode,
+      })
+      formService.getForm.mockResolvedValue(form)
+
+      const appointment = appointmentFactory.build({ sensitive: true })
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+
+      const viewData = {
+        backLink: '/back',
+        updatePath: '/update',
+        communityCampusPerson: { name: 'Mary Smith' },
+        courseName: 'Customer service',
+        unableToCreditTimePath: '/unable-to-credit-time',
+      }
+      page.viewData.mockReturnValue(viewData)
+
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: '12' }, body: {} })
+
+      const requestHandler = outcomeController.show()
+      await requestHandler(request, response, next)
+
+      expect(appointmentService.getAppointment).toHaveBeenCalledWith({
+        projectCode,
+        appointmentId: appointmentId.toString(),
+        username,
+      })
+
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, form, appointment)
     })
   })
 
@@ -162,7 +209,7 @@ describe('OutcomeController', () => {
     it('rerenders page if validation errors', async () => {
       const crn = 'some-crn'
       const deliusEventNumber = 1
-      formService.getForm.mockResolvedValue({ crn, deliusEventNumber })
+      formService.getForm.mockResolvedValue({ crn, deliusEventNumber, appointmentIdToUpdate: undefined })
       const viewData = {
         backLink: '/back',
         updatePath: '/update',
@@ -196,6 +243,7 @@ describe('OutcomeController', () => {
         notes: undefined,
         courseDetailsItems,
         requirementDetailsItems,
+        showIsSensitiveQuestion: false,
       })
       expect(formService.getForm).toHaveBeenCalledTimes(1)
       expect(CourseCompletionUtils.formattedCourseDetails).toHaveBeenCalledWith(courseCompletion)
@@ -220,7 +268,7 @@ describe('OutcomeController', () => {
       page.updatePath.mockReturnValue(showPath)
 
       const timeToCredit = { hours: '1', minutes: '30' }
-      const form = courseCompletionFormFactory.build({ timeToCredit })
+      const form = courseCompletionFormFactory.build({ timeToCredit, appointmentIdToUpdate: undefined })
       formService.getForm.mockResolvedValue(form)
 
       const errorSummary = [
@@ -237,7 +285,12 @@ describe('OutcomeController', () => {
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
       const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: false }]
-      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: 'some', isSensitiveItems })
+      const notesItems = {
+        notes: 'some',
+        isSensitiveItems,
+        showIsSensitiveQuestion: true,
+      }
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const body = { team: teamCode }
       const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body })
@@ -247,12 +300,11 @@ describe('OutcomeController', () => {
 
       expect(response.render).toHaveBeenCalledWith(templatePath, {
         ...viewData,
+        ...notesItems,
         errors,
         errorSummary,
         timeToCredit,
         dateItems,
-        notes: 'some',
-        isSensitiveItems,
         courseDetailsItems,
         requirementDetailsItems,
       })
@@ -266,11 +318,11 @@ describe('OutcomeController', () => {
         true,
       )
 
-      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form)
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form, undefined)
     })
 
     it('uses values from request body over form data', async () => {
-      const form = courseCompletionFormFactory.build()
+      const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: undefined })
       formService.getForm.mockResolvedValue(form)
       const formId = '12'
       const notes = 'some note'
@@ -298,7 +350,13 @@ describe('OutcomeController', () => {
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
       const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
-      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes, isSensitiveItems })
+      const notesItems = {
+        notes,
+        isSensitiveItems,
+        showIsSensitiveQuestion: true,
+        isSensitiveValue: undefined as YesOrNo,
+      }
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const body = {
         'date-day': '25',
@@ -320,12 +378,11 @@ describe('OutcomeController', () => {
 
       expect(response.render).toHaveBeenCalledWith(templatePath, {
         ...viewData,
+        ...notesItems,
         timeToCredit: { hours: body.hours, minutes: body.minutes },
         errorSummary,
         errors,
         dateItems,
-        isSensitiveItems,
-        notes: body.notes,
         courseDetailsItems,
         requirementDetailsItems,
       })
@@ -337,7 +394,7 @@ describe('OutcomeController', () => {
         },
         true,
       )
-      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form)
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form, undefined)
     })
   })
 })

--- a/server/controllers/courseCompletions/process/outcomeController.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.ts
@@ -8,6 +8,7 @@ import CourseCompletionUtils, { CourseDetails } from '../../../utils/courseCompl
 import { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import OffenderService from '../../../services/offenderService'
 import NotesUtils from '../../../utils/notesUtils'
+import AppointmentService from '../../../services/appointmentService'
 
 type ViewData = {
   dateItems: Array<GovUkFrontendDateInputItem>
@@ -22,6 +23,7 @@ export default class OutcomeController extends BaseController<OutcomePage> {
     courseCompletionService: CourseCompletionService,
     formService: CourseCompletionFormService,
     private readonly offenderService: OffenderService,
+    private readonly appointmentService: AppointmentService,
   ) {
     super(page, courseCompletionService, formService)
   }
@@ -33,6 +35,13 @@ export default class OutcomeController extends BaseController<OutcomePage> {
     errors,
     courseCompletion,
   }: StepViewDataParams): Promise<ViewData> {
+    const appointment = formData.appointmentIdToUpdate
+      ? await this.appointmentService.getAppointment({
+          projectCode: formData.project,
+          appointmentId: formData.appointmentIdToUpdate?.toString(),
+          username: res.locals.user.username,
+        })
+      : undefined
     const timeToCredit = {
       hours: this.getPropertyValue({ propertyName: 'hours', req, formData: formData.timeToCredit ?? {} }),
       minutes: this.getPropertyValue({ propertyName: 'minutes', req, formData: formData.timeToCredit ?? {} }),
@@ -55,7 +64,7 @@ export default class OutcomeController extends BaseController<OutcomePage> {
     const requirementDetailsItems = this.page.requirementDetailsItems(unpaidWorkDetails, formData.deliusEventNumber)
 
     return {
-      ...NotesUtils.questionItems(req.body ?? {}, formData),
+      ...NotesUtils.questionItems(req.body ?? {}, formData, appointment),
       timeToCredit,
       dateItems,
       courseDetailsItems,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../models/offender')
 
 describe('AttendanceOutcomePage', () => {
   const { contactOutcomes } = contactOutcomesFactory.build()
-  const appointment = appointmentFactory.build()
+  const appointment = appointmentFactory.build({ sensitive: undefined })
 
   const pathWithQuery = '/path?'
 
@@ -258,6 +258,7 @@ describe('AttendanceOutcomePage', () => {
         backLink: pathWithQuery,
         notes: 'Test notes',
         isSensitiveItems: expectedSensitiveItems,
+        showIsSensitiveQuestion: true,
       })
     })
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -86,7 +86,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
     return {
       ...this.commonViewData(this.appointment),
-      ...NotesUtils.questionItems(this.query, form),
+      ...NotesUtils.questionItems(this.query, form, this.appointment),
       items: this.items(form, hasErrors),
     }
   }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -27,7 +27,7 @@ describe('ConfirmPage', () => {
 
     beforeEach(() => {
       page = new ConfirmPage({})
-      appointment = appointmentFactory.build()
+      appointment = appointmentFactory.build({ sensitive: false })
       form = appointmentOutcomeFormFactory.build()
       jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
     })

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -148,6 +148,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       ...NotesUtils.checkYourAnswersRows(
         form,
         this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
+        appointment,
       ),
       {
         key: {

--- a/server/pages/courseCompletions/process/confirmPage.test.ts
+++ b/server/pages/courseCompletions/process/confirmPage.test.ts
@@ -1236,6 +1236,12 @@ describe('ConfirmPage', () => {
   })
 
   describe('requestBody', () => {
+    const date = '2026-03-30'
+
+    beforeEach(() => {
+      jest.spyOn(DateTimeFormats, 'dateAndTimeInputsToIsoString').mockReturnValue({ date })
+      jest.spyOn(GovUkRadioGroup, 'nullableValueFromYesOrNoItem').mockImplementation(value => value === 'yes')
+    })
     it('should build a CourseCompletionResolutionDto with CREDIT_TIME type', () => {
       const form = courseCompletionFormFactory.build({
         appointmentIdToUpdate: undefined,
@@ -1253,10 +1259,7 @@ describe('ConfirmPage', () => {
         alertPractitioner: 'yes' as YesOrNo,
       }
 
-      const date = '2026-03-30'
-      jest.spyOn(DateTimeFormats, 'dateAndTimeInputsToIsoString').mockReturnValue({ date })
       jest.spyOn(DateTimeFormats, 'hoursAndMinutesToMinutes').mockReturnValue(150)
-      jest.spyOn(GovUkRadioGroup, 'nullableValueFromYesOrNoItem').mockImplementation(value => value === 'yes')
       const result = page.requestBody(form, body)
 
       expect(result).toEqual({
@@ -1280,9 +1283,6 @@ describe('ConfirmPage', () => {
     })
 
     it('should include appointmentIdToUpdate if provided', () => {
-      const date = '2026-03-30'
-      jest.spyOn(DateTimeFormats, 'dateAndTimeInputsToIsoString').mockReturnValue({ date })
-
       const form = courseCompletionFormFactory.build({ appointmentIdToUpdate: 12 })
       const result = page.requestBody(form, {})
 

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -126,12 +126,16 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
     ]
   }
 
-  requestBody(formData: CourseCompletionForm, body: Body): CourseCompletionResolutionDto {
+  requestBody(
+    formData: CourseCompletionForm,
+    body: Body,
+    appointmentIsSensitive?: boolean,
+  ): CourseCompletionResolutionDto {
     return {
       type: 'CREDIT_TIME',
       crn: formData.crn,
       creditTimeDetails: {
-        ...NotesUtils.requestBody(formData),
+        ...NotesUtils.requestBody(formData, appointmentIsSensitive),
         appointmentIdToUpdate: formData.appointmentIdToUpdate,
         deliusEventNumber: formData.deliusEventNumber,
         date: DateTimeFormats.dateAndTimeInputsToIsoString(formData, 'date').date,

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -1,4 +1,5 @@
 import {
+  AppointmentDto,
   CourseCompletionResolutionDto,
   ProjectOutcomeSummaryDto,
   ProviderTeamSummaryDto,
@@ -33,6 +34,7 @@ interface AppointmentItems {
   teams?: ProviderTeamSummaryDto[]
   projects?: ProjectOutcomeSummaryDto[]
   canChangeAppointment: boolean
+  appointment?: AppointmentDto
 }
 
 export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
@@ -108,6 +110,7 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
     teams,
     projects,
     canChangeAppointment,
+    appointment,
   }: AppointmentItems): GovUkSummaryListItem[] {
     return [
       this.teamRow(form, courseCompletionId, formId, teams),
@@ -118,6 +121,7 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
       ...NotesUtils.checkYourAnswersRows(
         form,
         this.pathWithFormId(paths.courseCompletions.process({ page: 'outcome', id: courseCompletionId }), formId),
+        appointment,
       ),
     ]
   }

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -248,6 +248,50 @@ describe('NotesUtils', () => {
         },
       })
     })
+
+    it('should return sensitive row with empty actions when appointment is sensitive', () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+      const appointment = appointmentFactory.build({ sensitive: true })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
+
+      expect(result[1]).toEqual({
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: 'Yes',
+        },
+        actions: {
+          items: [],
+        },
+      })
+    })
+
+    it('should return sensitive row with action items when appointment is not sensitive', () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+      const appointment = appointmentFactory.build({ sensitive: false })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
+
+      expect(result[1]).toEqual({
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: 'No',
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ],
+        },
+      })
+    })
   })
 
   describe('formData', () => {

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -119,7 +119,7 @@ describe('NotesUtils', () => {
         expect(result.showIsSensitiveQuestion).toBe(true)
         expect(result.isSensitiveItems).toEqual([
           { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: false, text: 'No, they are not sensitive', value: 'no' },
+          { checked: true, text: 'No, they are not sensitive', value: 'no' },
         ])
       })
     })

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -308,15 +308,24 @@ describe('NotesUtils', () => {
   })
 
   describe('requestBody', () => {
-    it('should include form sensitive value ', () => {
-      const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
-      const result = NotesUtils.requestBody(form)
+    it('should include sensitive value of true if appointment sensitive value is true', () => {
+      const form = courseCompletionFormFactory.build()
+      const result = NotesUtils.requestBody(form, true)
       expect(result.sensitive).toBe(true)
     })
 
+    it.each([false, undefined, null])(
+      'should include form sensitive value if appointment sensitive value is not true',
+      (appointmentIsSensitive?: boolean) => {
+        const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+        const result = NotesUtils.requestBody(form, appointmentIsSensitive)
+        expect(result.sensitive).toBe(true)
+      },
+    )
+
     it('should include form notes value', () => {
       const form = courseCompletionFormFactory.build()
-      const result = NotesUtils.requestBody(form)
+      const result = NotesUtils.requestBody(form, true)
       expect(result.notes).toBe(form.notes)
     })
   })

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -1,4 +1,5 @@
 import { YesOrNo } from '../@types/user-defined'
+import appointmentFactory from '../testutils/factories/appointmentFactory'
 import courseCompletionFormFactory from '../testutils/factories/courseCompletionFormFactory'
 import NotesUtils from './notesUtils'
 
@@ -94,6 +95,32 @@ describe('NotesUtils', () => {
         ]
 
         expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+      })
+    })
+
+    describe('with appointment parameter', () => {
+      it('should return only showIsSensitiveQuestion false when appointment is sensitive', () => {
+        const form = courseCompletionFormFactory.build()
+        const appointment = appointmentFactory.build({ sensitive: true })
+
+        const result = NotesUtils.questionItems({}, form, appointment)
+
+        expect(result.showIsSensitiveQuestion).toBe(false)
+        expect(result.isSensitiveItems).toBeUndefined()
+      })
+
+      it('should return isSensitiveItems when appointment is not sensitive', () => {
+        const query = courseCompletionFormFactory.build({ isSensitive: undefined })
+        const form = courseCompletionFormFactory.build({ isSensitive: undefined })
+        const appointment = appointmentFactory.build({ sensitive: false })
+
+        const result = NotesUtils.questionItems(query, form, appointment)
+
+        expect(result.showIsSensitiveQuestion).toBe(true)
+        expect(result.isSensitiveItems).toEqual([
+          { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
+          { checked: false, text: 'No, they are not sensitive', value: 'no' },
+        ])
       })
     })
   })

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -292,6 +292,28 @@ describe('NotesUtils', () => {
         },
       })
     })
+
+    it("should return sensitive row displaying 'Yes' when appointment is sensitive true", () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+      const appointment = appointmentFactory.build({ sensitive: true })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
+
+      expect(result[1].value).toEqual({
+        text: 'Yes',
+      })
+    })
+
+    it("should return sensitive row displaying 'Yes' when appointment is not sensitive and form is 'yes'", () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+      const appointment = appointmentFactory.build({ sensitive: false })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
+
+      expect(result[1].value).toEqual({
+        text: 'Yes',
+      })
+    })
   })
 
   describe('formData', () => {

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -1,4 +1,5 @@
-import { BodyWithNotes, GovUkSummaryListItem, YesOrNo } from '../@types/user-defined'
+import { AppointmentDto } from '../@types/shared'
+import { BodyWithNotes, GovUkSummaryListItem, ViewDataWithNotes, YesOrNo } from '../@types/user-defined'
 import GovUkRadioGroup from '../forms/GovUkRadioGroup'
 import { properCase } from './utils'
 
@@ -53,12 +54,23 @@ export default class NotesUtils {
     ]
   }
 
-  static questionItems(query: BodyWithNotes, form: BodyWithNotes) {
-    const sensitive = query.isSensitive ?? form.isSensitive
+  static questionItems(query: BodyWithNotes, form: BodyWithNotes, appointment?: AppointmentDto): ViewDataWithNotes {
+    const notes = query.notes ?? form.notes
+    const showIsSensitiveQuestion = appointment?.sensitive !== true
+
+    if (showIsSensitiveQuestion) {
+      const sensitive = query.isSensitive ?? form.isSensitive
+
+      return {
+        notes,
+        showIsSensitiveQuestion,
+        isSensitiveItems: this.isSensitiveItems(sensitive),
+      }
+    }
 
     return {
-      notes: query.notes ?? form.notes,
-      isSensitiveItems: this.isSensitiveItems(sensitive),
+      notes,
+      showIsSensitiveQuestion,
     }
   }
 

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -54,13 +54,21 @@ export default class NotesUtils {
           text: 'Sensitive',
         },
         value: {
-          text: form.isSensitive ? properCase(form.isSensitive) : 'Not entered',
+          text: NotesUtils.getIsSensitiveAnswer(form, appointment),
         },
         actions: {
           items: isSensitiveActions,
         },
       },
     ]
+  }
+
+  private static getIsSensitiveAnswer(form: BodyWithNotes, appointment?: AppointmentDto): string {
+    if (appointment?.sensitive === true) {
+      return 'Yes'
+    }
+
+    return form.isSensitive ? properCase(form.isSensitive) : 'Not entered'
   }
 
   static questionItems(query: BodyWithNotes, form: BodyWithNotes, appointment?: AppointmentDto): ViewDataWithNotes {

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -8,10 +8,11 @@ export default class NotesUtils {
     return { notes: query.notes, isSensitive: query.isSensitive }
   }
 
-  static requestBody(form: BodyWithNotes) {
+  static requestBody(form: BodyWithNotes, appointmentIsSensitive?: boolean) {
     return {
       notes: form.notes,
-      sensitive: GovUkRadioGroup.nullableValueFromYesOrNoItem(form.isSensitive),
+      sensitive:
+        appointmentIsSensitive === true ? true : GovUkRadioGroup.nullableValueFromYesOrNoItem(form.isSensitive),
     }
   }
 

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -15,7 +15,21 @@ export default class NotesUtils {
     }
   }
 
-  static checkYourAnswersRows(form: BodyWithNotes, changePath: string): Array<GovUkSummaryListItem> {
+  static checkYourAnswersRows(
+    form: BodyWithNotes,
+    changePath: string,
+    appointment?: AppointmentDto,
+  ): Array<GovUkSummaryListItem> {
+    const isSensitiveActions =
+      appointment?.sensitive === true
+        ? []
+        : [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ]
     return [
       {
         key: {
@@ -42,13 +56,7 @@ export default class NotesUtils {
           text: form.isSensitive ? properCase(form.isSensitive) : 'Not entered',
         },
         actions: {
-          items: [
-            {
-              href: changePath,
-              text: 'Change',
-              visuallyHiddenText: 'sensitivity',
-            },
-          ],
+          items: isSensitiveActions,
         },
       },
     ]

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -59,7 +59,8 @@ export default class NotesUtils {
     const showIsSensitiveQuestion = appointment?.sensitive !== true
 
     if (showIsSensitiveQuestion) {
-      const sensitive = query.isSensitive ?? form.isSensitive
+      const sensitive =
+        query.isSensitive ?? form.isSensitive ?? GovUkRadioGroup.determineCheckedValue(appointment?.sensitive)
 
       return {
         notes,

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -12,18 +12,19 @@
     isPageHeading: false
   }
 }) }}
-
-{{ govukRadios({
-  name: 'isSensitive',
-  fieldset: {
-    legend: {
-      text: 'Do these notes include sensitive information?',
-      classes: 'govuk-fieldset__legend--s',
-      isPageHeading: false
-    }
-  },
-  hint: {
-    text: 'This is information that you believe must be recorded but not shared with a person on probation. If they make a request for their record, the Data Protection Team will decide whether the information can be shared.'
-  },
-  items: isSensitiveItems
-}) }}
+{% if showIsSensitiveQuestion %}
+  {{ govukRadios({
+    name: 'isSensitive',
+    fieldset: {
+      legend: {
+        text: 'Do these notes include sensitive information?',
+        classes: 'govuk-fieldset__legend--s',
+        isPageHeading: false
+      }
+    },
+    hint: {
+      text: 'This is information that you believe must be recorded but not shared with a person on probation. If they make a request for their record, the Data Protection Team will decide whether the information can be shared.'
+    },
+    items: isSensitiveItems
+  }) }}
+{% endif %}


### PR DESCRIPTION
## Context

A user should not be able to mark an appointment as non-sensitive after it has previously been marked as sensitive.
[CPB-912](https://dsdmoj.atlassian.net/browse/CPB-912)

## Changes in this PR

If the appointment has a value of `sensitive=true`
- Hide the “is sensitive” question next to notes
- Ensure the appointment is saved with the original sensitive value 
- Show appointment value on confirm details page, and remove the change link

**Note:** We are likely to add some content to explain that the appointment is sensitive alongside the notes question, we will add this later.

Otherwise:
- Show the 'is sensitive question' next to notes
- Show and save the user entered value with the appointment update
- Allow the user to change their answer via change link


### Screenshots of UI changes

#### Update appointment journey

##### Appointments with `sensitive=true`


https://github.com/user-attachments/assets/fc2c3c5d-f4a2-47e6-b41c-09ff682ab965


##### Appointments which are not sensitive


https://github.com/user-attachments/assets/80d8a948-6666-45bd-84a8-05c4c3bd2613

#### Course completion

##### Appointments with `sensitive=true`

https://github.com/user-attachments/assets/f1823ff1-75bc-4849-b9b7-05b2703d10ba


#### Appointments which are not sensitive




https://github.com/user-attachments/assets/cc54c6ed-9ddd-4228-be69-d8381a5e3695





## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-912]: https://dsdmoj.atlassian.net/browse/CPB-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ