### PR TITLE
Tweak formatting of confirm page start/end time

### DIFF
--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -78,7 +78,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     const { startTime, endTime } = form
     const hours = !form.contactOutcome.attended ? 0 : DateTimeFormats.timeBetween(startTime, endTime)
 
-    return `${startTime} - ${endTime}<br>Total hours worked: ${hours}`
+    return `${DateTimeFormats.stripTime(startTime)} - ${DateTimeFormats.stripTime(endTime)}<br>Total hours worked: ${hours}`
   }
 
   private getCreditedHours(form: AppointmentOutcomeForm) {


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-935)

Here we remove the seconds from the start/end time on the confirm page.

## Changes in this PR

### Screenshots of UI changes

<img width="1842" height="1335" alt="start-end-time-no-seconds" src="https://github.com/user-attachments/assets/830096f9-1b41-438d-84a4-3fbad8c3417b" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
