### PR TITLE
CPB-777: Add retry and idempotency for submitting travel time adjustments

### DIFF
--- a/server/@types/shared/models/CreateAdjustmentDto.ts
+++ b/server/@types/shared/models/CreateAdjustmentDto.ts
@@ -12,7 +12,6 @@ export type CreateAdjustmentDto = {
      * Adjustment minutes, must be greater than 0
      */
     minutes: number;
-    dateOfAdjustment: string;
     adjustmentReasonId: string;
 };
 

--- a/server/data/offenderClient.ts
+++ b/server/data/offenderClient.ts
@@ -26,6 +26,9 @@ export default class OffenderClient extends RestClient {
     data: CreateAdjustmentDto,
   ): Promise<void> {
     const path = paths.offender.adjustments({ crn, deliusEventNumber: deliusEventNumber.toString() })
-    return this.post({ path, data }, asSystem(username))
+    return this.post(
+      { path, data, retry: true, headers: { 'Idempotency-Key': `post-adjustment:${data.taskId}` } },
+      asSystem(username),
+    )
   }
 }

--- a/server/services/offenderService.test.ts
+++ b/server/services/offenderService.test.ts
@@ -38,9 +38,6 @@ describe('OffenderService', () => {
       const adjustmentReasonId = 'X23'
       referenceDataService.getTravelAdjustmentReasonId.mockResolvedValue(adjustmentReasonId)
 
-      const refDate = new Date('2025-02-01')
-      jest.useFakeTimers().setSystemTime(refDate.getTime())
-
       await offenderService.adjustTravelTime(details, data)
 
       expect(referenceDataService.getTravelAdjustmentReasonId).toHaveBeenCalled()
@@ -48,7 +45,6 @@ describe('OffenderService', () => {
         ...data,
         type: 'Negative',
         adjustmentReasonId,
-        dateOfAdjustment: refDate.toISOString(),
       })
     })
   })

--- a/server/services/offenderService.ts
+++ b/server/services/offenderService.ts
@@ -17,14 +17,12 @@ export default class OffenderService {
     adjustment: Pick<CreateAdjustmentDto, 'taskId' | 'minutes'>,
   ) {
     const adjustmentReasonId = await this.referenceDataService.getTravelAdjustmentReasonId(details.username)
-    const dateOfAdjustment = new Date().toISOString()
 
     const data: CreateAdjustmentDto = {
       ...adjustment,
       // Will result in a reduction of minutes required
       type: 'Negative',
       adjustmentReasonId,
-      dateOfAdjustment,
     }
 
     return this.offenderClient.saveAdjustment(details, data)


### PR DESCRIPTION
## Context

The API supports the use of the `Idempotency-Key` header to indicate that a request may occur multiple times.

Using this when submitting an adjustment allows retrying failed requests to be a safe operation, as the API will not process subsequent requests if it has already successfully processed a request with the same key and request body.

See [CPB-777](https://dsdmoj.atlassian.net/browse/CPB-777)

## Changes in this PR

- The `dateOfAdjustment` property has been removed from the `CreateAdjustmentDto` as it is no longer used by the API. This helps with introducing idempotency as submitting the same form now dispatches the same request to the API.
- The `OffenderClient.saveAdjustment` method now retries the request if it fails, and includes the `Idempotency-Key` header to indicate to the API which request is being tried/retried so that it can be handled correctly.

### Screenshots of UI changes

No visual changes have been introduced.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.


[CPB-777]: https://dsdmoj.atlassian.net/browse/CPB-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ