### PR TITLE
CPB-912: Refactor notes questions

### DIFF
--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -115,6 +115,7 @@ context('Confirm appointment details page', () => {
         attended: true,
       }),
       notes: 'Test',
+      isSensitive: undefined,
     })
 
     // Given I am on the confirm page of an in progress update
@@ -141,7 +142,7 @@ context('Confirm appointment details page', () => {
       contactOutcome: contactOutcomeFactory.build({
         attended: false,
       }),
-      sensitive: null,
+      isSensitive: undefined,
     })
 
     // Given I am on the confirm page of an in progress update
@@ -333,7 +334,7 @@ context('Confirm appointment details page', () => {
     it('navigates back to the log attendance page via sensitive section', function test() {
       const notes = 'Test note'
       const contactOutcome = contactOutcomeFactory.build({ attended: true })
-      const form = appointmentOutcomeFormFactory.build({ contactOutcome, notes, sensitive: true })
+      const form = appointmentOutcomeFormFactory.build({ contactOutcome, notes, isSensitive: 'yes' })
 
       // Given I am on the confirm page of an in progress update
       cy.task('stubFindAppointment', { appointment: this.appointment })

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -28,12 +28,10 @@ export type AppointmentOutcomeForm = {
   endTime: string
   contactOutcome?: ContactOutcomeDto
   supervisor?: SupervisorSummaryDto
-  notes?: string
   attendanceData?: AttendanceDataDto
   enforcement?: EnforcementOutcomeForm
-  sensitive?: boolean
   originalSearch: Record<string, string>
-}
+} & BodyWithNotes
 
 export interface BaseRequest {
   username: string

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -2,14 +2,14 @@ import type { Response } from 'express'
 import { AttendanceDataDto, ContactOutcomeDto, SupervisorSummaryDto, ProjectTypeDto } from '../shared'
 import ReferenceDataService from '../../services/referenceDataService'
 
-export interface AppointmentUpdatePageViewData {
+export type AppointmentUpdatePageViewData = {
   backLink: string
   offender: Offender
   updatePath: string
   form?: string
 }
 
-export interface AppointmentUpdateQuery {
+export type AppointmentUpdateQuery = {
   form?: string
 }
 
@@ -201,10 +201,15 @@ export interface SummaryCard {
 }
 
 export type ViewDataWithNotes = {
-  notes: string
-  isSensitiveItems: Array<GovUkRadioOption>
+  notes?: string
+  isSensitiveItems?: Array<GovUkRadioOption>
 }
 
 export type ViewDataWithTimeToCredit = {
   timeToCredit: { hours: string; minutes: string }
+}
+
+export type BodyWithNotes = {
+  notes?: string
+  isSensitive?: YesOrNo
 }

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -115,7 +115,7 @@ describe('ConfirmController', () => {
       const form = appointmentOutcomeFormFactory.build({
         contactOutcome,
         deliusVersion: formAppointmentVersion,
-        sensitive: true,
+        isSensitive: 'yes',
       })
 
       appointmentService.getAppointment.mockResolvedValue(appointment)
@@ -130,7 +130,7 @@ describe('ConfirmController', () => {
           deliusId: appointment.id,
           deliusVersionToUpdate: appointment.version,
           alertActive: true,
-          sensitive: form.sensitive,
+          sensitive: true,
           startTime: form.startTime,
           endTime: form.endTime,
           contactOutcomeCode: form.contactOutcome.code,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -6,6 +6,7 @@ import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared
 import { AppointmentOutcomeForm, AppointmentParams } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
+import NotesUtils from '../../utils/notesUtils'
 
 export default class ConfirmController {
   constructor(
@@ -54,16 +55,15 @@ export default class ConfirmController {
       const didAttend = form.contactOutcome.attended
 
       const payload: UpdateAppointmentOutcomeDto = {
+        ...NotesUtils.requestBody(form),
         deliusId: appointment.id,
         deliusVersionToUpdate: appointment.version,
         alertActive: page.isAlertSelected ?? appointment.alertActive,
-        sensitive: form.sensitive,
         startTime: form.startTime,
         endTime: form.endTime,
         contactOutcomeCode: form.contactOutcome.code,
         attendanceData: didAttend ? form.attendanceData : undefined,
         supervisorOfficerCode: form.supervisor.code,
-        notes: form.notes,
         date: appointment.date,
       }
 

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -7,11 +7,12 @@ import courseCompletionFactory from '../../../testutils/factories/courseCompleti
 import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
 import GovukFrontendDateInput from '../../../forms/GovukFrontendDateInput'
-import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
 import CourseCompletionUtils from '../../../utils/courseCompletionUtils'
 import OffenderService from '../../../services/offenderService'
 import unpaidWorkDetailsFactory from '../../../testutils/factories/unpaidWorkDetailsFactory'
 import offenderFullFactory from '../../../testutils/factories/offenderFullFactory'
+import NotesUtils from '../../../utils/notesUtils'
+import { YesOrNo } from '../../../@types/user-defined'
 
 describe('OutcomeController', () => {
   const username = 'username'
@@ -46,7 +47,7 @@ describe('OutcomeController', () => {
     outcomeController = new OutcomeController(page, courseCompletionService, formService, offenderService)
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue({})
-    jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue([])
+    jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: undefined, isSensitiveItems: [] })
     jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue([])
     jest.spyOn(CourseCompletionUtils, 'formattedCourseDetails').mockReturnValue(courseDetailsItems)
 
@@ -102,8 +103,8 @@ describe('OutcomeController', () => {
         { name: 'month', classes: '', value: '02' },
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' }]
-      jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(isSensitiveItems)
+      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ isSensitiveItems, notes: form.notes })
 
       const viewData = {
         backLink: '/back',
@@ -138,7 +139,7 @@ describe('OutcomeController', () => {
         false,
       )
 
-      expect(GovUkRadioGroup.yesNoItems).toHaveBeenCalledWith({ checkedValue: form.isSensitive })
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, form)
     })
   })
 
@@ -200,7 +201,6 @@ describe('OutcomeController', () => {
       expect(CourseCompletionUtils.formattedCourseDetails).toHaveBeenCalledWith(courseCompletion)
 
       expect(GovukFrontendDateInput.getDateItemsFromStructuredDate).toHaveBeenLastCalledWith({}, false)
-      expect(GovUkRadioGroup.yesNoItems).toHaveBeenCalledWith({ checkedValue: undefined })
       expect(offenderService.getOffenderSummary).toHaveBeenCalledWith({ username, crn })
       expect(page.requirementDetailsItems).toHaveBeenCalledWith(unpaidWorkDetails, deliusEventNumber)
     })
@@ -236,10 +236,11 @@ describe('OutcomeController', () => {
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' }]
-      jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(isSensitiveItems)
+      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: false }]
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: 'some', isSensitiveItems })
 
-      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: { team: teamCode } })
+      const body = { team: teamCode }
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body })
 
       const requestHandler = outcomeController.submit()
       await requestHandler(request, response, next)
@@ -250,7 +251,7 @@ describe('OutcomeController', () => {
         errorSummary,
         timeToCredit,
         dateItems,
-        notes: form.notes,
+        notes: 'some',
         isSensitiveItems,
         courseDetailsItems,
         requirementDetailsItems,
@@ -264,13 +265,15 @@ describe('OutcomeController', () => {
         },
         true,
       )
-      expect(GovUkRadioGroup.yesNoItems).toHaveBeenCalledWith({ checkedValue: form.isSensitive })
+
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form)
     })
 
     it('uses values from request body over form data', async () => {
       const form = courseCompletionFormFactory.build()
       formService.getForm.mockResolvedValue(form)
       const formId = '12'
+      const notes = 'some note'
 
       const viewData = {
         backLink: '/back',
@@ -294,8 +297,8 @@ describe('OutcomeController', () => {
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' }]
-      jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(isSensitiveItems)
+      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes, isSensitiveItems })
 
       const body = {
         'date-day': '25',
@@ -303,7 +306,7 @@ describe('OutcomeController', () => {
         'date-year': '2026',
         hours: '1',
         minutes: '20',
-        notes: 'some note',
+        notes,
         isSensitive: 'yes',
       }
       const request = createMock<Request>({
@@ -334,7 +337,7 @@ describe('OutcomeController', () => {
         },
         true,
       )
-      expect(GovUkRadioGroup.yesNoItems).toHaveBeenCalledWith({ checkedValue: body.isSensitive })
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith(body, form)
     })
   })
 })

--- a/server/controllers/courseCompletions/process/outcomeController.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.ts
@@ -3,11 +3,11 @@ import CourseCompletionFormService from '../../../services/forms/courseCompletio
 import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import GovukFrontendDateInput, { GovUkFrontendDateInputItem } from '../../../forms/GovukFrontendDateInput'
-import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
 import { ValidationErrors, ViewDataWithNotes, ViewDataWithTimeToCredit } from '../../../@types/user-defined'
 import CourseCompletionUtils, { CourseDetails } from '../../../utils/courseCompletionUtils'
 import { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import OffenderService from '../../../services/offenderService'
+import NotesUtils from '../../../utils/notesUtils'
 
 type ViewData = {
   dateItems: Array<GovUkFrontendDateInputItem>
@@ -44,9 +44,6 @@ export default class OutcomeController extends BaseController<OutcomePage> {
     }
     const hasDateError = (errors as ValidationErrors<OutcomePageBody>)['date-day'] !== undefined
     const dateItems = GovukFrontendDateInput.getDateItemsFromStructuredDate(date, hasDateError)
-    const notes = this.getPropertyValue({ propertyName: 'notes', req, formData })
-    const isSensitive = this.getPropertyValue({ propertyName: 'isSensitive', req, formData })
-    const isSensitiveItems = GovUkRadioGroup.yesNoItems({ checkedValue: isSensitive })
 
     const courseDetailsItems = CourseCompletionUtils.formattedCourseDetails(courseCompletion)
 
@@ -57,6 +54,12 @@ export default class OutcomeController extends BaseController<OutcomePage> {
 
     const requirementDetailsItems = this.page.requirementDetailsItems(unpaidWorkDetails, formData.deliusEventNumber)
 
-    return { timeToCredit, dateItems, notes, isSensitiveItems, courseDetailsItems, requirementDetailsItems }
+    return {
+      ...NotesUtils.questionItems(req.body ?? {}, formData),
+      timeToCredit,
+      dateItems,
+      courseDetailsItems,
+      requirementDetailsItems,
+    }
   }
 }

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -197,6 +197,7 @@ describe('AttendanceOutcomePage', () => {
       const formWithOutcomes = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[0].code }),
         notes: 'Test notes',
+        isSensitive: undefined,
       })
       const page = new AttendanceOutcomePage({
         query: {} as AttendanceOutcomeBody,
@@ -356,92 +357,6 @@ describe('AttendanceOutcomePage', () => {
         expect(result.items).toEqual(expectedItems)
       })
     })
-
-    describe('isSensitiveItems', () => {
-      it('Yes should be checked if form `sensitive` property is true', () => {
-        const form = appointmentOutcomeFormFactory.build({
-          sensitive: true,
-        })
-        const page = new AttendanceOutcomePage({
-          query: {},
-          appointment,
-          contactOutcomes,
-        })
-
-        const result = page.viewData(form)
-
-        const expectedSensitiveItems = [
-          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: false, text: 'No, they are not sensitive', value: 'no' },
-        ]
-
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
-      })
-
-      it('No should be checked if form `sensitive` property is false', () => {
-        const form = appointmentOutcomeFormFactory.build({
-          sensitive: false,
-        })
-        const page = new AttendanceOutcomePage({
-          query: {},
-          appointment,
-          contactOutcomes,
-        })
-
-        const result = page.viewData(form)
-
-        const expectedSensitiveItems = [
-          { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: true, text: 'No, they are not sensitive', value: 'no' },
-        ]
-
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
-      })
-
-      it.each([null, undefined])(
-        'Neither value should be checked if form `sensitive` property is null or undefined',
-        (isSensitive?: boolean) => {
-          const form = appointmentOutcomeFormFactory.build({
-            sensitive: isSensitive,
-          })
-          const page = new AttendanceOutcomePage({
-            query: {},
-            appointment,
-            contactOutcomes,
-          })
-
-          const result = page.viewData(form)
-
-          const expectedSensitiveItems = [
-            { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-            { checked: false, text: 'No, they are not sensitive', value: 'no' },
-          ]
-
-          expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
-        },
-      )
-
-      it('populates view data with query value if defined', () => {
-        const form = appointmentOutcomeFormFactory.build({
-          sensitive: false,
-        })
-
-        const page = new AttendanceOutcomePage({
-          query: { isSensitive: 'yes' },
-          appointment,
-          contactOutcomes,
-        })
-
-        const result = page.viewData(form)
-
-        const expectedSensitiveItems = [
-          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: false, text: 'No, they are not sensitive', value: 'no' },
-        ]
-
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
-      })
-    })
   })
 
   describe('next', () => {
@@ -493,7 +408,7 @@ describe('AttendanceOutcomePage', () => {
       const queryNotes = 'New notes'
       const form = appointmentOutcomeFormFactory.build({ notes: appointmentNotes })
       const page = new AttendanceOutcomePage({
-        query: { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes },
+        query: { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes, isSensitive: 'yes' },
         appointment,
         contactOutcomes,
       })
@@ -503,6 +418,7 @@ describe('AttendanceOutcomePage', () => {
         ...form,
         contactOutcome: contactOutcomes[0],
         notes: queryNotes,
+        isSensitive: 'yes',
       })
     })
   })

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -1,4 +1,13 @@
-import { AppointmentOutcomeForm, AppointmentUpdateQuery, ValidationErrors, YesOrNo } from '../../@types/user-defined'
+import {
+  AppointmentOutcomeForm,
+  AppointmentUpdatePageViewData,
+  AppointmentUpdateQuery,
+  BodyWithNotes,
+  GovUkRadioOption,
+  ValidationErrors,
+  ViewDataWithNotes,
+  YesOrNo,
+} from '../../@types/user-defined'
 import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
@@ -10,11 +19,15 @@ export type AttendanceOutcomeBody = {
   notes?: string
 }
 
-interface AttendanceOutcomeQuery extends AppointmentUpdateQuery {
+type AttendanceOutcomeQuery = {
   attendanceOutcome?: string
-  notes?: string
-  isSensitive?: YesOrNo
-}
+} & BodyWithNotes &
+  AppointmentUpdateQuery
+
+type ViewData = {
+  items: Array<GovUkRadioOption>
+} & ViewDataWithNotes &
+  AppointmentUpdatePageViewData
 
 export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   private query: AttendanceOutcomeQuery
@@ -72,7 +85,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return validationErrors
   }
 
-  viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false) {
+  viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
     const sensitive = GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.isSensitive) ?? form.sensitive
     return {
       ...this.commonViewData(this.appointment),

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -6,13 +6,12 @@ import {
   GovUkRadioOption,
   ValidationErrors,
   ViewDataWithNotes,
-  YesOrNo,
 } from '../../@types/user-defined'
 import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import DateTimeFormats from '../../utils/dateTimeUtils'
-import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
+import NotesUtils from '../../utils/notesUtils'
 
 export type AttendanceOutcomeBody = {
   attendanceOutcome: string
@@ -56,9 +55,8 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
     return {
       ...data,
+      ...NotesUtils.formData(this.query),
       contactOutcome,
-      notes: this.query.notes,
-      sensitive: GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.isSensitive),
     }
   }
 
@@ -86,12 +84,10 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
-    const sensitive = GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.isSensitive) ?? form.sensitive
     return {
       ...this.commonViewData(this.appointment),
+      ...NotesUtils.questionItems(this.query, form),
       items: this.items(form, hasErrors),
-      notes: hasErrors ? this.query.notes : form.notes,
-      isSensitiveItems: this.isSensitiveItems(sensitive),
     }
   }
 
@@ -130,21 +126,6 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
       value: outcome.code,
       checked: outcome.code === code,
     }))
-  }
-
-  private isSensitiveItems(isSensitive?: boolean): { text: string; value: YesOrNo; checked: boolean }[] {
-    return [
-      {
-        text: 'Yes, they include sensitive information',
-        value: 'yes',
-        checked: isSensitive === true,
-      },
-      {
-        text: 'No, they are not sensitive',
-        value: 'no',
-        checked: isSensitive === false,
-      },
-    ]
   }
 
   private outcomeIsAttendedOrEnforceable(outcomeCode: string): boolean {

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -133,6 +133,7 @@ describe('ConfirmPage', () => {
         const submitted = appointmentOutcomeFormFactory.build({
           contactOutcome,
           notes,
+          isSensitive: undefined,
         })
         const result = page.viewData(appointment, submitted)
         expect(result.submittedItems).toEqual([
@@ -175,7 +176,7 @@ describe('ConfirmPage', () => {
               text: 'Notes',
             },
             value: {
-              html: notes,
+              text: notes,
             },
             actions: {
               items: [
@@ -472,7 +473,7 @@ describe('ConfirmPage', () => {
             text: 'Notes',
           },
           value: {
-            html: 'test',
+            text: 'test',
           },
           actions: {
             items: [

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -10,7 +10,8 @@ import {
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
-import { properCase, yesNoDisplayValue } from '../../utils/utils'
+import NotesUtils from '../../utils/notesUtils'
+import { properCase } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 
 interface ViewData extends AppointmentUpdatePageViewData {
@@ -144,40 +145,10 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           ],
         },
       },
-      {
-        key: {
-          text: 'Notes',
-        },
-        value: {
-          html: form.notes,
-        },
-        actions: {
-          items: [
-            {
-              href: this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
-              text: 'Change',
-              visuallyHiddenText: 'notes',
-            },
-          ],
-        },
-      },
-      {
-        key: {
-          text: 'Sensitive',
-        },
-        value: {
-          text: yesNoDisplayValue(form.sensitive, 'Not entered'),
-        },
-        actions: {
-          items: [
-            {
-              href: this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
-              text: 'Change',
-              visuallyHiddenText: 'sensitivity',
-            },
-          ],
-        },
-      },
+      ...NotesUtils.checkYourAnswersRows(
+        form,
+        this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
+      ),
       {
         key: {
           text: 'Start and end time',

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -11,7 +11,7 @@ import paths from '../../../paths'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import ReferenceDataService from '../../../services/referenceDataService'
 import DateTimeFormats from '../../../utils/dateTimeUtils'
-import { properCase } from '../../../utils/utils'
+import NotesUtils from '../../../utils/notesUtils'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
 
@@ -115,7 +115,10 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
       this.appointmentTypeRow(form, courseCompletionId, canChangeAppointment, formId),
       this.creditedTimeRow(form, courseCompletionId, formId),
       this.appointmentDateRow(form, courseCompletionId, formId),
-      ...this.notesRows(form, courseCompletionId, formId),
+      ...NotesUtils.checkYourAnswersRows(
+        form,
+        this.pathWithFormId(paths.courseCompletions.process({ page: 'outcome', id: courseCompletionId }), formId),
+      ),
     ]
   }
 
@@ -124,6 +127,7 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
       type: 'CREDIT_TIME',
       crn: formData.crn,
       creditTimeDetails: {
+        ...NotesUtils.requestBody(formData),
         appointmentIdToUpdate: formData.appointmentIdToUpdate,
         deliusEventNumber: formData.deliusEventNumber,
         date: DateTimeFormats.dateAndTimeInputsToIsoString(formData, 'date').date,
@@ -133,8 +137,6 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
         ),
         contactOutcomeCode: ReferenceDataService.attendedCompliedOutcome,
         projectCode: formData.project,
-        notes: formData.notes,
-        sensitive: GovUkRadioGroup.nullableValueFromYesOrNoItem(formData.isSensitive),
         alertActive: GovUkRadioGroup.nullableValueFromYesOrNoItem(body.alertPractitioner),
       },
     }
@@ -291,54 +293,5 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
         ],
       },
     }
-  }
-
-  private notesRows(
-    form: CourseCompletionForm,
-    courseCompletionId: string,
-    formId?: string,
-  ): Array<GovUkSummaryListItem> {
-    return [
-      {
-        key: {
-          text: 'Notes',
-        },
-        value: {
-          text: form.notes,
-        },
-        actions: {
-          items: [
-            {
-              href: this.pathWithFormId(
-                paths.courseCompletions.process({ page: 'outcome', id: courseCompletionId }),
-                formId,
-              ),
-              text: 'Change',
-              visuallyHiddenText: 'notes',
-            },
-          ],
-        },
-      },
-      {
-        key: {
-          text: 'Sensitive',
-        },
-        value: {
-          text: form.isSensitive ? properCase(form.isSensitive) : 'Not entered',
-        },
-        actions: {
-          items: [
-            {
-              href: this.pathWithFormId(
-                paths.courseCompletions.process({ page: 'outcome', id: courseCompletionId }),
-                formId,
-              ),
-              text: 'Change',
-              visuallyHiddenText: 'sensitivity',
-            },
-          ],
-        },
-      },
-    ]
   }
 }

--- a/server/pages/courseCompletions/process/outcomePage.ts
+++ b/server/pages/courseCompletions/process/outcomePage.ts
@@ -6,6 +6,7 @@ import { CourseCompletionPage } from './pathMap'
 import { UnpaidWorkDetailsDto } from '../../../@types/shared'
 import UnpaidWorkUtils, { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../../forms/hoursAndMinutesInput'
+import NotesUtils from '../../../utils/notesUtils'
 
 type TimePeriods = 'day' | 'month' | 'year'
 type DateKeys = `date-${TimePeriods}`
@@ -23,12 +24,11 @@ export default class OutcomePage extends BaseCourseCompletionFormPage<OutcomePag
   getFormData(formData: CourseCompletionForm, body: OutcomePageBody): CourseCompletionForm {
     return {
       ...formData,
+      ...NotesUtils.formData(body),
       timeToCredit: { hours: body.hours, minutes: body.minutes },
       'date-day': body['date-day'],
       'date-month': body['date-month'],
       'date-year': body['date-year'],
-      notes: body.notes,
-      isSensitive: body.isSensitive,
     }
   }
 

--- a/server/pages/courseCompletions/process/outcomePage.ts
+++ b/server/pages/courseCompletions/process/outcomePage.ts
@@ -1,5 +1,5 @@
 import GovukFrontendDateInput from '../../../forms/GovukFrontendDateInput'
-import { ValidationErrors, YesOrNo } from '../../../@types/user-defined'
+import { BodyWithNotes, ValidationErrors } from '../../../@types/user-defined'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
@@ -14,9 +14,8 @@ export type OutcomePageBody = {
   [K in DateKeys]?: string
 } & {
   contactOutcome?: string
-  notes?: string
-  isSensitive?: YesOrNo
-} & ObjectWithHoursAndMinutes
+} & ObjectWithHoursAndMinutes &
+  BodyWithNotes
 
 export default class OutcomePage extends BaseCourseCompletionFormPage<OutcomePageBody> {
   protected page: CourseCompletionPage = 'outcome'

--- a/server/services/forms/courseCompletionFormService.ts
+++ b/server/services/forms/courseCompletionFormService.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { CourseCompletionResolutionDto } from '../../@types/shared'
-import { YesOrNo } from '../../@types/user-defined'
+import { BodyWithNotes } from '../../@types/user-defined'
 import FormClient from '../../data/formClient'
 import { CourseCompletionPageInput } from '../../pages/courseCompletionIndexPage'
 import BaseFormService from './baseFormService'
@@ -24,10 +24,9 @@ export type CourseCompletionForm = {
   contactOutcomeCode?: string
   team?: string
   project?: string
-  notes?: string
   alertActive?: boolean
-  isSensitive?: YesOrNo
-} & DoNotCreditTime
+} & BodyWithNotes &
+  DoNotCreditTime
 
 export default class CourseCompletionFormService extends BaseFormService<CourseCompletionForm> {
   constructor(formClient: FormClient) {

--- a/server/testutils/factories/appointmentOutcomeFormFactory.ts
+++ b/server/testutils/factories/appointmentOutcomeFormFactory.ts
@@ -13,8 +13,8 @@ export default Factory.define<AppointmentOutcomeForm>(
       contactOutcome: contactOutcomeFactory.build(),
       attendanceData: attendanceDataFactory.build(),
       supervisor: supervisorSummaryFactory.build(),
-      notes: null,
-      sensitive: null,
+      notes: undefined,
+      isSensitive: faker.helpers.arrayElement(['yes', 'no']),
       originalSearch: {
         provider: faker.string.alpha(8),
         team: faker.string.alpha(8),

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -1,0 +1,252 @@
+import { YesOrNo } from '../@types/user-defined'
+import courseCompletionFormFactory from '../testutils/factories/courseCompletionFormFactory'
+import NotesUtils from './notesUtils'
+
+describe('NotesUtils', () => {
+  describe('questionItems', () => {
+    describe('notes', () => {
+      it.each(['some note', ''])('should contain query value if any value', (notes: string) => {
+        const form = courseCompletionFormFactory.build()
+        const result = NotesUtils.questionItems({ notes }, form)
+
+        expect(result.notes).toBe(notes)
+      })
+
+      it.each(['some note', ''])(
+        'should contain form value if any value and query has no notes value',
+        (notes: string) => {
+          const form = courseCompletionFormFactory.build({ notes })
+          const result = NotesUtils.questionItems({}, form)
+
+          expect(result.notes).toBe(notes)
+        },
+      )
+
+      it('should be undefined value if notes is undefined on query and form', () => {
+        const form = courseCompletionFormFactory.build({ notes: undefined })
+        const result = NotesUtils.questionItems({}, form)
+
+        expect(result.notes).toBe(undefined)
+      })
+    })
+
+    describe('isSensitiveItems', () => {
+      it('Yes should be checked if form `sensitive` property is yes', () => {
+        const form = courseCompletionFormFactory.build({
+          isSensitive: 'yes',
+        })
+
+        const result = NotesUtils.questionItems({}, form)
+
+        const expectedSensitiveItems = [
+          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
+          { checked: false, text: 'No, they are not sensitive', value: 'no' },
+        ]
+
+        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+      })
+
+      it('No should be checked if form `sensitive` property is no', () => {
+        const form = courseCompletionFormFactory.build({
+          isSensitive: 'no',
+        })
+
+        const result = NotesUtils.questionItems({}, form)
+
+        const expectedSensitiveItems = [
+          { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
+          { checked: true, text: 'No, they are not sensitive', value: 'no' },
+        ]
+
+        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+      })
+
+      it.each([null, undefined])(
+        'Neither value should be checked if form `sensitive` property is null or undefined',
+        (isSensitive?: YesOrNo) => {
+          const form = courseCompletionFormFactory.build({
+            isSensitive,
+          })
+
+          const result = NotesUtils.questionItems({}, form)
+
+          const expectedSensitiveItems = [
+            { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
+            { checked: false, text: 'No, they are not sensitive', value: 'no' },
+          ]
+
+          expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+        },
+      )
+
+      it('populates view data with query value if defined', () => {
+        const form = courseCompletionFormFactory.build({
+          isSensitive: undefined,
+        })
+
+        const query = { isSensitive: 'yes' as YesOrNo }
+
+        const result = NotesUtils.questionItems(query, form)
+
+        const expectedSensitiveItems = [
+          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
+          { checked: false, text: 'No, they are not sensitive', value: 'no' },
+        ]
+
+        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+      })
+    })
+  })
+
+  describe('checkYourAnswersRows', () => {
+    const changePath = '/change-notes'
+
+    it('should return notes row with defined value', () => {
+      const notesValue = 'Some important notes'
+      const form = courseCompletionFormFactory.build({ notes: notesValue })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath)
+
+      expect(result[0]).toEqual({
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          text: notesValue,
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'notes',
+            },
+          ],
+        },
+      })
+    })
+
+    it('should return notes row with undefined value', () => {
+      const form = courseCompletionFormFactory.build({ notes: undefined })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath)
+
+      expect(result[0]).toEqual({
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          text: undefined,
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'notes',
+            },
+          ],
+        },
+      })
+    })
+
+    it("should return sensitive row displaying 'Yes' when isSensitive is 'yes'", () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath)
+
+      expect(result[1]).toEqual({
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: 'Yes',
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ],
+        },
+      })
+    })
+
+    it("should return sensitive row displaying 'No' when isSensitive is 'no'", () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath)
+
+      expect(result[1]).toEqual({
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: 'No',
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ],
+        },
+      })
+    })
+
+    it("should return sensitive row displaying 'Not entered' when isSensitive is undefined", () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: undefined })
+
+      const result = NotesUtils.checkYourAnswersRows(form, changePath)
+
+      expect(result[1]).toEqual({
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: 'Not entered',
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('formData', () => {
+    it('should return isSensitive and notes values as yes when appointment is sensitive', () => {
+      const query = { notes: 'test notes', isSensitive: 'yes' as YesOrNo }
+
+      const result = NotesUtils.formData(query)
+
+      expect(result).toEqual({
+        notes: 'test notes',
+        isSensitive: 'yes',
+      })
+    })
+  })
+
+  describe('requestBody', () => {
+    it('should include form sensitive value ', () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+      const result = NotesUtils.requestBody(form)
+      expect(result.sensitive).toBe(true)
+    })
+
+    it('should include form notes value', () => {
+      const form = courseCompletionFormFactory.build()
+      const result = NotesUtils.requestBody(form)
+      expect(result.notes).toBe(form.notes)
+    })
+  })
+})

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -1,0 +1,79 @@
+import { BodyWithNotes, GovUkSummaryListItem, YesOrNo } from '../@types/user-defined'
+import GovUkRadioGroup from '../forms/GovUkRadioGroup'
+import { properCase } from './utils'
+
+export default class NotesUtils {
+  static formData(query: BodyWithNotes): BodyWithNotes {
+    return { notes: query.notes, isSensitive: query.isSensitive }
+  }
+
+  static requestBody(form: BodyWithNotes) {
+    return {
+      notes: form.notes,
+      sensitive: GovUkRadioGroup.nullableValueFromYesOrNoItem(form.isSensitive),
+    }
+  }
+
+  static checkYourAnswersRows(form: BodyWithNotes, changePath: string): Array<GovUkSummaryListItem> {
+    return [
+      {
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          text: form.notes,
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'notes',
+            },
+          ],
+        },
+      },
+      {
+        key: {
+          text: 'Sensitive',
+        },
+        value: {
+          text: form.isSensitive ? properCase(form.isSensitive) : 'Not entered',
+        },
+        actions: {
+          items: [
+            {
+              href: changePath,
+              text: 'Change',
+              visuallyHiddenText: 'sensitivity',
+            },
+          ],
+        },
+      },
+    ]
+  }
+
+  static questionItems(query: BodyWithNotes, form: BodyWithNotes) {
+    const sensitive = query.isSensitive ?? form.isSensitive
+
+    return {
+      notes: query.notes ?? form.notes,
+      isSensitiveItems: this.isSensitiveItems(sensitive),
+    }
+  }
+
+  private static isSensitiveItems(isSensitive?: YesOrNo): { text: string; value: YesOrNo; checked: boolean }[] {
+    return [
+      {
+        text: 'Yes, they include sensitive information',
+        value: 'yes',
+        checked: isSensitive === 'yes',
+      },
+      {
+        text: 'No, they are not sensitive',
+        value: 'no',
+        checked: isSensitive === 'no',
+      },
+    ]
+  }
+}


### PR DESCRIPTION
## Context

This introduces shared handling of any logic related to notes and sensitivity questions related to an appointment - so that we can update the behaviour in a future PR (related to [CPB-912](https://dsdmoj.atlassian.net/browse/CPB-912))

## Changes in this PR

- Introduce shared types for forms with notes
- Introduce shared methods for handling notes and sensitivity questions in forms:
  - displaying and populating answers
  - updating in progress form data
  - calculating notes and sensitivity values on request data 

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-912]: https://dsdmoj.atlassian.net/browse/CPB-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ