### PR TITLE
Add hint text about sensitive flag

### DIFF
--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -1,10 +1,18 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
+{% if not showIsSensitiveQuestion %}
+ {% set notesHint = {
+      text: 'This note will be automatically marked sensitive as an earlier note was already flagged.'
+    }
+  %}
+{% endif %}
+
 {{ govukTextarea({
   name: "notes",
   id: "notes",
   value: notes,
+  hint: notesHint,
   errorMessage: errors.notes,
   label: {
     text: "Notes",


### PR DESCRIPTION
If an appointment has previously been marked as sensitive-as we are hiding the question about sensitivity in this case.

This completes [CPB-912](https://dsdmoj.atlassian.net/browse/CPB-912), following implementation in #536 

### Screenshots of UI changes

If appointment is sensitive show hint text explaining it will be automatically marked as sensitive:
<img width="1491" height="452" alt="" src="https://github.com/user-attachments/assets/6ba787e6-e597-48b0-9111-91ea67496724" />

If appointment is sensitive do not show any hint text (and show the sensitivity question):
<img width="1430" height="597" alt="" src="https://github.com/user-attachments/assets/da7266c3-7a8d-4247-b74e-2212f9f4228d" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-912]: https://dsdmoj.atlassian.net/browse/CPB-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ