### PR TITLE
Prevent double click on POST requests

### DIFF
--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -142,6 +142,7 @@ describe('AdjustTravelTimeController', () => {
         name: 'Project',
         type: 'Group',
       },
+      preventDoubleClick: true,
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -199,6 +200,7 @@ describe('AdjustTravelTimeController', () => {
         name: 'Project',
         type: 'Group',
       },
+      preventDoubleClick: true,
     }
     const appointmentId = '1'
     const projectCode = '2'

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -56,8 +56,9 @@ export default class AdjustTravelTimeController {
         originalSearch: req.query as SearchTravelTimePageInput,
       })
       const errorList = generateErrorTextList(res.locals.errorMessages)
+      const preventDoubleClick = true
 
-      res.render('appointments/update/travelTime/update', { ...viewData, errorList })
+      res.render('appointments/update/travelTime/update', { ...viewData, errorList, preventDoubleClick })
     }
   }
 
@@ -86,6 +87,8 @@ export default class AdjustTravelTimeController {
 
         const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
+        const preventDoubleClick = true
+
         const viewData = {
           ...this.page.viewData({
             appointment,
@@ -97,6 +100,7 @@ export default class AdjustTravelTimeController {
           errorSummary,
           errors,
           time,
+          preventDoubleClick,
         }
 
         return res.render('appointments/update/travelTime/update', viewData)

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -25,6 +25,7 @@ describe('ConfirmController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const confirmPageMock: jest.Mock = ConfirmPage as unknown as jest.Mock<ConfirmPage>
   const pageViewData = {
+    preventDoubleClick: true,
     someKey: 'some value',
   }
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -24,8 +24,9 @@ export default class ConfirmController {
       const page = new ConfirmPage(_req.query)
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
       const errorList = generateErrorTextList(res.locals.errorMessages)
+      const preventDoubleClick = true
 
-      res.render('appointments/update/confirm', { ...page.viewData(appointment, form), errorList })
+      res.render('appointments/update/confirm', { ...page.viewData(appointment, form), errorList, preventDoubleClick })
     }
   }
 

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -62,7 +62,8 @@
               type: "submit",
               attributes: {
                 "form": "appointmentForm"
-              }
+              },
+              preventDoubleClick: preventDoubleClick
             }) }}
           {% endif %}
           {% block secondaryButton %}

--- a/server/views/courseCompletions/process/confirm.njk
+++ b/server/views/courseCompletions/process/confirm.njk
@@ -53,3 +53,10 @@
   }) }}
   {% endif %}
 {% endblock %}
+
+{% block primaryButton %}
+  {{ govukButton({
+    text: submitButtonText,
+    preventDoubleClick: true
+  }) }}
+{% endblock %}


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-881)

On various forms where we are making POST requests to the API, let's set `preventDoubleClick : true` on the govukButton for the form submission.

## Changes in this PR

### Screenshots of UI changes

<img width="1699" height="1283" alt="prevent-double-click" src="https://github.com/user-attachments/assets/30ce84ff-99fe-45c6-8a07-fd0574805d1c" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
