### PR TITLE
CPB-909: Restructure appointment details page

### DIFF
--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -71,7 +71,7 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
   async toShowComplianceAnswer() {
     await this.confirmPage.details.expect.toHaveItemWith(
       'Compliance',
-      'High-vis - YesWorked intensively - YesWork quality - GoodBehaviour - Poor',
+      'Wore hi-vis - YesWorking intensively - YesWork quality - GoodBehaviour - Poor',
     )
 
     await this.confirmPage.details.expect.toHaveItemWith('Notes', 'There were some issues')

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -27,7 +27,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     super(offender.name)
     this.appointment = appointment
     this.project = project
-    this.projectDetails = new SummaryListComponent()
+    this.projectDetails = new SummaryListComponent('Project details')
     this.appointmentDetails = new SummaryListComponent()
     this.supervisorInput = new SelectInput('supervisor')
     this.provider = provider
@@ -56,24 +56,30 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.projectDetails.getValueWithLabel('Project type').should('contain.text', this.project.projectType.name)
     this.projectDetails.getValueWithLabel('Supervising team').should('contain.text', this.appointment.supervisingTeam)
     this.projectDetails
-      .getValueWithLabel('Date and time')
+      .getValueWithLabel('Date')
+      .should('contain.text', DateTimeFormats.isoDateToUIDate(this.appointment.date))
+    this.projectDetails
+      .getValueWithLabel('Time')
       .should(
         'contain.text',
-        DateTimeFormats.dateAndTimePeriod(this.appointment.date, this.appointment.startTime, this.appointment.endTime),
+        `${DateTimeFormats.stripTime(this.appointment.startTime)} - ${DateTimeFormats.stripTime(this.appointment.endTime)}`,
       )
-  }
-
-  shouldContainAppointmentDetails(): void {
-    this.appointmentDetails.getValueWithLabel('Provider').should('contain.text', this.provider.name)
-    this.appointmentDetails
+    this.projectDetails.getValueWithLabel('Region').should('contain.text', this.provider.name)
+    this.projectDetails
       .getValueWithLabel('Pick up time')
       .should('contain.text', DateTimeFormats.stripTime(this.appointment.pickUpData.time))
-    this.appointmentDetails
+    this.projectDetails
       .getValueWithLabel('Pick up place')
       .should(
         'contain.text',
-        LocationUtils.locationToString(this.appointment.pickUpData.location, { withLineBreaks: false }),
+        LocationUtils.locationToString(this.appointment.pickUpData.pickupLocation, { withLineBreaks: false }),
       )
+    this.projectDetails
+      .getValueWithLabel('Supervising officer')
+      .should('contain.text', this.appointment.supervisorOfficerName)
+  }
+
+  shouldContainAppointmentDetails(): void {
     this.appointmentDetails.getValueWithLabel('Notes').should('contain.text', this.appointment.notes)
 
     this.appointmentDetails

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -7,11 +7,14 @@ import Page from '../page'
 import Offender from '../../../server/models/offender'
 import LocationUtils from '../../../server/utils/locationUtils'
 import { pathWithQuery, yesNoDisplayValue } from '../../../server/utils/utils'
+import AppointmentUtils from '../../../server/utils/appointmentUtils'
 
 export default class CheckAppointmentDetailsPage extends Page {
   private readonly projectDetails: SummaryListComponent
 
   private readonly appointmentDetails: SummaryListComponent
+
+  readonly complianceDetails: SummaryListComponent
 
   readonly supervisorInput: SelectInput
 
@@ -29,6 +32,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.project = project
     this.projectDetails = new SummaryListComponent('Project details')
     this.appointmentDetails = new SummaryListComponent()
+    this.complianceDetails = new SummaryListComponent('Compliance details')
     this.supervisorInput = new SelectInput('supervisor')
     this.provider = provider
   }
@@ -87,12 +91,29 @@ export default class CheckAppointmentDetailsPage extends Page {
       .should('contain.text', yesNoDisplayValue(this.appointment.sensitive))
   }
 
+  shouldContainComplianceDetails(): void {
+    this.complianceDetails
+      .getValueWithLabel('Wore hi-vis')
+      .should('contain.text', yesNoDisplayValue(this.appointment.attendanceData.hiVisWorn))
+
+    this.complianceDetails
+      .getValueWithLabel('Working intensively')
+      .should('contain.text', yesNoDisplayValue(this.appointment.attendanceData.workedIntensively))
+
+    this.complianceDetails
+      .getValueWithLabel('Work quality')
+      .should('contain.text', AppointmentUtils.formatComplianceRatings(this.appointment.attendanceData.workQuality))
+
+    this.complianceDetails
+      .getValueWithLabel('Behaviour')
+      .should('contain.text', AppointmentUtils.formatComplianceRatings(this.appointment.attendanceData.behaviour))
+  }
+
   shouldNotShowContinueButton(): void {
     cy.contains('button', 'Continue').should('not.exist')
   }
 
   protected override customCheckOnPage(): void {
-    cy.get('h2').eq(1).should('contain.text', 'Project details')
-    cy.get('h2').eq(2).should('contain.text', 'Appointment details')
+    cy.get('h2').should('contain.text', 'Appointment details')
   }
 }

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -16,6 +16,8 @@ export default class CheckAppointmentDetailsPage extends Page {
 
   readonly complianceDetails: SummaryListComponent
 
+  readonly hoursDetails: SummaryListComponent
+
   readonly supervisorInput: SelectInput
 
   readonly appointment: AppointmentDto
@@ -31,6 +33,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.projectDetails = new SummaryListComponent('Project details')
     this.appointmentDetails = new SummaryListComponent()
     this.complianceDetails = new SummaryListComponent('Compliance details')
+    this.hoursDetails = new SummaryListComponent('Hours detail')
     this.supervisorInput = new SelectInput('supervisor')
   }
 
@@ -104,6 +107,12 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.complianceDetails
       .getValueWithLabel('Behaviour')
       .should('contain.text', AppointmentUtils.formatComplianceRatings(this.appointment.attendanceData.behaviour))
+  }
+
+  shouldContainTimeDetails(args: { worked: string; penalty: string; credited: string }) {
+    this.hoursDetails.getValueWithLabel('Hours worked').should('contain.text', args.worked)
+    this.hoursDetails.getValueWithLabel('Penalty hours').should('contain.text', args.penalty)
+    this.hoursDetails.getValueWithLabel('Hours credited').should('contain.text', args.credited)
   }
 
   shouldNotShowContinueButton(): void {

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -18,6 +18,8 @@ export default class CheckAppointmentDetailsPage extends Page {
 
   readonly hoursDetails: SummaryListComponent
 
+  readonly sharedDetails: SummaryListComponent
+
   readonly supervisorInput: SelectInput
 
   readonly appointment: AppointmentDto
@@ -34,6 +36,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.appointmentDetails = new SummaryListComponent()
     this.complianceDetails = new SummaryListComponent('Compliance details')
     this.hoursDetails = new SummaryListComponent('Hours detail')
+    this.sharedDetails = new SummaryListComponent('Shared information')
     this.supervisorInput = new SelectInput('supervisor')
   }
 
@@ -113,6 +116,18 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.hoursDetails.getValueWithLabel('Hours worked').should('contain.text', args.worked)
     this.hoursDetails.getValueWithLabel('Penalty hours').should('contain.text', args.penalty)
     this.hoursDetails.getValueWithLabel('Hours credited').should('contain.text', args.credited)
+  }
+
+  shouldShowSharedInformation() {
+    this.sharedDetails
+      .getValueWithLabel('Enforcement action')
+      .should('contain.text', this.appointment.enforcementData.enforcementActionName)
+    this.sharedDetails
+      .getValueWithLabel('Respond by')
+      .should('contain.text', DateTimeFormats.isoDateToUIDate(this.appointment.enforcementData.respondBy))
+    this.sharedDetails
+      .getValueWithLabel('Alert sent')
+      .should('contain.text', yesNoDisplayValue(this.appointment.alertActive))
   }
 
   shouldNotShowContinueButton(): void {

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -22,9 +22,7 @@ export default class CheckAppointmentDetailsPage extends Page {
 
   private readonly project: ProjectDto
 
-  private readonly provider: ProviderSummaryDto
-
-  constructor(appointment: AppointmentDto, project: ProjectDto, provider: ProviderSummaryDto) {
+  constructor(appointment: AppointmentDto, project: ProjectDto) {
     const offender = new Offender(appointment.offender)
 
     super(offender.name)
@@ -34,7 +32,6 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.appointmentDetails = new SummaryListComponent()
     this.complianceDetails = new SummaryListComponent('Compliance details')
     this.supervisorInput = new SelectInput('supervisor')
-    this.provider = provider
   }
 
   static visit(
@@ -52,7 +49,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     )
     cy.visit(path)
 
-    return new CheckAppointmentDetailsPage(appointment, project, provider)
+    return new CheckAppointmentDetailsPage(appointment, project)
   }
 
   shouldContainProjectDetails() {
@@ -68,7 +65,7 @@ export default class CheckAppointmentDetailsPage extends Page {
         'contain.text',
         `${DateTimeFormats.stripTime(this.appointment.startTime)} - ${DateTimeFormats.stripTime(this.appointment.endTime)}`,
       )
-    this.projectDetails.getValueWithLabel('Region').should('contain.text', this.provider.name)
+    this.projectDetails.getValueWithLabel('Region').should('contain.text', this.project.providerName)
     this.projectDetails
       .getValueWithLabel('Pick up time')
       .should('contain.text', DateTimeFormats.stripTime(this.appointment.pickUpData.time))

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -12,7 +12,7 @@ import AppointmentUtils from '../../../server/utils/appointmentUtils'
 export default class CheckAppointmentDetailsPage extends Page {
   private readonly projectDetails: SummaryListComponent
 
-  private readonly appointmentDetails: SummaryListComponent
+  readonly notesDetails: SummaryListComponent
 
   readonly complianceDetails: SummaryListComponent
 
@@ -33,7 +33,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.appointment = appointment
     this.project = project
     this.projectDetails = new SummaryListComponent('Project details')
-    this.appointmentDetails = new SummaryListComponent()
+    this.notesDetails = new SummaryListComponent('Notes')
     this.complianceDetails = new SummaryListComponent('Compliance details')
     this.hoursDetails = new SummaryListComponent('Hours detail')
     this.sharedDetails = new SummaryListComponent('Shared information')
@@ -86,10 +86,10 @@ export default class CheckAppointmentDetailsPage extends Page {
       .should('contain.text', this.appointment.supervisorOfficerName)
   }
 
-  shouldContainAppointmentDetails(): void {
-    this.appointmentDetails.getValueWithLabel('Notes').should('contain.text', this.appointment.notes)
+  shouldContainNotesDetails(): void {
+    this.notesDetails.getValueWithLabel('Notes detail').should('contain.text', this.appointment.notes)
 
-    this.appointmentDetails
+    this.notesDetails
       .getValueWithLabel('Sensitive')
       .should('contain.text', yesNoDisplayValue(this.appointment.sensitive))
   }

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -46,7 +46,7 @@ export default class ConfirmDetailsPage extends Page {
       .getValueWithLabel('Compliance')
       .should(
         'contain.html',
-        'High-vis - No<br>Worked intensively - No<br>Work quality - Good<br>Behaviour - Not applicable',
+        'Wore hi-vis - No<br>Working intensively - No<br>Work quality - Good<br>Behaviour - Not applicable',
       )
     this.formDetails.getValueWithLabel('Notes').should('contain.text', 'Test')
     this.formDetails.getValueWithLabel('Sensitive').should('contain.text', 'Not entered')

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -18,6 +18,10 @@ export default class SummaryListComponent {
     return this.getValueWithLabel(label).closest('.govuk-summary-list__row').find('a').should('not.exist')
   }
 
+  shouldNotBeVisible() {
+    this.component().should('not.exist')
+  }
+
   private component() {
     return this.title ? cy.get('.govuk-summary-card').filter(`:contains(${this.title})`) : cy.get('dl')
   }

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -76,6 +76,7 @@ import pagedModelProjectOutcomeSummaryFactory from '../../../server/testutils/fa
 import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import { pickupLocationFactory } from '../../../server/testutils/factories/pickupDataFactory'
+import attendanceDataFactory from '../../../server/testutils/factories/attendanceDataFactory'
 
 context('Session details', () => {
   beforeEach(() => {
@@ -388,6 +389,8 @@ context('Session details', () => {
       const appointmentWithContactOutcome = appointmentFactory.build({
         contactOutcomeCode: contactOutcome.code,
         projectCode: this.project.projectCode,
+        attendanceData: attendanceDataFactory.build({ penaltyMinutes: 30 }),
+        minutesCredited: 60,
       })
       cy.task('stubFindAppointment', { appointment: appointmentWithContactOutcome })
 
@@ -407,17 +410,33 @@ context('Session details', () => {
 
       // And I should see outcome details
       page.shouldContainComplianceDetails()
+      page.shouldContainTimeDetails({ worked: '1 hour 30 minutes', penalty: '30 minutes', credited: '1 hour' })
     })
 
     //  Scenario: Completing the check appointment details page
     it('does not show compliance details and allows user to continue to the next page', function test() {
       const contactOutcomes = contactOutcomesFactory.build()
 
+      const appointmentWithoutContactOutcome = appointmentFactory.build({
+        contactOutcomeCode: undefined,
+        projectCode: this.project.projectCode,
+        attendanceData: undefined,
+        minutesCredited: undefined,
+      })
+      cy.task('stubFindAppointment', { appointment: appointmentWithoutContactOutcome })
+      cy.task('stubGetSupervisors', {
+        teamCode: appointmentWithoutContactOutcome.supervisingTeamCode,
+        providerCode: appointmentWithoutContactOutcome.providerCode,
+        supervisors: this.supervisors,
+      })
+
       // Given I am on an appointment 'check appointment details' page
-      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider)
+      const page = CheckAppointmentDetailsPage.visit(appointmentWithoutContactOutcome, this.project, this.provider)
+      page.shouldContainProjectDetails()
 
       // Then I should not see compliance details
       page.complianceDetails.shouldNotBeVisible()
+      page.hoursDetails.shouldNotBeVisible()
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})
@@ -425,7 +444,7 @@ context('Session details', () => {
       page.clickSubmit()
 
       // Then I see the choose supervisor page
-      Page.verifyOnPage(ChooseSupervisorPage, this.appointment)
+      Page.verifyOnPage(ChooseSupervisorPage, appointmentWithoutContactOutcome)
     })
   })
 })

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -73,6 +73,7 @@ import FindIndividualPlacementPage from '../../pages/projects/findIndividualPlac
 import pagedModelProjectOutcomeSummaryFactory from '../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
 import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
+import { pickupLocationFactory } from '../../../server/testutils/factories/pickupDataFactory'
 
 context('Session details', () => {
   beforeEach(() => {
@@ -86,7 +87,7 @@ context('Session details', () => {
     const firstAppointment = appointmentFactory.build({
       id: 1001,
       projectCode: project.projectCode,
-      pickUpData: { time, location: locationFactory.build() },
+      pickUpData: { time, pickupLocation: pickupLocationFactory.build() },
       contactOutcomeCode: undefined,
     })
     cy.wrap(firstAppointment).as('appointment')

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -163,23 +163,11 @@ context('Session details', () => {
     page.shouldShowAppointmentsList()
 
     // When I click update for a particular session
-    const provider = providerSummaryFactory.build({ code: appointment.providerCode })
     cy.task('stubFindAppointment', { appointment })
-    cy.task('stubGetProviders', { providers: { providers: [provider] } })
-    cy.task('stubGetSupervisors', {
-      teamCode: appointment.supervisingTeamCode,
-      providerCode: appointment.providerCode,
-      supervisors: this.supervisors,
-    })
     page.clickUpdateAnAppointment()
 
     // Then I see the check appointment details page
-    const checkAppointmentDetailsPage = Page.verifyOnPage(
-      CheckAppointmentDetailsPage,
-      appointment,
-      this.project,
-      provider,
-    )
+    const checkAppointmentDetailsPage = Page.verifyOnPage(CheckAppointmentDetailsPage, appointment, this.project)
     checkAppointmentDetailsPage.shouldContainProjectDetails()
     checkAppointmentDetailsPage.shouldContainAppointmentDetails()
   })

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -43,9 +43,11 @@
 //    Given I am on the appointment details page
 //    And an outcome has previously been recorded
 //    Then I should not see the Continue button
+//    And I should see outcome details
 
 // Scenario: Completing the check appointment details page
 //    Given I am on an appointment 'check appointment details' page
+//    Then I should not see compliance details
 //    When I submit the form
 //    Then I see the choose supervisor page
 
@@ -89,6 +91,7 @@ context('Session details', () => {
       projectCode: project.projectCode,
       pickUpData: { time, pickupLocation: pickupLocationFactory.build() },
       contactOutcomeCode: undefined,
+      attendanceData: undefined,
     })
     cy.wrap(firstAppointment).as('appointment')
 
@@ -389,9 +392,9 @@ context('Session details', () => {
     })
   })
 
-  describe('Continue', () => {
+  describe('Contact outcome status', () => {
     // Scenario: Viewing the appointment details page with an existing outcome
-    it('does not show the continue button if a contact outcome exists', function test() {
+    it('shows outcome details and does not show the continue button if a contact outcome exists', function test() {
       const contactOutcome = contactOutcomeFactory.build()
 
       const appointmentWithContactOutcome = appointmentFactory.build({
@@ -413,14 +416,20 @@ context('Session details', () => {
 
       // Then I should not see the Continue button
       page.shouldNotShowContinueButton()
+
+      // And I should see outcome details
+      page.shouldContainComplianceDetails()
     })
 
     //  Scenario: Completing the check appointment details page
-    it('continues to the next page', function test() {
+    it('does not show compliance details and allows user to continue to the next page', function test() {
       const contactOutcomes = contactOutcomesFactory.build()
 
       // Given I am on an appointment 'check appointment details' page
       const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider)
+
+      // Then I should not see compliance details
+      page.complianceDetails.shouldNotBeVisible()
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -170,7 +170,7 @@ context('Session details', () => {
     // Then I see the check appointment details page
     const checkAppointmentDetailsPage = Page.verifyOnPage(CheckAppointmentDetailsPage, appointment, this.project)
     checkAppointmentDetailsPage.shouldContainProjectDetails()
-    checkAppointmentDetailsPage.shouldContainAppointmentDetails()
+    checkAppointmentDetailsPage.shouldContainNotesDetails()
   })
 
   //  Scenario: Accessing the view appointment form
@@ -215,7 +215,7 @@ context('Session details', () => {
       provider,
     )
     checkAppointmentDetailsPage.shouldContainProjectDetails()
-    checkAppointmentDetailsPage.shouldContainAppointmentDetails()
+    checkAppointmentDetailsPage.shouldContainNotesDetails()
   })
 
   //  Scenario: Viewing a session with Limited Access Offenders
@@ -411,6 +411,7 @@ context('Session details', () => {
       // And I should see outcome details
       page.shouldContainComplianceDetails()
       page.shouldContainTimeDetails({ worked: '1 hour 30 minutes', penalty: '30 minutes', credited: '1 hour' })
+      page.shouldContainNotesDetails()
       page.shouldShowSharedInformation()
     })
 
@@ -425,6 +426,8 @@ context('Session details', () => {
         minutesCredited: undefined,
         enforcementData: undefined,
         alertActive: undefined,
+        notes: undefined,
+        sensitive: undefined,
       })
       cy.task('stubFindAppointment', { appointment: appointmentWithoutContactOutcome })
       cy.task('stubGetSupervisors', {
@@ -441,7 +444,7 @@ context('Session details', () => {
       page.complianceDetails.shouldNotBeVisible()
       page.hoursDetails.shouldNotBeVisible()
       page.sharedDetails.shouldNotBeVisible()
-
+      page.notesDetails.shouldNotBeVisible()
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})
       // When I submit the form

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -411,6 +411,7 @@ context('Session details', () => {
       // And I should see outcome details
       page.shouldContainComplianceDetails()
       page.shouldContainTimeDetails({ worked: '1 hour 30 minutes', penalty: '30 minutes', credited: '1 hour' })
+      page.shouldShowSharedInformation()
     })
 
     //  Scenario: Completing the check appointment details page
@@ -422,6 +423,8 @@ context('Session details', () => {
         projectCode: this.project.projectCode,
         attendanceData: undefined,
         minutesCredited: undefined,
+        enforcementData: undefined,
+        alertActive: undefined,
       })
       cy.task('stubFindAppointment', { appointment: appointmentWithoutContactOutcome })
       cy.task('stubGetSupervisors', {
@@ -437,6 +440,7 @@ context('Session details', () => {
       // Then I should not see compliance details
       page.complianceDetails.shouldNotBeVisible()
       page.hoursDetails.shouldNotBeVisible()
+      page.sharedDetails.shouldNotBeVisible()
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})

--- a/server/controllers/appointments/appointmentDetailsController.test.ts
+++ b/server/controllers/appointments/appointmentDetailsController.test.ts
@@ -2,15 +2,12 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import CheckAppointmentDetailsPage from '../../pages/appointments/checkAppointmentDetailsPage'
 import AppointmentService from '../../services/appointmentService'
-import ProviderService from '../../services/providerService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
-import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import ProjectDetailsController from './appointmentDetailsController'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import ProjectService from '../../services/projectService'
-import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
 import projectFactory from '../../testutils/factories/projectFactory'
 
 jest.mock('../../pages/appointments/checkAppointmentDetailsPage')
@@ -29,18 +26,12 @@ describe('AppointmentsController', () => {
 
   let appointmentsController: ProjectDetailsController
   const appointmentService = createMock<AppointmentService>()
-  const providerDataService = createMock<ProviderService>()
   const formService = createMock<AppointmentFormService>()
   const projectService = createMock<ProjectService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    appointmentsController = new ProjectDetailsController(
-      appointmentService,
-      formService,
-      providerDataService,
-      projectService,
-    )
+    appointmentsController = new ProjectDetailsController(appointmentService, formService, projectService)
   })
 
   describe('show', () => {
@@ -52,14 +43,10 @@ describe('AppointmentsController', () => {
         }
       })
       const appointment = appointmentFactory.build()
-      const supervisors = supervisorSummaryFactory.buildList(2)
-      const providers = [providerSummaryFactory.build()]
       const project = projectFactory.build()
 
       const response = createMock<Response>()
       appointmentService.getAppointment.mockResolvedValue(appointment)
-      providerDataService.getSupervisors.mockResolvedValue(supervisors)
-      providerDataService.getProviders.mockResolvedValue(providers)
       projectService.getProject.mockResolvedValue(project)
 
       const requestHandler = appointmentsController.show()
@@ -129,14 +116,10 @@ describe('AppointmentsController', () => {
       }))
 
       const appointment = appointmentFactory.build()
-      const supervisors = supervisorSummaryFactory.buildList(2)
-      const providers = [providerSummaryFactory.build()]
       const project = projectFactory.build()
 
       const response = createMock<Response>()
       appointmentService.getAppointment.mockResolvedValue(appointment)
-      providerDataService.getSupervisors.mockResolvedValue(supervisors)
-      providerDataService.getProviders.mockResolvedValue(providers)
       projectService.getProject.mockResolvedValue(project)
 
       const requestHandler = appointmentsController.submit()

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -1,17 +1,14 @@
 import type { Request, RequestHandler, Response } from 'express'
 import CheckAppointmentDetailsPage from '../../pages/appointments/checkAppointmentDetailsPage'
 import AppointmentService from '../../services/appointmentService'
-import ProviderService from '../../services/providerService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentParams, AppointmentOutcomeForm } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
-import { AppointmentDto, ProviderSummaryDto } from '../../@types/shared'
 
 export default class AppointmentDetailsController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,
-    private readonly providerService: ProviderService,
     private readonly projectService: ProjectService,
   ) {}
 
@@ -27,8 +24,6 @@ export default class AppointmentDetailsController {
         username: res.locals.user.username,
         projectCode: appointmentParams.projectCode,
       })
-
-      const provider = await this.getProviderForAppointment(res, appointment)
 
       const page = new CheckAppointmentDetailsPage(_req.query, project)
 
@@ -47,7 +42,7 @@ export default class AppointmentDetailsController {
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData({ appointment, project, provider, originalSearch: form.originalSearch }),
+        ...page.viewData({ appointment, project, originalSearch: form.originalSearch }),
       })
     }
   }
@@ -60,10 +55,5 @@ export default class AppointmentDetailsController {
 
       return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
     }
-  }
-
-  private async getProviderForAppointment(res: Response, appointment: AppointmentDto): Promise<ProviderSummaryDto> {
-    const providers = await this.providerService.getProviders(res.locals.user.username)
-    return providers.find(provider => provider.code === appointment.providerCode)
   }
 }

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -47,7 +47,7 @@ export default class AppointmentDetailsController {
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData(appointment, project, provider, form.originalSearch),
+        ...page.viewData({ appointment, project, provider, originalSearch: form.originalSearch }),
       })
     }
   }

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -27,7 +27,6 @@ const controllers = (services: Services) => {
   const appointmentDetailsController = new AppointmentDetailsController(
     services.appointmentService,
     services.appointmentFormService,
-    services.providerService,
     services.projectService,
   )
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -12,6 +12,7 @@ import projectFactory from '../../testutils/factories/projectFactory'
 import LocationUtils from '../../utils/locationUtils'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
+import enforcementDataFactory from '../../testutils/factories/enforcementDataFactory'
 
 jest.mock('../../models/offender')
 
@@ -343,6 +344,93 @@ describe('CheckAppointmentDetailsPage', () => {
         expect(result.timeItems).toEqual([
           { key: { text: 'Hours worked' }, value: { text: '3 hours' } },
           { key: { text: 'Hours credited' }, value: { text: '3 hours' } },
+        ])
+      })
+    })
+
+    describe('sharedItems', () => {
+      it('should return all shared items with values when all properties are defined', () => {
+        const enforcementData = enforcementDataFactory.build()
+        const appointmentWithEnforcement = appointmentFactory.build({
+          enforcementData,
+          alertActive: true,
+        })
+
+        jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue('15 February 2025')
+        jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
+
+        const result = page.viewData({
+          appointment: appointmentWithEnforcement,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.sharedItems).toEqual([
+          { key: { text: 'Enforcement action' }, value: { text: enforcementData.enforcementActionName } },
+          { key: { text: 'Respond by' }, value: { text: '15 February 2025' } },
+          { key: { text: 'Alert sent' }, value: { text: 'Yes' } },
+        ])
+      })
+
+      it('should omit enforcement action when enforcementData is undefined', () => {
+        const appointmentWithoutEnforcement = appointmentFactory.build({
+          enforcementData: undefined,
+          alertActive: true,
+        })
+
+        jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
+
+        const result = page.viewData({
+          appointment: appointmentWithoutEnforcement,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.sharedItems).toEqual([{ key: { text: 'Alert sent' }, value: { text: 'Yes' } }])
+      })
+
+      it('should omit respond by when respondBy is undefined but enforcementActionName is defined', () => {
+        const enforcementData = enforcementDataFactory.build({
+          enforcementActionName: 'Warning Letter',
+          respondBy: undefined,
+        })
+        const appointmentWithPartialEnforcement = appointmentFactory.build({
+          enforcementData,
+          alertActive: false,
+        })
+
+        jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('No')
+
+        const result = page.viewData({
+          appointment: appointmentWithPartialEnforcement,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.sharedItems).toEqual([
+          { key: { text: 'Enforcement action' }, value: { text: 'Warning Letter' } },
+          { key: { text: 'Alert sent' }, value: { text: 'No' } },
+        ])
+      })
+
+      it('should handle alertActive being undefined', () => {
+        const enforcementData = enforcementDataFactory.build()
+        const appointmentWithNoAlert = appointmentFactory.build({
+          enforcementData,
+          alertActive: undefined,
+        })
+
+        jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue('1 April 2025')
+
+        const result = page.viewData({
+          appointment: appointmentWithNoAlert,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.sharedItems).toEqual([
+          { key: { text: 'Enforcement action' }, value: { text: enforcementData.enforcementActionName } },
+          { key: { text: 'Respond by' }, value: { text: '1 April 2025' } },
         ])
       })
     })

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -10,7 +10,6 @@ import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import projectFactory from '../../testutils/factories/projectFactory'
 import LocationUtils from '../../utils/locationUtils'
-import locationFactory from '../../testutils/factories/locationFactory'
 import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
 
 jest.mock('../../models/offender')
@@ -37,44 +36,90 @@ describe('CheckAppointmentDetailsPage', () => {
 
     it('should return an object containing project details', () => {
       const projectDto = projectFactory.build()
-      const dateAndTime = '1 January 2025, 09:00 - 17:00'
+      const date = '1 January 2025'
       const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
-      jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
+      const pickUpTime = '09:00'
+      const startTime = '09:00'
+      const endTime = '17:00'
+
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(date)
+
       jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
+      jest.spyOn(DateTimeFormats, 'stripTime').mockImplementation(timeVal => {
+        if (timeVal === appointment.endTime) {
+          return endTime
+        }
+        if (timeVal === appointment.startTime) {
+          return startTime
+        }
+        return pickUpTime
+      })
 
       const result = page.viewData(appointment, projectDto, providerDto, {})
 
-      const project = {
-        name: projectDto.projectName,
-        type: projectDto.projectType.name,
-        supervisingTeam: appointment.supervisingTeam,
-        location,
-        dateAndTime,
-      }
+      expect(result.projectItems).toEqual([
+        { key: { text: 'Region' }, value: { text: providerDto.name } },
+        { key: { text: 'Team' }, value: { text: projectDto.teamName } },
+        { key: { text: 'Project' }, value: { text: projectDto.projectName } },
+        { key: { text: 'Project type' }, value: { text: projectDto.projectType.name } },
+        { key: { text: 'Location' }, value: { text: location } },
+        { key: { text: 'Date' }, value: { text: date } },
+        { key: { text: 'Time' }, value: { text: `${startTime} - ${endTime}` } },
+        { key: { text: 'Pick up place' }, value: { text: location } },
+        { key: { text: 'Pick up time' }, value: { text: pickUpTime } },
+        { key: { text: 'Supervising team' }, value: { text: appointment.supervisingTeam } },
+        { key: { text: 'Supervising officer' }, value: { text: appointment.supervisorOfficerName } },
+      ])
+    })
 
-      expect(result.project).toStrictEqual(project)
+    it('should exclude pick up place and time if they are undefined', () => {
+      const projectDto = projectFactory.build()
+      const date = '1 January 2025'
+      const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
+      const startTime = '09:00'
+      const endTime = '17:00'
+      const appointmentWithoutPickUp = appointmentFactory.build({ pickUpData: undefined })
+
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(date)
+      jest.spyOn(LocationUtils, 'locationToString').mockImplementation(val => (val ? location : undefined))
+      jest.spyOn(DateTimeFormats, 'stripTime').mockImplementation(timeVal => {
+        if (timeVal === appointmentWithoutPickUp.endTime) {
+          return endTime
+        }
+        if (timeVal === appointmentWithoutPickUp.startTime) {
+          return startTime
+        }
+        return ''
+      })
+
+      const result = page.viewData(appointmentWithoutPickUp, projectDto, providerDto, {})
+
+      expect(result.projectItems).toEqual([
+        { key: { text: 'Region' }, value: { text: providerDto.name } },
+        { key: { text: 'Team' }, value: { text: projectDto.teamName } },
+        { key: { text: 'Project' }, value: { text: projectDto.projectName } },
+        { key: { text: 'Project type' }, value: { text: projectDto.projectType.name } },
+        { key: { text: 'Location' }, value: { text: location } },
+        { key: { text: 'Date' }, value: { text: date } },
+        { key: { text: 'Time' }, value: { text: `${startTime} - ${endTime}` } },
+        { key: { text: 'Supervising team' }, value: { text: appointmentWithoutPickUp.supervisingTeam } },
+        { key: { text: 'Supervising officer' }, value: { text: appointmentWithoutPickUp.supervisorOfficerName } },
+      ])
     })
 
     it('should return an object containing appointment details', () => {
-      const time = '09:00'
       const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
-      const appointmentDto = appointmentFactory.build({ pickUpData: { time, location: locationFactory.build() } })
       jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
-      jest.spyOn(DateTimeFormats, 'stripTime').mockReturnValue(time)
       jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
 
-      const result = page.viewData(appointmentDto, projectFactory.build(), providerDto, {})
+      const result = page.viewData(appointment, projectFactory.build(), providerDto, {})
 
       const appointmentDetails = {
-        pickUpPlace: location,
-        pickUpTime: time,
-        providerCode: appointmentDto.providerCode,
-        notes: appointmentDto.notes,
+        notes: appointment.notes,
         sensitive: 'Yes',
-        provider: providerDto.name,
       }
 
-      expect(result.appointment).toStrictEqual(appointmentDetails)
+      expect(result.appointment).toEqual(appointmentDetails)
     })
 
     it('should return an object containing offender', () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -55,7 +55,7 @@ describe('CheckAppointmentDetailsPage', () => {
         return pickUpTime
       })
 
-      const result = page.viewData(appointment, projectDto, providerDto, {})
+      const result = page.viewData({ appointment, project: projectDto, provider: providerDto, originalSearch: {} })
 
       expect(result.projectItems).toEqual([
         { key: { text: 'Region' }, value: { text: providerDto.name } },
@@ -92,7 +92,12 @@ describe('CheckAppointmentDetailsPage', () => {
         return ''
       })
 
-      const result = page.viewData(appointmentWithoutPickUp, projectDto, providerDto, {})
+      const result = page.viewData({
+        appointment: appointmentWithoutPickUp,
+        project: projectDto,
+        provider: providerDto,
+        originalSearch: {},
+      })
 
       expect(result.projectItems).toEqual([
         { key: { text: 'Region' }, value: { text: providerDto.name } },
@@ -112,7 +117,12 @@ describe('CheckAppointmentDetailsPage', () => {
       jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
       jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
 
-      const result = page.viewData(appointment, projectFactory.build(), providerDto, {})
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        provider: providerDto,
+        originalSearch: {},
+      })
 
       const appointmentDetails = {
         notes: appointment.notes,
@@ -133,18 +143,28 @@ describe('CheckAppointmentDetailsPage', () => {
         return offender
       })
 
-      const result = page.viewData(appointment, projectFactory.build(), providerDto, {})
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        provider: providerDto,
+        originalSearch: {},
+      })
 
       expect(result.offender).toBe(offender)
     })
 
     it('should return an object containing a back link to the session page', async () => {
       const backLink = '/session/1'
-      const search = { provider: 'provider' }
+      const originalSearch = { provider: 'provider' }
       jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
 
-      const result = page.viewData(appointment, projectFactory.build(), providerDto, search)
-      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, search)
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        provider: providerDto,
+        originalSearch,
+      })
+      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, originalSearch)
       expect(result.backLink).toBe(backLink)
     })
 
@@ -154,14 +174,19 @@ describe('CheckAppointmentDetailsPage', () => {
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
       page = new CheckAppointmentDetailsPage({}, project)
       const search = { provider: 'provider' }
-      const result = page.viewData(appointment, project, providerDto, search)
+      const result = page.viewData({ appointment, project, provider: providerDto, originalSearch: search })
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
       expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, search)
       expect(result.backLink).toBe(pathWithQuery)
     })
 
     it('should return an object containing an update link for the form', async () => {
-      const result = page.viewData(appointment, projectFactory.build(), providerDto, {})
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        provider: providerDto,
+        originalSearch: {},
+      })
       expect(paths.appointments.appointmentDetails).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
@@ -178,7 +203,12 @@ describe('CheckAppointmentDetailsPage', () => {
         jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
         jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
 
-        const result = page.viewData(appointmentWithNoOutcome, projectDto, providerDto, {})
+        const result = page.viewData({
+          appointment: appointmentWithNoOutcome,
+          project: projectDto,
+          provider: providerDto,
+          originalSearch: {},
+        })
 
         expect(result.showContinueButton).toBe(true)
       })
@@ -191,7 +221,12 @@ describe('CheckAppointmentDetailsPage', () => {
         jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
         jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
 
-        const result = page.viewData(appointmentWithOutcome, projectDto, providerDto, {})
+        const result = page.viewData({
+          appointment: appointmentWithOutcome,
+          project: projectDto,
+          provider: providerDto,
+          originalSearch: {},
+        })
 
         expect(result.showContinueButton).toBe(false)
       })

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -10,7 +10,6 @@ import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import projectFactory from '../../testutils/factories/projectFactory'
 import LocationUtils from '../../utils/locationUtils'
-import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 
@@ -28,7 +27,6 @@ describe('CheckAppointmentDetailsPage', () => {
     let appointment: AppointmentDto
     const updatePath = '/update'
     const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
-    const providerDto = providerSummaryFactory.build()
 
     beforeEach(() => {
       page = new CheckAppointmentDetailsPage({}, projectFactory.build())
@@ -57,10 +55,10 @@ describe('CheckAppointmentDetailsPage', () => {
         return pickUpTime
       })
 
-      const result = page.viewData({ appointment, project: projectDto, provider: providerDto, originalSearch: {} })
+      const result = page.viewData({ appointment, project: projectDto, originalSearch: {} })
 
       expect(result.projectItems).toEqual([
-        { key: { text: 'Region' }, value: { text: providerDto.name } },
+        { key: { text: 'Region' }, value: { text: projectDto.providerName } },
         { key: { text: 'Team' }, value: { text: projectDto.teamName } },
         { key: { text: 'Project' }, value: { text: projectDto.projectName } },
         { key: { text: 'Project type' }, value: { text: projectDto.projectType.name } },
@@ -97,12 +95,11 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment: appointmentWithoutPickUp,
         project: projectDto,
-        provider: providerDto,
         originalSearch: {},
       })
 
       expect(result.projectItems).toEqual([
-        { key: { text: 'Region' }, value: { text: providerDto.name } },
+        { key: { text: 'Region' }, value: { text: projectDto.providerName } },
         { key: { text: 'Team' }, value: { text: projectDto.teamName } },
         { key: { text: 'Project' }, value: { text: projectDto.projectName } },
         { key: { text: 'Project type' }, value: { text: projectDto.projectType.name } },
@@ -122,7 +119,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        provider: providerDto,
         originalSearch: {},
       })
 
@@ -148,7 +144,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        provider: providerDto,
         originalSearch: {},
       })
 
@@ -163,7 +158,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        provider: providerDto,
         originalSearch,
       })
       expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, originalSearch)
@@ -176,7 +170,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
       page = new CheckAppointmentDetailsPage({}, project)
       const search = { provider: 'provider' }
-      const result = page.viewData({ appointment, project, provider: providerDto, originalSearch: search })
+      const result = page.viewData({ appointment, project, originalSearch: search })
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
       expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, search)
       expect(result.backLink).toBe(pathWithQuery)
@@ -186,7 +180,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        provider: providerDto,
         originalSearch: {},
       })
       expect(paths.appointments.appointmentDetails).toHaveBeenCalledWith({
@@ -218,7 +211,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithAttendance,
           project: projectFactory.build(),
-          provider: providerDto,
           originalSearch: {},
         })
 
@@ -236,7 +228,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithoutAttendance,
           project: projectFactory.build(),
-          provider: providerDto,
           originalSearch: {},
         })
 
@@ -256,7 +247,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithNoOutcome,
           project: projectDto,
-          provider: providerDto,
           originalSearch: {},
         })
 
@@ -274,7 +264,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithOutcome,
           project: projectDto,
-          provider: providerDto,
           originalSearch: {},
         })
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -11,6 +11,8 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import projectFactory from '../../testutils/factories/projectFactory'
 import LocationUtils from '../../utils/locationUtils'
 import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
+import AppointmentUtils from '../../utils/appointmentUtils'
+import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 
 jest.mock('../../models/offender')
 
@@ -192,6 +194,54 @@ describe('CheckAppointmentDetailsPage', () => {
         appointmentId: appointment.id.toString(),
       })
       expect(result.updatePath).toBe(pathWithQuery)
+    })
+
+    describe('complianceItems', () => {
+      it('should return compliance items when attendance data is defined', () => {
+        const attendanceData = attendanceDataFactory.build({
+          hiVisWorn: true,
+          workedIntensively: false,
+          workQuality: 'GOOD',
+          behaviour: 'EXCELLENT',
+        })
+        const appointmentWithAttendance = appointmentFactory.build({ attendanceData })
+
+        jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
+        jest.spyOn(AppointmentUtils, 'formatComplianceRatings').mockImplementation(rating => {
+          const ratingMap: { [key: string]: string } = {
+            GOOD: 'Good',
+            EXCELLENT: 'Excellent',
+          }
+          return ratingMap[rating]
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithAttendance,
+          project: projectFactory.build(),
+          provider: providerDto,
+          originalSearch: {},
+        })
+
+        expect(result.complianceItems).toEqual([
+          { key: { text: 'Wore hi-vis' }, value: { text: 'Yes' } },
+          { key: { text: 'Working intensively' }, value: { text: 'Yes' } },
+          { key: { text: 'Work quality' }, value: { text: 'Good' } },
+          { key: { text: 'Behaviour' }, value: { text: 'Excellent' } },
+        ])
+      })
+
+      it('should return empty array when attendance data is undefined', () => {
+        const appointmentWithoutAttendance = appointmentFactory.build({ attendanceData: undefined })
+
+        const result = page.viewData({
+          appointment: appointmentWithoutAttendance,
+          project: projectFactory.build(),
+          provider: providerDto,
+          originalSearch: {},
+        })
+
+        expect(result.complianceItems).toEqual([])
+      })
     })
 
     describe('showContinueButton', () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -235,6 +235,118 @@ describe('CheckAppointmentDetailsPage', () => {
       })
     })
 
+    describe('timeItems', () => {
+      it('should return all time items with values when all values are above 0', () => {
+        const appointmentWithAllTimeValues = appointmentFactory.build({
+          minutesCredited: 240,
+          attendanceData: { penaltyMinutes: 60 },
+        })
+
+        jest.spyOn(DateTimeFormats, 'totalMinutesToHumanReadableHoursAndMinutes').mockImplementation(minutes => {
+          if (minutes === 240) return '4 hours'
+          if (minutes === 60) return '1 hour'
+          if (minutes === 300) return '5 hours'
+          return ''
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithAllTimeValues,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.timeItems).toEqual([
+          { key: { text: 'Hours worked' }, value: { text: '5 hours' } },
+          { key: { text: 'Penalty hours' }, value: { text: '1 hour' } },
+          { key: { text: 'Hours credited' }, value: { text: '4 hours' } },
+        ])
+      })
+
+      it('should only show hours credited when penaltyMinutes is 0', () => {
+        const appointmentWithOnlyCredited = appointmentFactory.build({
+          minutesCredited: 240,
+          attendanceData: { penaltyMinutes: 0 },
+        })
+
+        jest.spyOn(DateTimeFormats, 'totalMinutesToHumanReadableHoursAndMinutes').mockImplementation(minutes => {
+          if (minutes === 240) return '4 hours'
+          return ''
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithOnlyCredited,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.timeItems).toEqual([
+          { key: { text: 'Hours worked' }, value: { text: '4 hours' } },
+          { key: { text: 'Hours credited' }, value: { text: '4 hours' } },
+        ])
+      })
+
+      it('should only show hours worked and penalty hours when minutesCredited is 0', () => {
+        const appointmentWithOnlyPenalty = appointmentFactory.build({
+          minutesCredited: 0,
+          attendanceData: { penaltyMinutes: 120 },
+        })
+
+        jest.spyOn(DateTimeFormats, 'totalMinutesToHumanReadableHoursAndMinutes').mockImplementation(minutes => {
+          if (minutes === 120) return '2 hours'
+          return ''
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithOnlyPenalty,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.timeItems).toEqual([
+          { key: { text: 'Hours worked' }, value: { text: '2 hours' } },
+          { key: { text: 'Penalty hours' }, value: { text: '2 hours' } },
+        ])
+      })
+
+      it('should return empty values for all time items when both minutesCredited and penaltyMinutes are 0', () => {
+        const appointmentWithNoTime = appointmentFactory.build({
+          minutesCredited: 0,
+          attendanceData: { penaltyMinutes: 0 },
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithNoTime,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.timeItems).toEqual([])
+      })
+
+      it('should default penaltyMinutes to 0 when attendanceData is undefined', () => {
+        const appointmentWithoutAttendance = appointmentFactory.build({
+          minutesCredited: 180,
+          attendanceData: undefined,
+        })
+
+        jest.spyOn(DateTimeFormats, 'totalMinutesToHumanReadableHoursAndMinutes').mockImplementation(minutes => {
+          if (minutes === 180) return '3 hours'
+          return ''
+        })
+
+        const result = page.viewData({
+          appointment: appointmentWithoutAttendance,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.timeItems).toEqual([
+          { key: { text: 'Hours worked' }, value: { text: '3 hours' } },
+          { key: { text: 'Hours credited' }, value: { text: '3 hours' } },
+        ])
+      })
+    })
+
     describe('showContinueButton', () => {
       it('should return true if no outcome is associated with the appointment', () => {
         const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -31,7 +31,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
     beforeEach(() => {
       page = new CheckAppointmentDetailsPage({}, projectFactory.build())
-      appointment = appointmentFactory.build()
+      appointment = appointmentFactory.build({ sensitive: false })
       jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue(updatePath)
     })
 
@@ -112,23 +112,22 @@ describe('CheckAppointmentDetailsPage', () => {
       ])
     })
 
-    it('should return an object containing appointment details', () => {
-      const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
-      jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
-      jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Yes')
+    describe('appointmentItems', () => {
+      it('should return appointment items with formatted notes and sensitive values', () => {
+        jest.spyOn(AppointmentUtils, 'formatNotesAsHtml').mockReturnValue(appointment.notes)
 
-      const result = page.viewData({
-        appointment,
-        project: projectFactory.build(),
-        originalSearch: {},
+        const result = page.viewData({
+          appointment,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.appointmentItems).toEqual([
+          { key: { text: 'Notes detail' }, value: { html: appointment.notes } },
+          { key: { text: 'Sensitive' }, value: { text: 'No' } },
+        ])
+        expect(AppointmentUtils.formatNotesAsHtml).toHaveBeenCalledWith(appointment.notes)
       })
-
-      const appointmentDetails = {
-        notes: appointment.notes,
-        sensitive: 'Yes',
-      }
-
-      expect(result.appointment).toEqual(appointmentDetails)
     })
 
     it('should return an object containing offender', () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -23,6 +23,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
     contactOutcomeCode?: string
   }
   complianceItems: Array<GovUkSummaryListItem>
+  timeItems: Array<GovUkSummaryListItem>
 }
 
 interface Body {
@@ -73,7 +74,36 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       projectItems: this.buildProjectDetails(project, appointment),
       showContinueButton: !appointment.contactOutcomeCode,
       complianceItems: this.buildComplianceDetails(appointment),
+      timeItems: this.buildTimeDetails(appointment),
     }
+  }
+
+  private buildTimeDetails(appointment: AppointmentDto): GovUkSummaryListItem[] {
+    const penaltyMinutes = appointment.attendanceData?.penaltyMinutes ?? 0
+    const minutesCredited = appointment.minutesCredited ?? 0
+    const minutesWorked = minutesCredited + penaltyMinutes
+    return GovUKComponentUtils.buildSummaryListItems(
+      [
+        {
+          label: 'Hours worked',
+          content:
+            minutesWorked > 0 ? DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(minutesWorked) : undefined,
+        },
+        {
+          label: 'Penalty hours',
+          content:
+            penaltyMinutes > 0 ? DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(penaltyMinutes) : undefined,
+        },
+        {
+          label: 'Hours credited',
+          content:
+            minutesCredited > 0
+              ? DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(minutesCredited)
+              : undefined,
+        },
+      ],
+      true,
+    )
   }
 
   private buildComplianceDetails(appointment: AppointmentDto): Array<GovUkSummaryListItem> {
@@ -116,7 +146,10 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
           ? LocationUtils.locationToString(appointment.pickUpData?.pickupLocation, { withLineBreaks: false })
           : undefined,
       },
-      { label: 'Pick up time', content: DateTimeFormats.stripTime(appointment.pickUpData?.time) },
+      {
+        label: 'Pick up time',
+        content: appointment.pickUpData?.time ? DateTimeFormats.stripTime(appointment.pickUpData?.time) : undefined,
+      },
       { label: 'Supervising team', content: appointment.supervisingTeam },
       { label: 'Supervising officer', content: appointment.supervisorOfficerName },
     ]

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -7,6 +7,7 @@ import {
   ValidationErrors,
 } from '../../@types/user-defined'
 import paths from '../../paths'
+import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import GovUKComponentUtils from '../../utils/govUkComponentUtils'
 import LocationUtils from '../../utils/locationUtils'
@@ -21,6 +22,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
     sensitive: string
     contactOutcomeCode?: string
   }
+  complianceItems: Array<GovUkSummaryListItem>
 }
 
 interface Body {
@@ -72,7 +74,30 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       },
       projectItems: this.buildProjectDetails(project, appointment, provider),
       showContinueButton: !appointment.contactOutcomeCode,
+      complianceItems: this.buildComplianceDetails(appointment),
     }
+  }
+
+  private buildComplianceDetails(appointment: AppointmentDto): Array<GovUkSummaryListItem> {
+    if (appointment.attendanceData) {
+      return GovUKComponentUtils.buildSummaryListItems(
+        [
+          { label: 'Wore hi-vis', content: yesNoDisplayValue(appointment.attendanceData?.hiVisWorn) },
+          { label: 'Working intensively', content: yesNoDisplayValue(appointment.attendanceData?.workedIntensively) },
+          {
+            label: 'Work quality',
+            content: AppointmentUtils.formatComplianceRatings(appointment.attendanceData?.workQuality),
+          },
+          {
+            label: 'Behaviour',
+            content: AppointmentUtils.formatComplianceRatings(appointment.attendanceData?.behaviour),
+          },
+        ],
+        true,
+      )
+    }
+
+    return []
   }
 
   private buildProjectDetails(

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -53,12 +53,17 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     this.formId = id
   }
 
-  viewData(
-    appointment: AppointmentDto,
-    project: ProjectDto,
-    provider: ProviderSummaryDto,
-    originalSearch: Record<string, string>,
-  ): ViewData {
+  viewData({
+    appointment,
+    project,
+    provider,
+    originalSearch,
+  }: {
+    appointment: AppointmentDto
+    project: ProjectDto
+    provider: ProviderSummaryDto
+    originalSearch: Record<string, string>
+  }): ViewData {
     return {
       ...this.commonViewData(appointment, originalSearch),
       appointment: {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -17,11 +17,7 @@ import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 interface ViewData extends AppointmentUpdatePageViewData {
   projectItems: Array<GovUkSummaryListItem>
   showContinueButton: boolean
-  appointment: {
-    notes: string
-    sensitive: string
-    contactOutcomeCode?: string
-  }
+  appointmentItems: Array<GovUkSummaryListItem>
   complianceItems: Array<GovUkSummaryListItem>
   timeItems: Array<GovUkSummaryListItem>
   sharedItems: Array<GovUkSummaryListItem>
@@ -68,16 +64,23 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
   }): ViewData {
     return {
       ...this.commonViewData(appointment, originalSearch),
-      appointment: {
-        notes: appointment.notes,
-        sensitive: yesNoDisplayValue(appointment.sensitive),
-      },
       projectItems: this.buildProjectDetails(project, appointment),
+      appointmentItems: this.buildAppointmentDetails(appointment),
       showContinueButton: !appointment.contactOutcomeCode,
       complianceItems: this.buildComplianceDetails(appointment),
       timeItems: this.buildTimeDetails(appointment),
       sharedItems: this.buildSharedDetails(appointment),
     }
+  }
+
+  private buildAppointmentDetails(appointment: AppointmentDto): Array<GovUkSummaryListItem> {
+    return GovUKComponentUtils.buildSummaryListItems(
+      [
+        { label: 'Notes detail', content: AppointmentUtils.formatNotesAsHtml(appointment.notes), contentIsHtml: true },
+        { label: 'Sensitive', content: yesNoDisplayValue(appointment.sensitive) },
+      ],
+      true,
+    )
   }
 
   private buildSharedDetails(appointment: AppointmentDto): Array<GovUkSummaryListItem> {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -24,6 +24,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
   }
   complianceItems: Array<GovUkSummaryListItem>
   timeItems: Array<GovUkSummaryListItem>
+  sharedItems: Array<GovUkSummaryListItem>
 }
 
 interface Body {
@@ -75,7 +76,24 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       showContinueButton: !appointment.contactOutcomeCode,
       complianceItems: this.buildComplianceDetails(appointment),
       timeItems: this.buildTimeDetails(appointment),
+      sharedItems: this.buildSharedDetails(appointment),
     }
+  }
+
+  private buildSharedDetails(appointment: AppointmentDto): Array<GovUkSummaryListItem> {
+    return GovUKComponentUtils.buildSummaryListItems(
+      [
+        { label: 'Enforcement action', content: appointment.enforcementData?.enforcementActionName },
+        {
+          label: 'Respond by',
+          content: appointment.enforcementData?.respondBy
+            ? DateTimeFormats.isoDateToUIDate(appointment.enforcementData.respondBy)
+            : undefined,
+        },
+        { label: 'Alert sent', content: yesNoDisplayValue(appointment.alertActive) },
+      ],
+      true,
+    )
   }
 
   private buildTimeDetails(appointment: AppointmentDto): GovUkSummaryListItem[] {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ProjectDto, ProviderSummaryDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ProjectDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
@@ -58,12 +58,10 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
   viewData({
     appointment,
     project,
-    provider,
     originalSearch,
   }: {
     appointment: AppointmentDto
     project: ProjectDto
-    provider: ProviderSummaryDto
     originalSearch: Record<string, string>
   }): ViewData {
     return {
@@ -72,7 +70,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
         notes: appointment.notes,
         sensitive: yesNoDisplayValue(appointment.sensitive),
       },
-      projectItems: this.buildProjectDetails(project, appointment, provider),
+      projectItems: this.buildProjectDetails(project, appointment),
       showContinueButton: !appointment.contactOutcomeCode,
       complianceItems: this.buildComplianceDetails(appointment),
     }
@@ -100,13 +98,9 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return []
   }
 
-  private buildProjectDetails(
-    project: ProjectDto,
-    appointment: AppointmentDto,
-    provider: ProviderSummaryDto,
-  ): Array<GovUkSummaryListItem> {
+  private buildProjectDetails(project: ProjectDto, appointment: AppointmentDto): Array<GovUkSummaryListItem> {
     const items = [
-      { label: 'Region', content: provider?.name },
+      { label: 'Region', content: project.providerName },
       { label: 'Team', content: project.teamName },
       { label: 'Project', content: project.projectName },
       { label: 'Project type', content: project.projectType.name },

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -3,24 +3,22 @@ import {
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
+  GovUkSummaryListItem,
   ValidationErrors,
 } from '../../@types/user-defined'
 import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import GovUKComponentUtils from '../../utils/govUkComponentUtils'
 import LocationUtils from '../../utils/locationUtils'
 import { yesNoDisplayValue } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 
 interface ViewData extends AppointmentUpdatePageViewData {
-  project: { name: string; type: string; supervisingTeam: string; dateAndTime: string; location: string }
+  projectItems: Array<GovUkSummaryListItem>
   showContinueButton: boolean
   appointment: {
-    providerCode: string
     notes: string
-    pickUpTime: string
-    pickUpPlace: string
     sensitive: string
-    provider: string
     contactOutcomeCode?: string
   }
 }
@@ -64,24 +62,42 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return {
       ...this.commonViewData(appointment, originalSearch),
       appointment: {
-        providerCode: appointment.providerCode,
         notes: appointment.notes,
         sensitive: yesNoDisplayValue(appointment.sensitive),
-        pickUpTime: appointment.pickUpData?.time ? DateTimeFormats.stripTime(appointment.pickUpData.time) : '',
-        pickUpPlace: appointment.pickUpData?.location
-          ? LocationUtils.locationToString(appointment.pickUpData.location, { withLineBreaks: false })
-          : '',
-        provider: provider?.name,
       },
-      project: {
-        name: project.projectName,
-        type: project.projectType.name,
-        supervisingTeam: appointment.supervisingTeam,
-        location: LocationUtils.locationToString(project.location, { withLineBreaks: false }),
-        dateAndTime: DateTimeFormats.dateAndTimePeriod(appointment.date, appointment.startTime, appointment.endTime),
-      },
+      projectItems: this.buildProjectDetails(project, appointment, provider),
       showContinueButton: !appointment.contactOutcomeCode,
     }
+  }
+
+  private buildProjectDetails(
+    project: ProjectDto,
+    appointment: AppointmentDto,
+    provider: ProviderSummaryDto,
+  ): Array<GovUkSummaryListItem> {
+    const items = [
+      { label: 'Region', content: provider?.name },
+      { label: 'Team', content: project.teamName },
+      { label: 'Project', content: project.projectName },
+      { label: 'Project type', content: project.projectType.name },
+      { label: 'Location', content: LocationUtils.locationToString(project.location, { withLineBreaks: false }) },
+      { label: 'Date', content: DateTimeFormats.isoDateToUIDate(appointment.date) },
+      {
+        label: 'Time',
+        content: `${DateTimeFormats.stripTime(appointment.startTime)} - ${DateTimeFormats.stripTime(appointment.endTime)}`,
+      },
+      {
+        label: 'Pick up place',
+        content: appointment.pickUpData?.pickupLocation
+          ? LocationUtils.locationToString(appointment.pickUpData?.pickupLocation, { withLineBreaks: false })
+          : undefined,
+      },
+      { label: 'Pick up time', content: DateTimeFormats.stripTime(appointment.pickUpData?.time) },
+      { label: 'Supervising team', content: appointment.supervisingTeam },
+      { label: 'Supervising officer', content: appointment.supervisorOfficerName },
+    ]
+
+    return GovUKComponentUtils.buildSummaryListItems(items, true)
   }
 
   protected backPath(appointment: AppointmentDto, originalSearch: Record<string, string>): string {

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -279,7 +279,7 @@ describe('ConfirmPage', () => {
             const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { hiVisWorn: true } })
 
             const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('High-vis - Yes')
+            expect(result).toMatch('Wore hi-vis - Yes')
           })
         })
 
@@ -288,7 +288,7 @@ describe('ConfirmPage', () => {
             const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { hiVisWorn: false } })
 
             const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('High-vis - No')
+            expect(result).toMatch('Wore hi-vis - No')
           })
         })
 
@@ -299,7 +299,7 @@ describe('ConfirmPage', () => {
             })
 
             const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Worked intensively - No')
+            expect(result).toMatch('Working intensively - No')
           })
         })
 
@@ -310,7 +310,7 @@ describe('ConfirmPage', () => {
             })
 
             const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Worked intensively - Yes')
+            expect(result).toMatch('Working intensively - Yes')
           })
         })
 
@@ -446,7 +446,7 @@ describe('ConfirmPage', () => {
             text: 'Compliance',
           },
           value: {
-            html: 'High-vis - Yes<br>Worked intensively - Yes<br>Work quality - Good<br>Behaviour - Not applicable',
+            html: 'Wore hi-vis - Yes<br>Working intensively - Yes<br>Work quality - Good<br>Behaviour - Not applicable',
           },
           actions: {
             items: [

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -9,9 +9,9 @@ import {
 } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import paths from '../../paths'
+import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import NotesUtils from '../../utils/notesUtils'
-import { properCase } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 
 interface ViewData extends AppointmentUpdatePageViewData {
@@ -227,19 +227,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     }
 
     if (form.attendanceData?.workQuality) {
-      answers += `Work quality - ${this.formatComplianceRatings(form.attendanceData.workQuality)}<br>`
+      answers += `Work quality - ${AppointmentUtils.formatComplianceRatings(form.attendanceData.workQuality)}<br>`
     }
 
     if (form.attendanceData?.behaviour) {
-      answers += `Behaviour - ${this.formatComplianceRatings(form.attendanceData.behaviour)}`
+      answers += `Behaviour - ${AppointmentUtils.formatComplianceRatings(form.attendanceData.behaviour)}`
     }
 
     return answers
-  }
-
-  private formatComplianceRatings(rating: string): string {
-    const ratingWithProperCasing = properCase(rating)
-    const ratingSubstrings = ratingWithProperCasing.split('_')
-    return ratingSubstrings.length > 1 ? `${ratingSubstrings[0]} ${ratingSubstrings[1]}` : ratingSubstrings[0]
   }
 }

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -219,11 +219,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     let answers = ''
 
     if (typeof form.attendanceData?.hiVisWorn === 'boolean') {
-      answers += `High-vis - ${form.attendanceData.hiVisWorn ? 'Yes' : 'No'}<br>`
+      answers += `Wore hi-vis - ${form.attendanceData.hiVisWorn ? 'Yes' : 'No'}<br>`
     }
 
     if (typeof form.attendanceData?.workedIntensively === 'boolean') {
-      answers += `Worked intensively - ${form.attendanceData.workedIntensively ? 'Yes' : 'No'}<br>`
+      answers += `Working intensively - ${form.attendanceData.workedIntensively ? 'Yes' : 'No'}<br>`
     }
 
     if (form.attendanceData?.workQuality) {

--- a/server/pages/courseCompletions/process/appointmentPage.test.ts
+++ b/server/pages/courseCompletions/process/appointmentPage.test.ts
@@ -131,6 +131,20 @@ describe('AppointmentPage', () => {
       )
     })
 
+    it('returns an array of options with notes containing line breaks', () => {
+      const notes = 'First note\nSecond note\nThird note'
+      const appointmentSummary = appointmentSummaryFactory.build({ notes })
+      const pagedModelAppointmentSummaries = pagedModelAppointmentSummaryFactory.build({
+        content: [appointmentSummary],
+      })
+
+      const [result] = page.getAppointmentOptions(pagedModelAppointmentSummaries)
+
+      expect(result.hint.html).toEqual(
+        `Project type: ${appointmentSummary.projectTypeName}<br>Project: ${appointmentSummary.projectName}<br>Notes: First note<br/>Second note<br/>Third note`,
+      )
+    })
+
     it('returns an array of options with selected value', () => {
       const appointmentSummary = appointmentSummaryFactory.build()
       const pagedModelAppointmentSummaries = pagedModelAppointmentSummaryFactory.build({

--- a/server/pages/courseCompletions/process/appointmentPage.ts
+++ b/server/pages/courseCompletions/process/appointmentPage.ts
@@ -1,6 +1,7 @@
 import { PagedModelAppointmentSummaryDto } from '../../../@types/shared'
 import { ValidationErrors } from '../../../@types/user-defined'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import AppointmentUtils from '../../../utils/appointmentUtils'
 import DateTimeFormats from '../../../utils/dateTimeUtils'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
@@ -50,7 +51,7 @@ export default class AppointmentPage extends BaseCourseCompletionFormPage<Body> 
       const hintContent = [`Project type: ${appointment.projectTypeName}`, `Project: ${appointment.projectName}`]
 
       if (appointment.notes) {
-        hintContent.push(`Notes: ${appointment.notes.split('\n').join('<br>')}`)
+        hintContent.push(`Notes: ${AppointmentUtils.formatNotesAsHtml(appointment.notes)}`)
       }
 
       const hintHtml = hintContent.join('<br>')

--- a/server/testutils/factories/appointmentFactory.ts
+++ b/server/testutils/factories/appointmentFactory.ts
@@ -5,6 +5,7 @@ import offenderFullFactory from './offenderFullFactory'
 import attendanceDataFactory from './attendanceDataFactory'
 import enforcementDataFactory from './enforcementDataFactory'
 import projectTypeFactory from './projectTypeFactory'
+import pickupDataFactory from './pickupDataFactory'
 
 export default Factory.define<AppointmentDto>(() => ({
   id: faker.number.int(),
@@ -30,4 +31,5 @@ export default Factory.define<AppointmentDto>(() => ({
   notes: faker.string.alpha(30),
   sensitive: faker.datatype.boolean(),
   alertActive: faker.datatype.boolean(),
+  pickUpData: pickupDataFactory.build(),
 }))

--- a/server/testutils/factories/pickupDataFactory.ts
+++ b/server/testutils/factories/pickupDataFactory.ts
@@ -1,0 +1,19 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { PickUpDataDto, PickUpLocationDto } from '../../@types/shared'
+
+export default Factory.define<PickUpDataDto>(() => ({
+  pickupLocation: pickupLocationFactory.build(),
+  time: '09:00:00',
+}))
+
+export const pickupLocationFactory = Factory.define<PickUpLocationDto>(() => ({
+  buildingName: faker.company.name(),
+  buildingNumber: faker.location.buildingNumber(),
+  streetName: faker.location.street(),
+  townCity: faker.location.city(),
+  county: faker.location.county(),
+  deliusCode: faker.string.alpha(8),
+  description: faker.location.streetAddress(),
+  postCode: faker.location.zipCode(),
+}))

--- a/server/utils/appointmentUtils.test.ts
+++ b/server/utils/appointmentUtils.test.ts
@@ -75,4 +75,25 @@ describe('AppointmentUtils', () => {
       expect(result.rows[4].value).toEqual({ html: 'note 1<br/>note 2<br/>note 3' })
     })
   })
+
+  describe('formatComplianceRatings', () => {
+    it.each([
+      ['EXCELLENT', 'Excellent'],
+      ['GOOD', 'Good'],
+      ['POOR', 'Poor'],
+      ['SATISFACTORY', 'Satisfactory'],
+      ['UNSATISFACTORY', 'Unsatisfactory'],
+      ['NOT_APPLICABLE', 'Not applicable'],
+    ])('formats %s rating as %s', (input, expected) => {
+      const result = AppointmentUtils.formatComplianceRatings(
+        input as 'EXCELLENT' | 'GOOD' | 'NOT_APPLICABLE' | 'POOR' | 'SATISFACTORY' | 'UNSATISFACTORY',
+      )
+      expect(result).toBe(expected)
+    })
+
+    it('returns undefined if rating is undefined', () => {
+      const result = AppointmentUtils.formatComplianceRatings(undefined)
+      expect(result).toBeUndefined()
+    })
+  })
 })

--- a/server/utils/appointmentUtils.test.ts
+++ b/server/utils/appointmentUtils.test.ts
@@ -26,7 +26,7 @@ describe('AppointmentUtils', () => {
           { key: { text: 'Project' }, value: { text: appointment.projectName } },
           { key: { text: 'Time credited' }, value: { text: '3 hours 54 minutes' } },
           { key: { text: 'Outcome' }, value: { text: appointment.contactOutcome.name } },
-          { key: { text: 'Notes' }, value: { html: appointment.notes } },
+          { key: { text: 'Notes' }, value: { html: AppointmentUtils.formatNotesAsHtml(appointment.notes) } },
         ],
       })
 
@@ -73,6 +73,30 @@ describe('AppointmentUtils', () => {
       const result = AppointmentUtils.appointmentCard(appointment)
 
       expect(result.rows[4].value).toEqual({ html: 'note 1<br/>note 2<br/>note 3' })
+    })
+  })
+
+  describe('formatNotesAsHtml', () => {
+    it('converts newline characters to <br/> tags', () => {
+      const notes = 'Line 1\nLine 2\nLine 3'
+      const result = AppointmentUtils.formatNotesAsHtml(notes)
+      expect(result).toBe('Line 1<br/>Line 2<br/>Line 3')
+    })
+
+    it('returns undefined if notes is undefined', () => {
+      const result = AppointmentUtils.formatNotesAsHtml(undefined)
+      expect(result).toBeUndefined()
+    })
+
+    it('returns empty string if notes is empty', () => {
+      const result = AppointmentUtils.formatNotesAsHtml('')
+      expect(result).toBe('')
+    })
+
+    it('returns the same string if there are no newlines', () => {
+      const notes = 'Single line note'
+      const result = AppointmentUtils.formatNotesAsHtml(notes)
+      expect(result).toBe('Single line note')
     })
   })
 

--- a/server/utils/appointmentUtils.ts
+++ b/server/utils/appointmentUtils.ts
@@ -1,6 +1,7 @@
-import { AppointmentSummaryDto } from '../@types/shared'
+import { AppointmentSummaryDto, AttendanceDataDto } from '../@types/shared'
 import { SummaryCard } from '../@types/user-defined'
 import DateTimeFormats from './dateTimeUtils'
+import { properCase } from './utils'
 
 export default class AppointmentUtils {
   static appointmentCard(appointment: AppointmentSummaryDto): SummaryCard {
@@ -51,6 +52,17 @@ export default class AppointmentUtils {
         },
       ],
     }
+  }
+
+  static formatComplianceRatings(
+    rating?: AttendanceDataDto['workQuality'] | AttendanceDataDto['behaviour'],
+  ): string | undefined {
+    if (!rating) {
+      return undefined
+    }
+    const ratingWithProperCasing = properCase(rating)
+    const ratingSubstrings = ratingWithProperCasing.split('_')
+    return ratingSubstrings.length > 1 ? `${ratingSubstrings[0]} ${ratingSubstrings[1]}` : ratingSubstrings[0]
   }
 
   private static timeCreditedText(appointment: AppointmentSummaryDto): string {

--- a/server/utils/appointmentUtils.ts
+++ b/server/utils/appointmentUtils.ts
@@ -47,11 +47,15 @@ export default class AppointmentUtils {
             text: 'Notes',
           },
           value: {
-            html: appointment.notes?.split('\n').join('<br/>'),
+            html: AppointmentUtils.formatNotesAsHtml(appointment.notes),
           },
         },
       ],
     }
+  }
+
+  static formatNotesAsHtml(notes?: string): string | undefined {
+    return notes?.split('\n').join('<br/>')
   }
 
   static formatComplianceRatings(

--- a/server/utils/govUkComponentUtils.test.ts
+++ b/server/utils/govUkComponentUtils.test.ts
@@ -114,4 +114,114 @@ describe('GovUKComponentUtils', () => {
       expect(result[0].classes).toBe('custom-class another-class govuk-summary-list__row--no-actions')
     })
   })
+
+  describe('buildSummaryListItem', () => {
+    it('should build summary list item with text content by default', () => {
+      const result = GovUKComponentUtils.buildSummaryListItem({ label: 'Name', content: 'John Doe' })
+
+      expect(result).toEqual({
+        key: { text: 'Name' },
+        value: { text: 'John Doe' },
+      })
+    })
+
+    it('should build summary list item with text content when contentIsHtml is false', () => {
+      const result = GovUKComponentUtils.buildSummaryListItem({
+        label: 'Name',
+        content: 'John Doe',
+        contentIsHtml: false,
+      })
+
+      expect(result).toEqual({
+        key: { text: 'Name' },
+        value: { text: 'John Doe' },
+      })
+    })
+
+    it('should build summary list item with html content when contentIsHtml is true', () => {
+      const htmlContent = '<strong>Important</strong>'
+      const result = GovUKComponentUtils.buildSummaryListItem({
+        label: 'Status',
+        content: htmlContent,
+        contentIsHtml: true,
+      })
+
+      expect(result).toEqual({
+        key: { text: 'Status' },
+        value: { html: htmlContent },
+      })
+    })
+
+    it('should build summary list item with undefined value when content is undefined', () => {
+      const result = GovUKComponentUtils.buildSummaryListItem({ label: 'Notes', content: undefined })
+
+      expect(result).toEqual({
+        key: { text: 'Notes' },
+        value: { text: undefined },
+      })
+    })
+
+    it('should build summary list item with undefined html value when content is undefined and contentIsHtml is true', () => {
+      const result = GovUKComponentUtils.buildSummaryListItem({
+        label: 'Notes',
+        content: undefined,
+        contentIsHtml: true,
+      })
+
+      expect(result).toEqual({
+        key: { text: 'Notes' },
+        value: { html: undefined },
+      })
+    })
+  })
+
+  describe('buildSummaryListItems', () => {
+    it('should build multiple summary list items', () => {
+      const items = [
+        { label: 'Name', content: 'John Doe' },
+        { label: 'Age', content: '30' },
+        { label: 'Status', content: '<strong>Active</strong>', contentIsHtml: true },
+        { label: 'Notes', content: undefined },
+      ]
+
+      const result = GovUKComponentUtils.buildSummaryListItems(items)
+
+      expect(result).toEqual([
+        {
+          key: { text: 'Name' },
+          value: { text: 'John Doe' },
+        },
+        {
+          key: { text: 'Age' },
+          value: { text: '30' },
+        },
+        {
+          key: { text: 'Status' },
+          value: { html: '<strong>Active</strong>' },
+        },
+        {
+          key: { text: 'Notes' },
+          value: { text: undefined },
+        },
+      ])
+    })
+
+    it('should remove empty rows if required', () => {
+      const items = [
+        { label: 'Name', content: 'John Doe' },
+        { label: 'Age', content: '' },
+        { label: 'Status', content: null },
+        { label: 'Notes', content: undefined },
+      ]
+
+      const result = GovUKComponentUtils.buildSummaryListItems(items, true)
+
+      expect(result).toEqual([
+        {
+          key: { text: 'Name' },
+          value: { text: 'John Doe' },
+        },
+      ])
+    })
+  })
 })

--- a/server/utils/govUkComponentUtils.ts
+++ b/server/utils/govUkComponentUtils.ts
@@ -1,5 +1,10 @@
 import { GovUkSummaryListItem } from '../@types/user-defined'
 
+export type SummaryListBuildOptions = {
+  label: string
+  content?: string
+  contentIsHtml?: boolean
+}
 export default class GovUKComponentUtils {
   static summaryListRowsWithAndWithoutActions(items: Array<GovUkSummaryListItem>) {
     return items.map(item => {
@@ -10,5 +15,33 @@ export default class GovUKComponentUtils {
 
       return { ...item, classes }
     })
+  }
+
+  static buildSummaryListItem({
+    label,
+    content,
+    contentIsHtml = false,
+  }: SummaryListBuildOptions): GovUkSummaryListItem {
+    const value = contentIsHtml
+      ? {
+          html: content,
+        }
+      : {
+          text: content,
+        }
+    return {
+      key: {
+        text: label,
+      },
+      value,
+    }
+  }
+
+  static buildSummaryListItems(
+    items: Array<SummaryListBuildOptions>,
+    removeEmptyRows: boolean = false,
+  ): Array<GovUkSummaryListItem> {
+    const itemsToMap = removeEmptyRows ? items.filter(item => item.content) : items
+    return itemsToMap.map(this.buildSummaryListItem)
   }
 }

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -54,35 +54,21 @@
     </div>
   {% endif %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {{ govukSummaryList({
-        card: {
-          title: {
-            text: 'Appointment details'
-          }
-        },
-        rows: [
-          {
-            key: {
-              text: "Notes"
-            },
-            value: {
-              text: appointment.notes | escape | nl2br
+  {% if appointmentItems.length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: 'Notes',
+              headingLevel: 3
             }
           },
-          {
-            key: {
-              text: "Sensitive"
-            },
-            value: {
-              text: appointment.sensitive
-            }
-          }
-        ]
-      }) }}
+          rows: appointmentItems
+        }) }}
+      </div>
     </div>
-  </div>
+  {% endif %}
 
   {% if sharedItems.length %}
     <div class="govuk-grid-row">

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -84,4 +84,20 @@
     </div>
   </div>
 
+  {% if sharedItems.length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: 'Shared information',
+              headingLevel: 3
+            }
+          },
+          rows: sharedItems
+        }) }}
+      </div>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -13,51 +13,11 @@
       {{ govukSummaryList({
         card: {
           title: {
-            text: 'Project details'
+            text: 'Project details',
+            headingLevel: 3
           }
         },
-        rows: [
-          {
-            key: {
-              text: "Project"
-            },
-            value: {
-              text: project.name
-            }
-          },
-          {
-            key: {
-              text: "Project type"
-            },
-            value: {
-              text: project.type
-            }
-          },
-          {
-            key: {
-              text: "Supervising team"
-            },
-            value: {
-              text: project.supervisingTeam
-            }
-          },
-          {
-            key: {
-              text: "Date and time"
-            },
-            value: {
-              text: project.dateAndTime
-            }
-          },
-          {
-            key: {
-              text: "Location"
-            },
-            value: {
-              text: project.location
-            }
-          }
-        ]
+        rows: projectItems
       }) }}
     </div>
   </div>
@@ -71,30 +31,6 @@
           }
         },
         rows: [
-          {
-            key: {
-              text: "Provider"
-            },
-            value: {
-              text: appointment.provider
-            }
-          },
-          {
-            key: {
-              text: "Pick up time"
-            },
-            value: {
-              text: appointment.pickUpTime
-            }
-          },
-          {
-            key: {
-              text: "Pick up place"
-            },
-            value: {
-              text: appointment.pickUpPlace
-            }
-          },
           {
             key: {
               text: "Notes"

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -22,6 +22,22 @@
     </div>
   </div>
 
+  {% if complianceItems.length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: 'Compliance details',
+              headingLevel: 3
+            }
+          },
+          rows: complianceItems
+        }) }}
+      </div>
+    </div>
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {{ govukSummaryList({

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -22,6 +22,22 @@
     </div>
   </div>
 
+  {% if timeItems.length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ govukSummaryList({
+          card: {
+            title: {
+              text: 'Hours detail',
+              headingLevel: 3
+            }
+          },
+          rows: timeItems
+        }) }}
+      </div>
+    </div>
+  {% endif %}
+
   {% if complianceItems.length %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">


### PR DESCRIPTION
## Context

This PR restructures the appointment details page into multiple summary-card sections (project, hours, compliance, notes, shared info), in order to display more upfront information about the appointment upfront.

[CPB-909](https://dsdmoj.atlassian.net/browse/CPB-909)

## Changes in this PR

- Updated the `appointmentDetails.njk` template to conditionally render summary cards from projectItems, timeItems, complianceItems, appointmentItems, and sharedItems, if they each have any items.
- Added a utility function to standardise summary-list row creation in TypeScript, with optional empty-row filtering.
- Extracted methods to format multiline notes as HTML and format compliance ratings and updated related pages/tests to use them.
- removed provider lookups from the appointment details controller flow, and replaced with new property on the `AppointmentDto`.

Yet to implement:
- Display the contact outcome as a status tag
- Display an additional call to action if no contact outcome on an appointment in the past
- Move Update button into header

### Screenshots of UI changes

An appointment with compliance and hours details:
<img width="2456" height="5364" alt="attended - complied appointment page" src="https://github.com/user-attachments/assets/c03803ec-03aa-422a-a281-44edafe3ee51" />

An appointment with no compliance and hours details but an enforcement action:
<img width="2456" height="4056" alt="unacceptable - absence appointment page" src="https://github.com/user-attachments/assets/3932b04a-e116-476b-a9fd-bf0acee3d96b" />

An appointment with no outcome or attendance details logged:
<img width="2456" height="3514" alt="appointment page with no outcome" src="https://github.com/user-attachments/assets/790af7c1-5f95-4719-8d87-0676ee238531" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-909]: https://dsdmoj.atlassian.net/browse/CPB-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ