### PR TITLE
Integration test fixes

### DIFF
--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ProjectDto, ProviderSummaryDto } from '../../../server/@types/shared'
+import { AppointmentDto, ProjectDto } from '../../../server/@types/shared'
 import paths from '../../../server/paths'
 import SelectInput from '../components/selectComponent'
 import SummaryListComponent from '../components/summaryListComponent'
@@ -43,7 +43,6 @@ export default class CheckAppointmentDetailsPage extends Page {
   static visit(
     appointment: AppointmentDto,
     project: ProjectDto,
-    provider: ProviderSummaryDto,
     originalSearch?: Record<string, string>,
   ): CheckAppointmentDetailsPage {
     const path = pathWithQuery(

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -239,7 +239,7 @@ context('Session details', () => {
     // Scenario: Returning to a session page
     it('enables navigation back to session page', function test() {
       // Given I am on an appointment 'check your details' page
-      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider)
+      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project)
 
       // When I click back
       cy.task('stubFindSession', { session: this.session })
@@ -264,7 +264,7 @@ context('Session details', () => {
         'endDate-year': '2025',
       }
       // Given I am on an appointment 'check your details' page
-      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, this.provider, originalSearch)
+      const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, originalSearch)
 
       // When I click back
       cy.task('stubFindSession', { session: this.session })
@@ -346,7 +346,7 @@ context('Session details', () => {
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubFindProject', { project })
 
-      const page = CheckAppointmentDetailsPage.visit(appointment, project, this.provider, {
+      const page = CheckAppointmentDetailsPage.visit(appointment, project, {
         provider: this.appointment.providerCode,
         team: this.appointment.supervisingTeamCode,
       })

--- a/integration_tests/tests/projects/viewAnIndvidualPlacement.cy.ts
+++ b/integration_tests/tests/projects/viewAnIndvidualPlacement.cy.ts
@@ -59,9 +59,6 @@ context('Project page', () => {
     })
     cy.task('stubSaveAppointmentForm')
 
-    const provider = providerSummaryFactory.build({ code: appointment.providerCode })
-    cy.task('stubGetProviders', { providers: { providers: [provider] } })
-
     page.clickUpdateAnAppointment()
 
     // Then I should see the start of the appointment update journey

--- a/server/testutils/factories/appointmentFactory.ts
+++ b/server/testutils/factories/appointmentFactory.ts
@@ -23,7 +23,7 @@ export default Factory.define<AppointmentDto>(() => ({
   date: faker.date.recent().toISOString().slice(0, 10),
   startTime: '09:00:00',
   endTime: '17:00:00',
-  contactOutcomeId: faker.string.uuid(),
+  contactOutcomeCode: faker.string.alpha(8),
   attendanceData: attendanceDataFactory.build(),
   enforcementData: enforcementDataFactory.build(),
   supervisorOfficerCode: faker.string.alpha(10),


### PR DESCRIPTION
## Context

Contains two small fixes to integration test set up, which is causing issues with the PR checks in #548

## Changes in this PR

- Rename contactOutcome property on `appointmentFactory`. This means that appointments were always being created with undefined contactOutcome codes (which was maybe not a bad thing!)
- Remove a redundant `provider` parameter in the page object model for appointment details page - as I had removed the call to providers in #548 

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
