### PR TITLE
CPB-940: Corrected appointment tasks filter to providerCode for region

### DIFF
--- a/server/data/appointmentClient.test.ts
+++ b/server/data/appointmentClient.test.ts
@@ -69,7 +69,8 @@ describe('appointmentClient', () => {
     it('should make a GET request to the appointment tasks path using user token and return the response body', async () => {
       const appointments = pagedModelAppointmentTaskSummaryFactory.build()
       nock(config.apis.communityPaybackApi.url)
-        .get(paths.appointments.tasks.filter({ provider: '123' }))
+        .get(paths.appointments.tasks.filter.pattern)
+        .query({ providerCode: '123' })
         .matchHeader('authorization', 'Bearer test-system-token')
         .reply(200, appointments)
 

--- a/server/data/appointmentClient.ts
+++ b/server/data/appointmentClient.ts
@@ -47,10 +47,9 @@ export default class AppointmentClient extends RestClient {
   }
 
   async getAppointmentTasks(params: GetAppointmentTasksRequest): Promise<PagedModelAppointmentTaskSummaryDto> {
-    const { username, providerCode, ...queryParams } = params
+    const { username, ...queryParams } = params
     const query = createQueryString(queryParams)
-    const path = paths.appointments.tasks.filter({ appointmentProviderCode: params.providerCode })
-
+    const path = paths.appointments.tasks.filter.pattern
     return (await this.get({ path, query }, asSystem(username))) as PagedModelAppointmentTaskSummaryDto
   }
 


### PR DESCRIPTION
## Context

Filtering by region is currently not working for appointment tasks - this fixes it.

## Changes in this PR

Corrected the query parameter name to providerCode.
