### PR TITLE
CPB-954 Hide update link for LAOs on search travel time page

### DIFF
--- a/server/pages/appointments/searchTravelTimePage.test.ts
+++ b/server/pages/appointments/searchTravelTimePage.test.ts
@@ -2,12 +2,11 @@ import { PagedModelAppointmentTaskSummaryDto } from '../../@types/shared'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentTaskSummaryFactory from '../../testutils/factories/appointmentTaskSummaryFactory'
+import offenderLimitedFactory from '../../testutils/factories/offenderLimitedFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import HtmlUtils from '../../utils/htmlUtils'
 import { pathWithQuery } from '../../utils/utils'
 import SearchTravelTimePage from './searchTravelTimePage'
-
-jest.mock('../../models/offender')
 
 describe('SearchTravelTimePage', () => {
   const page = new SearchTravelTimePage()
@@ -74,6 +73,33 @@ describe('SearchTravelTimePage', () => {
       const tasks = {}
 
       expect(SearchTravelTimePage.getRows(tasks, { provider: '' })).toEqual([])
+    })
+
+    it('does not contain an update link if the offender is limited', () => {
+      const offender = offenderLimitedFactory.build()
+      const task = appointmentTaskSummaryFactory.build({ offender })
+      const tasks = {
+        content: [task],
+      }
+
+      const htmlAnchorSpy = jest.spyOn(HtmlUtils, 'getAnchor')
+      const linkHtml = '<a>link</a>'
+      htmlAnchorSpy.mockReturnValue(linkHtml)
+
+      const dateSpy = jest.spyOn(DateTimeFormats, 'isoDateToUIDate')
+      const date = '1 Apr 2026'
+      dateSpy.mockReturnValue(date)
+
+      const searchParams = { provider: 'provider' }
+      const row = SearchTravelTimePage.getRows(tasks as PagedModelAppointmentTaskSummaryDto, searchParams)[0]
+
+      expect(row[0].text).toEqual(new Offender(task.offender).name)
+      expect(row[1].text).toEqual(task.offender.crn)
+      expect(row[2].text).toEqual(date)
+      expect(row[3].text).toEqual(task.projectTypeName)
+      expect(row[4].html).toEqual('')
+
+      expect(HtmlUtils.getAnchor).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/pages/appointments/searchTravelTimePage.ts
+++ b/server/pages/appointments/searchTravelTimePage.ts
@@ -45,21 +45,25 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
     }
 
     return tasks.content.map(row => {
-      const link = HtmlUtils.getAnchor(
-        'Update',
-        pathWithQuery(
-          paths.appointments.travelTime.update({
-            appointmentId: row.deliusAppointmentId.toString(),
-            projectCode: row.projectCode,
-            taskId: row.taskId,
-          }),
-          originalSearch,
-        ),
-      )
+      const offender = new Offender(row.offender)
+
+      const link = offender.isLimited
+        ? ''
+        : HtmlUtils.getAnchor(
+            'Update',
+            pathWithQuery(
+              paths.appointments.travelTime.update({
+                appointmentId: row.deliusAppointmentId.toString(),
+                projectCode: row.projectCode,
+                taskId: row.taskId,
+              }),
+              originalSearch,
+            ),
+          )
 
       return [
-        { text: new Offender(row.offender).name },
-        { text: row.offender.crn },
+        { text: offender.name },
+        { text: offender.crn },
         { text: DateTimeFormats.isoDateToUIDate(row.date) },
         { text: row.projectTypeName },
         { html: link },


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-954?atlOrigin=eyJpIjoiZGJkZjliZDBkNGY1NDYzZGIwYjVmZGNmZTlkYTkxN2UiLCJwIjoiaiJ9)

## Context
Hide update link for LAOs on the search travel time page, as we will be restricting the updating of LAO appointments across the service for private beta.

If person is restricted return an empty string to the action HTML. Returning an
empty string instead of removing the action entirely means we don't encounter
the styling issues that creates.

The row will display an empty table cell which should not be confusing for
accessibility.

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
I wasn't able to find a LAO to test with, so this will be done post-merge by a member of the team.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
