### PR TITLE
CPB-909: Display contact outcome information on appointment details page

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -1,11 +1,11 @@
 $govuk-global-styles: true;
-$path: "/assets/images/";
+$path: '/assets/images/';
 
 $moj-page-width: 1170px;
 $govuk-page-width: $moj-page-width;
 
-@import "govuk-frontend/dist/govuk/index";
-@import "@ministryofjustice/frontend/moj/all";
+@import 'govuk-frontend/dist/govuk/index';
+@import '@ministryofjustice/frontend/moj/all';
 
 @import './components/header-bar';
 @import './components/search-and-filter';
@@ -13,3 +13,4 @@ $govuk-page-width: $moj-page-width;
 @import './pages/dashboard-index';
 
 @import './overrides/local';
+@import './utilities';

--- a/assets/scss/utilities.scss
+++ b/assets/scss/utilities.scss
@@ -1,0 +1,3 @@
+.cpb-unset-max-width {
+  max-width: unset;
+}

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -8,6 +8,7 @@ import Offender from '../../../server/models/offender'
 import LocationUtils from '../../../server/utils/locationUtils'
 import { pathWithQuery, yesNoDisplayValue } from '../../../server/utils/utils'
 import AppointmentUtils from '../../../server/utils/appointmentUtils'
+import WarningComponent from '../components/warningComponent'
 
 export default class CheckAppointmentDetailsPage extends Page {
   private readonly projectDetails: SummaryListComponent
@@ -21,6 +22,8 @@ export default class CheckAppointmentDetailsPage extends Page {
   readonly sharedDetails: SummaryListComponent
 
   readonly supervisorInput: SelectInput
+
+  readonly warningMessage: WarningComponent
 
   readonly appointment: AppointmentDto
 
@@ -38,6 +41,7 @@ export default class CheckAppointmentDetailsPage extends Page {
     this.hoursDetails = new SummaryListComponent('Hours detail')
     this.sharedDetails = new SummaryListComponent('Shared information')
     this.supervisorInput = new SelectInput('supervisor')
+    this.warningMessage = new WarningComponent('Outcome not recorded')
   }
 
   static visit(

--- a/integration_tests/pages/components/warningComponent.ts
+++ b/integration_tests/pages/components/warningComponent.ts
@@ -1,0 +1,15 @@
+export default class WarningComponent {
+  constructor(private readonly message: string) {}
+
+  clickCallToAction() {
+    return this.component().find('a').click()
+  }
+
+  shouldNotBeVisible() {
+    cy.get('.govuk-warning-text').should('not.exist')
+  }
+
+  private component() {
+    return cy.get('.govuk-warning-text').contains(this.message)
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -56,6 +56,10 @@ export default abstract class Page {
     })
   }
 
+  shouldShowTagWith(content: string): void {
+    cy.get('.govuk-tag').contains(content)
+  }
+
   signOut = (): PageElement => cy.get('[data-qa=signOut]')
 
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -144,6 +144,7 @@ context('Session details', () => {
     const appointment = appointmentFactory.build({
       projectCode: this.project.projectCode,
       pickUpData: { time: '09:00:30', location: locationFactory.build() },
+      contactOutcomeCode: undefined,
     })
 
     const appointmentSummaries = appointmentSummaryFactory.buildList(1, {
@@ -191,6 +192,11 @@ context('Session details', () => {
       projectCode: this.project.projectCode,
     })
 
+    const contactOutcomes = [
+      ...contactOutcomeFactory.buildList(2),
+      contactOutcomeFactory.build({ code: appointment.contactOutcomeCode }),
+    ]
+
     cy.task('stubFindSession', { session })
     // Given I am on the view session page
     const page = ViewSessionPage.visit(session)
@@ -205,6 +211,7 @@ context('Session details', () => {
       providerCode: appointment.providerCode,
       supervisors: this.supervisors,
     })
+    cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes } })
     page.clickViewAnAppointment()
 
     // Then I see the check appointment details page
@@ -309,6 +316,7 @@ context('Session details', () => {
         supervisingTeamCode: this.appointment.supervisingTeamCode,
         providerCode: this.appointment.providerCode,
         projectCode: project.projectCode,
+        contactOutcomeCode: undefined,
       })
 
       cy.task('stubFindAppointment', { appointment })
@@ -341,6 +349,7 @@ context('Session details', () => {
         supervisingTeamCode: this.appointment.supervisingTeamCode,
         providerCode: this.appointment.providerCode,
         projectCode: project.projectCode,
+        contactOutcomeCode: undefined,
       })
 
       cy.task('stubFindAppointment', { appointment })
@@ -393,6 +402,9 @@ context('Session details', () => {
         minutesCredited: 60,
       })
       cy.task('stubFindAppointment', { appointment: appointmentWithContactOutcome })
+
+      const contactOutcomes = [...contactOutcomeFactory.buildList(2), contactOutcome]
+      cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes } })
 
       cy.task('stubGetSupervisors', {
         teamCode: appointmentWithContactOutcome.supervisingTeamCode,

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -45,12 +45,16 @@
 //    Then I should not see the Continue button
 //    And I should see outcome details
 
-// Scenario: Completing the check appointment details page
+//  Scenario: Completing the check appointment details page
 //    Given I am on an appointment 'check appointment details' page
 //    Then I should not see compliance details
 //    When I submit the form
 //    Then I see the choose supervisor page
 
+//  Scenario: Displaying a call to action for missing outcome
+//    Given I am on an appointment 'check appointment details' page for an appointment in the past
+//    When I click the call to action
+//    Then I see the choose supervisor page
 import CheckAppointmentDetailsPage from '../../pages/appointments/checkAppointmentDetailsPage'
 import Page from '../../pages/page'
 import ViewSessionPage from '../../pages/viewSessionPage'
@@ -77,6 +81,7 @@ import sessionSummaryFactory from '../../../server/testutils/factories/sessionSu
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import { pickupLocationFactory } from '../../../server/testutils/factories/pickupDataFactory'
 import attendanceDataFactory from '../../../server/testutils/factories/attendanceDataFactory'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 
 context('Session details', () => {
   beforeEach(() => {
@@ -426,6 +431,7 @@ context('Session details', () => {
       page.shouldContainNotesDetails()
       page.shouldShowSharedInformation()
       page.shouldShowTagWith(contactOutcome.name)
+      page.warningMessage.shouldNotBeVisible()
     })
 
     //  Scenario: Completing the check appointment details page
@@ -465,6 +471,35 @@ context('Session details', () => {
 
       // Then I see the choose supervisor page
       Page.verifyOnPage(ChooseSupervisorPage, appointmentWithoutContactOutcome)
+    })
+
+    //  Scenario: Displaying a call to action for missing outcome
+    it('shows a warning message with call to action to update appointment', function test() {
+      const contactOutcomes = contactOutcomesFactory.build()
+
+      const appointmentInThePast = appointmentFactory.build({
+        contactOutcomeCode: undefined,
+        projectCode: this.project.projectCode,
+        date: DateTimeFormats.getTodaysDatePlusDays(-1).formattedDate,
+      })
+      cy.task('stubFindAppointment', { appointment: appointmentInThePast })
+      cy.task('stubGetSupervisors', {
+        teamCode: appointmentInThePast.supervisingTeamCode,
+        providerCode: appointmentInThePast.providerCode,
+        supervisors: this.supervisors,
+      })
+      cy.task('stubGetContactOutcomes', { contactOutcomes })
+      cy.task('stubGetAppointmentForm', {})
+
+      // Given I am on an appointment 'check appointment details' page for an appointment in the past
+      const page = CheckAppointmentDetailsPage.visit(appointmentInThePast, this.project, this.provider)
+      page.shouldContainProjectDetails()
+
+      // When I click the call to action
+      page.warningMessage.clickCallToAction()
+
+      // Then I see the choose supervisor page
+      Page.verifyOnPage(ChooseSupervisorPage, appointmentInThePast)
     })
   })
 })

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -393,7 +393,7 @@ context('Session details', () => {
   describe('Contact outcome status', () => {
     // Scenario: Viewing the appointment details page with an existing outcome
     it('shows outcome details and does not show the continue button if a contact outcome exists', function test() {
-      const contactOutcome = contactOutcomeFactory.build()
+      const contactOutcome = contactOutcomeFactory.build({ name: 'Attended - complied' })
 
       const appointmentWithContactOutcome = appointmentFactory.build({
         contactOutcomeCode: contactOutcome.code,
@@ -425,6 +425,7 @@ context('Session details', () => {
       page.shouldContainTimeDetails({ worked: '1 hour 30 minutes', penalty: '30 minutes', credited: '1 hour' })
       page.shouldContainNotesDetails()
       page.shouldShowSharedInformation()
+      page.shouldShowTagWith(contactOutcome.name)
     })
 
     //  Scenario: Completing the check appointment details page

--- a/integration_tests/tests/projects/viewAnIndvidualPlacement.cy.ts
+++ b/integration_tests/tests/projects/viewAnIndvidualPlacement.cy.ts
@@ -49,7 +49,11 @@ context('Project page', () => {
 
     // When I click on 'Update' for an appointment
     const [selected] = [...pagedAppointments.content].sort(Utils.sortByDate)
-    const appointment = appointmentFactory.build({ projectCode: project.projectCode, id: selected.id })
+    const appointment = appointmentFactory.build({
+      projectCode: project.projectCode,
+      id: selected.id,
+      contactOutcomeCode: undefined,
+    })
     const supervisors = supervisorSummaryFactory.buildList(2)
     cy.task('stubFindAppointment', { appointment })
     cy.task('stubGetSupervisors', {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -135,7 +135,7 @@ export interface LinkItem {
   href: string
 }
 
-export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow' | 'green'
+export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow' | 'green' | 'teal'
 
 export type GovUKValue = { text: string } | { html: string }
 

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -45,13 +45,15 @@ export default class AdjustTravelTimeController {
         username: res.locals.user.username,
       })
 
-      const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
+      const contactOutcome = appointment.contactOutcomeCode
+        ? await this.referenceDataService.getContactOutcome(res.locals.user.username, appointment.contactOutcomeCode)
+        : undefined
       const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
       const viewData = this.page.viewData({
         appointment,
         taskId,
-        contactOutcomes,
+        contactOutcome,
         project,
         originalSearch: req.query as SearchTravelTimePageInput,
       })
@@ -81,9 +83,9 @@ export default class AdjustTravelTimeController {
           minutes,
         }
 
-        const { contactOutcomes } = await this.referenceDataService.getAvailableContactOutcomes(
-          res.locals.user.username,
-        )
+        const contactOutcome = appointment.contactOutcomeCode
+          ? await this.referenceDataService.getContactOutcome(res.locals.user.username, appointment.contactOutcomeCode)
+          : undefined
 
         const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
@@ -93,7 +95,7 @@ export default class AdjustTravelTimeController {
           ...this.page.viewData({
             appointment,
             taskId,
-            contactOutcomes,
+            contactOutcome,
             project,
             originalSearch: req.query as SearchTravelTimePageInput,
           }),

--- a/server/controllers/appointments/appointmentDetailsController.test.ts
+++ b/server/controllers/appointments/appointmentDetailsController.test.ts
@@ -9,6 +9,8 @@ import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import ProjectService from '../../services/projectService'
 import projectFactory from '../../testutils/factories/projectFactory'
+import ReferenceDataService from '../../services/referenceDataService'
+import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 
 jest.mock('../../pages/appointments/checkAppointmentDetailsPage')
 jest.mock('../../utils/errorUtils')
@@ -28,10 +30,16 @@ describe('AppointmentsController', () => {
   const appointmentService = createMock<AppointmentService>()
   const formService = createMock<AppointmentFormService>()
   const projectService = createMock<ProjectService>()
+  const referenceDataService = createMock<ReferenceDataService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    appointmentsController = new ProjectDetailsController(appointmentService, formService, projectService)
+    appointmentsController = new ProjectDetailsController(
+      appointmentService,
+      formService,
+      projectService,
+      referenceDataService,
+    )
   })
 
   describe('show', () => {
@@ -100,6 +108,51 @@ describe('AppointmentsController', () => {
 
       expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
       expect(response.render).toHaveBeenCalledWith('appointments/update/appointmentDetails', viewData)
+    })
+
+    it('should call reference data service if appointment has a contact outcome code', async () => {
+      const appointment = appointmentFactory.build({ contactOutcomeCode: 'OUTCOME_001' })
+      const contactOutcome = contactOutcomeFactory.build({ code: 'OUTCOME_001' })
+
+      checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
+        formId: undefined,
+        setFormId: () => {},
+        viewData: () => ({}),
+      }))
+
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+
+      referenceDataService.getContactOutcome.mockResolvedValue(contactOutcome)
+
+      const requestHandler = appointmentsController.show()
+      const response = createMock<Response>({ locals: { user: { username: userName } } })
+
+      await requestHandler(request, response, next)
+
+      expect(referenceDataService.getContactOutcome).toHaveBeenCalledWith(userName, 'OUTCOME_001')
+    })
+
+    it('should not call reference data service if appointment does not have a contact outcome code', async () => {
+      const appointment = appointmentFactory.build({ contactOutcomeCode: undefined })
+
+      checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
+        formId: undefined,
+        setFormId: () => {},
+        viewData: () => ({}),
+      }))
+
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      formService.createForm.mockResolvedValue({
+        key: { id: 'form-id', type: 'some-type' },
+        data: appointmentOutcomeFormFactory.build(),
+      })
+
+      const requestHandler = appointmentsController.show()
+      const response = createMock<Response>({ locals: { user: { username: userName } } })
+
+      await requestHandler(request, response, next)
+
+      expect(referenceDataService.getContactOutcome).not.toHaveBeenCalled()
     })
   })
 

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -4,12 +4,14 @@ import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentParams, AppointmentOutcomeForm } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
+import ReferenceDataService from '../../services/referenceDataService'
 
 export default class AppointmentDetailsController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,
     private readonly projectService: ProjectService,
+    private readonly referenceDataService: ReferenceDataService,
   ) {}
 
   show(): RequestHandler {
@@ -24,6 +26,10 @@ export default class AppointmentDetailsController {
         username: res.locals.user.username,
         projectCode: appointmentParams.projectCode,
       })
+
+      const contactOutcome = appointment.contactOutcomeCode
+        ? await this.referenceDataService.getContactOutcome(res.locals.user.username, appointment.contactOutcomeCode)
+        : undefined
 
       const page = new CheckAppointmentDetailsPage(_req.query, project)
 
@@ -42,7 +48,7 @@ export default class AppointmentDetailsController {
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData({ appointment, project, originalSearch: form.originalSearch }),
+        ...page.viewData({ appointment, project, originalSearch: form.originalSearch, contactOutcome }),
       })
     }
   }

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -28,6 +28,7 @@ const controllers = (services: Services) => {
     services.appointmentService,
     services.appointmentFormService,
     services.projectService,
+    services.referenceDataService,
   )
 
   const chooseSupervisorController = new ChooseSupervisorController(

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -13,6 +13,8 @@ import LocationUtils from '../../utils/locationUtils'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 import enforcementDataFactory from '../../testutils/factories/enforcementDataFactory'
+import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
+import HtmlUtils from '../../utils/htmlUtils'
 
 jest.mock('../../models/offender')
 
@@ -128,6 +130,29 @@ describe('CheckAppointmentDetailsPage', () => {
         ])
         expect(AppointmentUtils.formatNotesAsHtml).toHaveBeenCalledWith(appointment.notes)
       })
+    })
+
+    it('should include contact outcome name in view data when contact outcome provided', () => {
+      const statusColour = 'teal'
+      jest.spyOn(AppointmentUtils, 'getStatusColour').mockReturnValue(statusColour)
+      const className = 'govuk-tag--teal'
+      jest.spyOn(HtmlUtils, 'getStatusTagClass').mockReturnValue(className)
+
+      const contactOutcome = contactOutcomeFactory.build()
+
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        originalSearch: {},
+        contactOutcome,
+      })
+
+      expect(result.contactOutcome).toEqual({
+        name: contactOutcome.name,
+        tagClass: className,
+      })
+      expect(AppointmentUtils.getStatusColour).toHaveBeenCalledWith(contactOutcome)
+      expect(HtmlUtils.getStatusTagClass).toHaveBeenCalledWith(statusColour)
     })
 
     it('should return an object containing offender', () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -459,6 +459,54 @@ describe('CheckAppointmentDetailsPage', () => {
       })
     })
 
+    describe('showMissingOutcomeMessage', () => {
+      it('should return false when an outcome is associated with the appointment', () => {
+        const appointmentWithOutcome = appointmentFactory.build({ contactOutcomeCode: 'OUTC' })
+
+        const result = page.viewData({
+          appointment: appointmentWithOutcome,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(result.showMissingOutcomeMessage).toBe(false)
+      })
+
+      it('should return false when no outcome exists and appointment is in the future', () => {
+        const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })
+        jest.spyOn(DateTimeFormats, 'dateTimeIsInFuture').mockReturnValue(true)
+
+        const result = page.viewData({
+          appointment: appointmentWithNoOutcome,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(DateTimeFormats.dateTimeIsInFuture).toHaveBeenCalledWith(
+          appointmentWithNoOutcome.date,
+          appointmentWithNoOutcome.startTime,
+        )
+        expect(result.showMissingOutcomeMessage).toBe(false)
+      })
+
+      it('should return true when no outcome exists and appointment is in the past', () => {
+        const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })
+        jest.spyOn(DateTimeFormats, 'dateTimeIsInFuture').mockReturnValue(false)
+
+        const result = page.viewData({
+          appointment: appointmentWithNoOutcome,
+          project: projectFactory.build(),
+          originalSearch: {},
+        })
+
+        expect(DateTimeFormats.dateTimeIsInFuture).toHaveBeenCalledWith(
+          appointmentWithNoOutcome.date,
+          appointmentWithNoOutcome.startTime,
+        )
+        expect(result.showMissingOutcomeMessage).toBe(true)
+      })
+    })
+
     describe('showContinueButton', () => {
       it('should return true if no outcome is associated with the appointment', () => {
         const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -214,6 +214,23 @@ describe('CheckAppointmentDetailsPage', () => {
       expect(result.updatePath).toBe(pathWithQuery)
     })
 
+    it('should return an object containing the next path', () => {
+      const nextPath = '/appointments/choose-supervisor'
+      jest.spyOn(paths.appointments, 'chooseSupervisor').mockReturnValue(nextPath)
+
+      const result = page.viewData({
+        appointment,
+        project: projectFactory.build(),
+        originalSearch: {},
+      })
+
+      expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+      })
+      expect(result.nextPath).toBe(pathWithQuery)
+    })
+
     describe('complianceItems', () => {
       it('should return compliance items when attendance data is defined', () => {
         const attendanceData = attendanceDataFactory.build({

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -18,6 +18,7 @@ import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 interface ViewData extends AppointmentUpdatePageViewData {
   projectItems: Array<GovUkSummaryListItem>
   showContinueButton: boolean
+  showMissingOutcomeMessage: boolean
   appointmentItems: Array<GovUkSummaryListItem>
   complianceItems: Array<GovUkSummaryListItem>
   timeItems: Array<GovUkSummaryListItem>
@@ -78,7 +79,20 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       timeItems: this.buildTimeDetails(appointment),
       sharedItems: this.buildSharedDetails(appointment),
       contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
+      showMissingOutcomeMessage: this.isMissingOutcome(appointment),
     }
+  }
+
+  private isMissingOutcome(appointment: AppointmentDto): boolean {
+    if (appointment.contactOutcomeCode) {
+      return false
+    }
+
+    if (DateTimeFormats.dateTimeIsInFuture(appointment.date, appointment.startTime)) {
+      return false
+    }
+
+    return true
   }
 
   buildContactOutcomeDetails(contactOutcome?: ContactOutcomeDto): { name: string; tagClass: string } | undefined {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ProjectDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, ProjectDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
@@ -10,6 +10,7 @@ import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import GovUKComponentUtils from '../../utils/govUkComponentUtils'
+import HtmlUtils from '../../utils/htmlUtils'
 import LocationUtils from '../../utils/locationUtils'
 import { yesNoDisplayValue } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
@@ -21,6 +22,10 @@ interface ViewData extends AppointmentUpdatePageViewData {
   complianceItems: Array<GovUkSummaryListItem>
   timeItems: Array<GovUkSummaryListItem>
   sharedItems: Array<GovUkSummaryListItem>
+  contactOutcome?: {
+    name: string
+    tagClass: string
+  }
 }
 
 interface Body {
@@ -57,10 +62,12 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     appointment,
     project,
     originalSearch,
+    contactOutcome,
   }: {
     appointment: AppointmentDto
     project: ProjectDto
     originalSearch: Record<string, string>
+    contactOutcome?: ContactOutcomeDto
   }): ViewData {
     return {
       ...this.commonViewData(appointment, originalSearch),
@@ -70,6 +77,18 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       complianceItems: this.buildComplianceDetails(appointment),
       timeItems: this.buildTimeDetails(appointment),
       sharedItems: this.buildSharedDetails(appointment),
+      contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
+    }
+  }
+
+  buildContactOutcomeDetails(contactOutcome?: ContactOutcomeDto): { name: string; tagClass: string } | undefined {
+    if (!contactOutcome) {
+      return undefined
+    }
+
+    return {
+      name: contactOutcome.name,
+      tagClass: HtmlUtils.getStatusTagClass(AppointmentUtils.getStatusColour(contactOutcome)),
     }
   }
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -27,6 +27,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
     name: string
     tagClass: string
   }
+  nextPath: string
 }
 
 interface Body {
@@ -80,6 +81,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       sharedItems: this.buildSharedDetails(appointment),
       contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
       showMissingOutcomeMessage: this.isMissingOutcome(appointment),
+      nextPath: this.nextPath(appointment.projectCode, appointment.id.toString()),
     }
   }
 

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -78,13 +78,13 @@ describe('UpdateTravelTimePage', () => {
         return time === appointment.startTime ? startTime : endTime
       })
 
-      const contactOutcomes = contactOutcomeFactory.buildList(2)
+      const contactOutcome = contactOutcomeFactory.build()
       const project = projectFactory.build()
 
       const result = page.viewData({
         appointment,
         taskId,
-        contactOutcomes,
+        contactOutcome,
         project,
         originalSearch: {},
       })
@@ -106,7 +106,7 @@ describe('UpdateTravelTimePage', () => {
           date: uiDate,
           startTime,
           endTime,
-          contactOutcome: undefined,
+          contactOutcome: contactOutcome.name,
         },
         project: {
           name: project.projectName,
@@ -119,22 +119,15 @@ describe('UpdateTravelTimePage', () => {
       expect(DateTimeFormats.stripTime).toHaveBeenCalledWith(appointment.endTime)
     })
 
-    it('returns contact outcome name when it matches the appointment code', () => {
+    it('returns contact outcome name', () => {
       const contactOutcomeName = 'Attended'
       const appointment = appointmentFactory.build()
-
-      const matchingContactOutcome = contactOutcomeFactory.build({
-        code: appointment.contactOutcomeCode,
-        name: contactOutcomeName,
-      })
-
-      const contactOutcomes = [contactOutcomeFactory.build(), matchingContactOutcome]
       const project = projectFactory.build()
 
       const result = page.viewData({
         appointment,
         taskId: '1',
-        contactOutcomes,
+        contactOutcome: contactOutcomeFactory.build({ name: contactOutcomeName }),
         project,
         originalSearch: {},
       })
@@ -151,7 +144,7 @@ describe('UpdateTravelTimePage', () => {
       const result = page.viewData({
         appointment,
         taskId: '1',
-        contactOutcomes: contactOutcomeFactory.buildList(2),
+        contactOutcome: contactOutcomeFactory.build(),
         project,
         originalSearch,
       })
@@ -168,7 +161,7 @@ describe('UpdateTravelTimePage', () => {
       const result = page.viewData({
         appointment,
         taskId: '1',
-        contactOutcomes: contactOutcomeFactory.buildList(2),
+        contactOutcome: contactOutcomeFactory.build(),
         project,
         originalSearch,
       })

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -35,13 +35,13 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
   viewData({
     appointment,
     taskId,
-    contactOutcomes,
+    contactOutcome,
     project,
     originalSearch,
   }: {
     appointment: AppointmentDto
     taskId: string
-    contactOutcomes: Array<ContactOutcomeDto>
+    contactOutcome?: ContactOutcomeDto
     project: ProjectDto
     originalSearch: SearchTravelTimePageInput
   }): PageViewData {
@@ -57,7 +57,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
         date: DateTimeFormats.isoDateToUIDate(appointment.date),
         startTime: DateTimeFormats.stripTime(appointment.startTime),
         endTime: DateTimeFormats.stripTime(appointment.endTime),
-        contactOutcome: this.selectedContactOutcomeName(appointment, contactOutcomes),
+        contactOutcome: contactOutcome?.name,
       },
       project: {
         name: project.projectName,
@@ -108,14 +108,5 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     }
 
     return `${offender.name}'s appointment ${dateDetail} ${actionDescription}`
-  }
-
-  private selectedContactOutcomeName(
-    appointment: AppointmentDto,
-    contactOutcomes: ContactOutcomeDto[],
-  ): string | undefined {
-    const selectedOutcome = contactOutcomes.find(outcome => outcome.code === appointment.contactOutcomeCode)
-
-    return selectedOutcome?.name
   }
 }

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -1,7 +1,7 @@
 import ReferenceDataClient from '../data/referenceDataClient'
 import adjustmentReasonFactory from '../testutils/factories/adjustmentReasonFactory'
 import { communityCampusPdusFactory } from '../testutils/factories/communityCampusPduFactory'
-import { contactOutcomesFactory } from '../testutils/factories/contactOutcomeFactory'
+import { contactOutcomeFactory, contactOutcomesFactory } from '../testutils/factories/contactOutcomeFactory'
 import ReferenceDataService from './referenceDataService'
 
 jest.mock('../data/referenceDataClient')
@@ -65,6 +65,33 @@ describe('ReferenceDataService', () => {
 
     expect(referenceDataClient.getAdjustmentReasons).toHaveBeenCalledWith('some-username')
     expect(result).toEqual(adjustmentReasons)
+  })
+
+  describe('getContactOutcome', () => {
+    it('should return a matching contact outcome when found', async () => {
+      const matchingOutcome = contactOutcomeFactory.build()
+      const contactOutcomes = contactOutcomesFactory.build({
+        contactOutcomes: [contactOutcomeFactory.build(), matchingOutcome, contactOutcomeFactory.build()],
+      })
+
+      referenceDataClient.getContactOutcomes.mockResolvedValue(contactOutcomes)
+
+      const result = await referenceDataService.getContactOutcome('some-username', matchingOutcome.code)
+
+      expect(referenceDataClient.getContactOutcomes).toHaveBeenCalledWith('some-username')
+      expect(result).toEqual(matchingOutcome)
+    })
+
+    it('should return undefined when no matching contact outcome is found', async () => {
+      const contactOutcomes = contactOutcomesFactory.build()
+
+      referenceDataClient.getContactOutcomes.mockResolvedValue(contactOutcomes)
+
+      const result = await referenceDataService.getContactOutcome('some-username', 'NON_EXISTENT')
+
+      expect(referenceDataClient.getContactOutcomes).toHaveBeenCalledWith('some-username')
+      expect(result).toBeUndefined()
+    })
   })
 
   describe('getTravelAdjustmentId', () => {

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,4 +1,10 @@
-import { AdjustmentReasonDto, CommunityCampusPdusDto, ContactOutcomesDto, ProjectTypesDto } from '../@types/shared'
+import {
+  AdjustmentReasonDto,
+  CommunityCampusPdusDto,
+  ContactOutcomeDto,
+  ContactOutcomesDto,
+  ProjectTypesDto,
+} from '../@types/shared'
 import ReferenceDataClient from '../data/referenceDataClient'
 
 export default class ReferenceDataService {
@@ -10,6 +16,11 @@ export default class ReferenceDataService {
 
   async getAvailableContactOutcomes(userName: string): Promise<ContactOutcomesDto> {
     return this.referenceDataClient.getContactOutcomes(userName, 'AVAILABLE_TO_ADMIN')
+  }
+
+  async getContactOutcome(username: string, contactOutcomeCode: string): Promise<ContactOutcomeDto | undefined> {
+    const contactOutcomes = await this.referenceDataClient.getContactOutcomes(username)
+    return contactOutcomes.contactOutcomes.find(contactOutcome => contactOutcome.code === contactOutcomeCode)
   }
 
   async getCommunityCampusPdus(userName: string): Promise<CommunityCampusPdusDto> {

--- a/server/utils/appointmentUtils.test.ts
+++ b/server/utils/appointmentUtils.test.ts
@@ -1,4 +1,5 @@
 import appointmentSummaryFactory from '../testutils/factories/appointmentSummaryFactory'
+import { contactOutcomeFactory } from '../testutils/factories/contactOutcomeFactory'
 import AppointmentUtils from './appointmentUtils'
 import DateTimeFormats from './dateTimeUtils'
 
@@ -118,6 +119,32 @@ describe('AppointmentUtils', () => {
     it('returns undefined if rating is undefined', () => {
       const result = AppointmentUtils.formatComplianceRatings(undefined)
       expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getStatusColour', () => {
+    it('returns teal colour when outcome is not enforceable', () => {
+      const contactOutcome = contactOutcomeFactory.build({ enforceable: false, attended: true })
+
+      const result = AppointmentUtils.getStatusColour(contactOutcome)
+
+      expect(result).toBe('teal')
+    })
+
+    it('returns yellow colour when attended and enforceable', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: true })
+
+      const result = AppointmentUtils.getStatusColour(contactOutcome)
+
+      expect(result).toBe('yellow')
+    })
+
+    it('returns red colour when not attended and enforceable', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
+
+      const result = AppointmentUtils.getStatusColour(contactOutcome)
+
+      expect(result).toBe('red')
     })
   })
 })

--- a/server/utils/appointmentUtils.ts
+++ b/server/utils/appointmentUtils.ts
@@ -1,5 +1,5 @@
-import { AppointmentSummaryDto, AttendanceDataDto } from '../@types/shared'
-import { SummaryCard } from '../@types/user-defined'
+import { AppointmentSummaryDto, AttendanceDataDto, ContactOutcomeDto } from '../@types/shared'
+import { GovUkStatusTagColour, SummaryCard } from '../@types/user-defined'
 import DateTimeFormats from './dateTimeUtils'
 import { properCase } from './utils'
 
@@ -67,6 +67,21 @@ export default class AppointmentUtils {
     const ratingWithProperCasing = properCase(rating)
     const ratingSubstrings = ratingWithProperCasing.split('_')
     return ratingSubstrings.length > 1 ? `${ratingSubstrings[0]} ${ratingSubstrings[1]}` : ratingSubstrings[0]
+  }
+
+  static getStatusColour(contactOutcome: ContactOutcomeDto): GovUkStatusTagColour {
+    // Attended & complied or acceptable absence
+    if (!contactOutcome.enforceable) {
+      return 'teal'
+    }
+
+    // Attended & did not comply
+    if (contactOutcome.attended) {
+      return 'yellow'
+    }
+
+    // Unexpected absence
+    return 'red'
   }
 
   private static timeCreditedText(appointment: AppointmentSummaryDto): string {

--- a/server/utils/dateTimeUtils.test.ts
+++ b/server/utils/dateTimeUtils.test.ts
@@ -461,6 +461,30 @@ describe('DateTimeFormats', () => {
     })
   })
 
+  describe('dateTimeIsInFuture', () => {
+    it('returns true if date and time are in the future', () => {
+      const tomorrow = DateTimeFormats.getTodaysDatePlusDays(1).formattedDate
+
+      expect(DateTimeFormats.dateTimeIsInFuture(tomorrow, '23:59')).toBe(true)
+    })
+
+    it('returns false if date is in the past', () => {
+      expect(DateTimeFormats.dateTimeIsInFuture('2020-10-23', '09:00:00')).toBe(false)
+    })
+
+    it('returns false if date is today but time has passed', () => {
+      const today = DateTimeFormats.getTodaysDatePlusDays(0).formattedDate
+
+      expect(DateTimeFormats.dateTimeIsInFuture(today, '00:00:00')).toBe(false)
+    })
+
+    it('returns true if date is today and time is in the future', () => {
+      const today = DateTimeFormats.getTodaysDatePlusDays(0).formattedDate
+
+      expect(DateTimeFormats.dateTimeIsInFuture(today, '23:59:00')).toBe(true)
+    })
+  })
+
   describe('datesAreWithinNDays', () => {
     it('returns false if dates are more than N days apart', () => {
       const firstDate = '2026-01-10'

--- a/server/utils/dateTimeUtils.ts
+++ b/server/utils/dateTimeUtils.ts
@@ -331,6 +331,17 @@ export default class DateTimeFormats {
   }
 
   /**
+   * Checks that the given and date and time is earlier than now
+   * @param date - string like "2024-10-25"
+   * @param time - string like "09:00:00"
+   * @returns A boolean
+   */
+  static dateTimeIsInFuture(date: string, time: string): boolean {
+    const dateTime = new Date(`${date}T${time}`)
+    return isAfter(dateTime, new Date())
+  }
+
+  /**
    * Check that two dates are within `N` days of each other
    * @param startDate - string like "2024-10-25"
    * @param endDate - string like "2024-10-25"

--- a/server/utils/htmlUtils.test.ts
+++ b/server/utils/htmlUtils.test.ts
@@ -37,4 +37,11 @@ describe('HTMLUtils', () => {
       expect(result).toEqual(`<strong class="govuk-tag govuk-tag--${colour}">Label</strong>`)
     })
   })
+
+  describe('getStatusTagClass', () => {
+    it.each(['grey', 'red', 'yellow', 'teal'])('returns the status tag class for %s colour', colour => {
+      const result = HtmlUtils.getStatusTagClass(colour as GovUkStatusTagColour)
+      expect(result).toEqual(`govuk-tag--${colour}`)
+    })
+  })
 })

--- a/server/utils/htmlUtils.ts
+++ b/server/utils/htmlUtils.ts
@@ -14,6 +14,10 @@ export default class HtmlUtils {
   }
 
   static getStatusTag = (statusLabel: string, colour: GovUkStatusTagColour): string => {
-    return `<strong class="govuk-tag govuk-tag--${colour}">${statusLabel}</strong>`
+    return `<strong class="govuk-tag ${this.getStatusTagClass(colour)}">${statusLabel}</strong>`
+  }
+
+  static getStatusTagClass(colour: GovUkStatusTagColour): string {
+    return `govuk-tag--${colour}`
   }
 }

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% extends "./layout.njk" %}
 
@@ -11,6 +12,13 @@
 {% block beforeForm %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% if showMissingOutcomeMessage %}
+        {% set messageHtml = 'Outcome not recorded. <a href="' + nextPath + '">Update appointment</a>.' %}
+        {{ govukWarningText({
+          html: messageHtml,
+          iconFallbackText: "Warning"
+        }) }}
+      {% endif %}
       {% if contactOutcome %}
         {% set tagClasses = contactOutcome.tagClass + ' cpb-unset-max-width govuk-!-margin-top-4 govuk-!-margin-bottom-4' %}
         {{ govukTag({

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% extends "./layout.njk" %}
 
@@ -10,6 +11,13 @@
 {% block beforeForm %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% if contactOutcome %}
+        {% set tagClasses = contactOutcome.tagClass + ' cpb-unset-max-width govuk-!-margin-top-4 govuk-!-margin-bottom-4' %}
+        {{ govukTag({
+          classes: tagClasses,
+          text: contactOutcome.name
+        }) }}
+      {% endif %}
       {{ govukSummaryList({
         card: {
           title: {


### PR DESCRIPTION
## Context

This updates the appointment details page to display contact outcome info with either:
- A status tag with the saved contact outcome,
- A call to action if a contact outcome is missing for an appointment in the past, or
- Nothing if no contact outcome and appointment in the future

[CPB-909](https://dsdmoj.atlassian.net/browse/CPB-909)

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

Appointment with a saved contact outcome and status tag:
<img width="1484" height="950" alt="Appointment page with a contact outcome status tag" src="https://github.com/user-attachments/assets/98d55b7d-6e74-4143-94cc-c81e765e054b" />

Appointment in the past with a missing outcome message:
<img width="1432" height="904" alt="Appointment in the past with a missing outcome message" src="https://github.com/user-attachments/assets/ed4076ad-56c4-4cd9-aedb-fa3b244f22cd" />

Appointment in the future with no outcome and no message:
<img width="1495" height="848" alt="Appointment in the future with no outcome and no message" src="https://github.com/user-attachments/assets/f9d4bb78-cb87-4460-9ab3-979ed446b9e2" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-909]: https://dsdmoj.atlassian.net/browse/CPB-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ