### PR TITLE
CPB-912: Tidy up styling for summary lists with and without actions

### DIFF
--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -141,7 +141,12 @@ export type GovUKValue = { text: string } | { html: string }
 
 export type GovUKActionItem = { href: string; text: string; visuallyHiddenText: string }
 
-export type GovUkSummaryListItem = { key: GovUKValue; value: GovUKValue; actions?: { items: Array<GovUKActionItem> } }
+export type GovUkSummaryListItem = {
+  key: GovUKValue
+  value: GovUKValue
+  actions?: { items: Array<GovUKActionItem> }
+  classes?: string
+}
 
 export type StructuredDate = { year: string; month: string; day: string; formattedDate: string }
 

--- a/server/utils/govUkComponentUtils.test.ts
+++ b/server/utils/govUkComponentUtils.test.ts
@@ -1,0 +1,117 @@
+import { GovUkSummaryListItem } from '../@types/user-defined'
+import GovUKComponentUtils from './govUkComponentUtils'
+
+describe('GovUKComponentUtils', () => {
+  describe('summaryListRowsWithAndWithoutActions', () => {
+    it('should return items unchanged when all items have action items', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Name' },
+          value: { text: 'John Doe' },
+          actions: { items: [{ text: 'Edit', href: '/edit', visuallyHiddenText: 'name' }] },
+        },
+        {
+          key: { text: 'Age' },
+          value: { text: '30' },
+          actions: { items: [{ text: 'Change', href: '/change', visuallyHiddenText: 'age' }] },
+        },
+      ]
+
+      const result = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      expect(result).toEqual(items)
+    })
+
+    it('should add no-actions class to items without action items when some items have action items', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Name' },
+          value: { text: 'John Doe' },
+          actions: { items: [{ text: 'Edit', href: '/edit', visuallyHiddenText: 'name' }] },
+        },
+        {
+          key: { text: 'Age' },
+          value: { text: '30' },
+          actions: { items: [] },
+        },
+      ]
+
+      const result = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      expect(result[0].classes).toBeUndefined()
+      expect(result[1].classes).toBe('govuk-summary-list__row--no-actions')
+    })
+
+    it('should add no-actions class when item has empty actions items array', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          actions: { items: [] },
+        },
+      ]
+
+      const result = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      expect(result[0].classes).toBe('govuk-summary-list__row--no-actions')
+    })
+
+    it('should add no-actions class when item has undefined actions', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          actions: undefined,
+        },
+      ]
+
+      const result = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      expect(result[0].classes).toBe('govuk-summary-list__row--no-actions')
+    })
+
+    it('should add no-actions class when item has no action items and no existing classes', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+        },
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          classes: '',
+        },
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          classes: undefined,
+        },
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          classes: null,
+        },
+      ]
+
+      const results = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      results.forEach(result => {
+        expect(result.classes).toBe('govuk-summary-list__row--no-actions')
+      })
+    })
+
+    it('should append no-actions class when item has no action items and existing classes', () => {
+      const items: Array<GovUkSummaryListItem> = [
+        {
+          key: { text: 'Status' },
+          value: { text: 'Active' },
+          classes: 'custom-class another-class',
+        },
+      ]
+
+      const result = GovUKComponentUtils.summaryListRowsWithAndWithoutActions(items)
+
+      expect(result[0].classes).toBe('custom-class another-class govuk-summary-list__row--no-actions')
+    })
+  })
+})

--- a/server/utils/govUkComponentUtils.ts
+++ b/server/utils/govUkComponentUtils.ts
@@ -1,0 +1,14 @@
+import { GovUkSummaryListItem } from '../@types/user-defined'
+
+export default class GovUKComponentUtils {
+  static summaryListRowsWithAndWithoutActions(items: Array<GovUkSummaryListItem>) {
+    return items.map(item => {
+      if (item.actions?.items?.length > 0) {
+        return item
+      }
+      const classes = [item.classes, 'govuk-summary-list__row--no-actions'].join(' ').trim()
+
+      return { ...item, classes }
+    })
+  }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -12,6 +12,7 @@ import HtmlUtils from './htmlUtils'
 import GovUkRadioGroup from '../forms/GovUkRadioGroup'
 import LayoutUtils from './layoutUtils'
 import { paginationComponentParams } from './paginationUtils'
+import GovUKComponentUtils from './govUkComponentUtils'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -57,4 +58,5 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('mergeObjects', (obj1: Record<string, unknown>, obj2: Record<string, unknown>) => {
     return { ...(obj1 ?? {}), ...(obj2 ?? {}) }
   })
+  njkEnv.addFilter('summaryListRowsWithAndWithoutActions', GovUKComponentUtils.summaryListRowsWithAndWithoutActions)
 }

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -141,12 +141,13 @@ describe('SessionUtils', () => {
 
       const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
-      expect(sessionRow[sessionRow.length - 2].html).toEqual(attendanceName)
+      expect(sessionRow[sessionRow.length - 2]).toEqual({ html: attendanceName })
       expect(HtmlUtils.getStatusTag).not.toHaveBeenCalled()
     })
 
     it("returns a session row with a grey tag containing 'Not entered' if there is no attendance outcome", () => {
-      jest.spyOn(HtmlUtils, 'getStatusTag')
+      const statusTagHtml = '<span>Not entered</span>'
+      jest.spyOn(HtmlUtils, 'getStatusTag').mockReturnValue(statusTagHtml)
 
       const offender: OffenderFullDto = {
         crn: 'CRN123',
@@ -163,8 +164,8 @@ describe('SessionUtils', () => {
 
       const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
-      expect(HtmlUtils.getStatusTag).toHaveBeenCalled()
-      expect(sessionRow[sessionRow.length - 2].html).toMatch(/grey.+Not entered/)
+      expect(HtmlUtils.getStatusTag).toHaveBeenCalledWith('Not entered', 'grey')
+      expect(sessionRow[sessionRow.length - 2]).toEqual({ html: statusTagHtml })
     })
 
     it('returns a session row with "update" action link when a contact outcome does not exist', () => {

--- a/server/views/appointments/update/confirm.njk
+++ b/server/views/appointments/update/confirm.njk
@@ -21,7 +21,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
     {{ govukSummaryList({
-        rows: submittedItems
+        rows: submittedItems | summaryListRowsWithAndWithoutActions
       }) }}
     </div>
   </div>

--- a/server/views/courseCompletions/process/confirm.njk
+++ b/server/views/courseCompletions/process/confirm.njk
@@ -30,7 +30,7 @@
         html: 'The outcome of this appointment will be <span class="govuk-!-font-weight-bold">Attended - Complied</span>'
       }) }}
       {{ govukSummaryList({
-        rows: appointmentItems
+        rows: appointmentItems | summaryListRowsWithAndWithoutActions
       }) }}
     </div>
   </div>


### PR DESCRIPTION
## Context

In our check your answers lists on confirm pages of forms, we are hiding the 'Change' link in certain cases where a value will be automated.

This causes the component line break styling to look inconsistent on these rows in certain browsers. 

We can use the [`govuk-summary-list__row--no-actions`](https://design-system.service.gov.uk/components/summary-list/#showing-rows-with-and-without-actions)  class on these rows.

## Changes in this PR

- Add a utility method for calculating whether a row has no actions and should have the class applied.
- Apply this method in the views where relevant, using a nunjucks filter.

### Screenshots of UI changes

#### Previously

<img width="1244" height="662" alt="A summary list with inconsistent line break lengths" src="https://github.com/user-attachments/assets/0f1f75f6-b3c8-4df9-87fa-1ca3b4e9ae07" />

#### Now

Appointment update form:
<img width="1426" height="726" alt="" src="https://github.com/user-attachments/assets/518f0fdf-bcf8-4e4c-8f68-37424b6532d2" />

Course completion form with automated sensitive value:
<img width="1432" height="571" alt="" src="https://github.com/user-attachments/assets/db1f5056-ae7b-4998-8cd5-50b3f617035a" />

Course completion form with unchangeable appointment type value:
<img width="1412" height="596" alt="" src="https://github.com/user-attachments/assets/ccc9f08f-caa2-4845-a584-9f7e70f27ad6" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
