### PR TITLE
CPB-909: Update appointment details call to action

### DIFF
--- a/assets/scss/components/_offender-details.scss
+++ b/assets/scss/components/_offender-details.scss
@@ -1,0 +1,6 @@
+.cpb-offender-details {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -10,6 +10,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/header-bar';
 @import './components/search-and-filter';
 @import './components/sortable-table';
+@import './components/offender-details';
 @import './pages/dashboard-index';
 
 @import './overrides/local';

--- a/e2e-tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/e2e-tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -4,12 +4,19 @@ import AppointmentFormPage from './appointmentFormPage'
 export default class CheckAppointmentDetailsPage extends AppointmentFormPage {
   readonly supervisorInputLocator: Locator
 
+  readonly updateButtonLocator: Locator
+
   constructor(page: Page) {
     super(page, 'Appointment details')
     this.supervisorInputLocator = page.getByLabel('Choose supervisor')
+    this.updateButtonLocator = page.getByRole('button', { name: 'Update appointment' })
   }
 
   chooseSupervisor(supervisor: string) {
     this.supervisorInputLocator.selectOption({ label: supervisor })
+  }
+
+  override async continue() {
+    await this.updateButtonLocator.click()
   }
 }

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -61,6 +61,10 @@ export default class CheckAppointmentDetailsPage extends Page {
     return new CheckAppointmentDetailsPage(appointment, project)
   }
 
+  clickUpdate() {
+    cy.get('a').contains('Update appointment').click()
+  }
+
   shouldContainProjectDetails() {
     this.projectDetails.getValueWithLabel('Project').should('contain.text', this.project.projectName)
     this.projectDetails.getValueWithLabel('Project type').should('contain.text', this.project.projectType.name)

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -466,8 +466,8 @@ context('Session details', () => {
       page.notesDetails.shouldNotBeVisible()
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})
-      // When I submit the form
-      page.clickSubmit()
+      // When I click update
+      page.clickUpdate()
 
       // Then I see the choose supervisor page
       Page.verifyOnPage(ChooseSupervisorPage, appointmentWithoutContactOutcome)

--- a/server/views/appointments/_offenderDetails.njk
+++ b/server/views/appointments/_offenderDetails.njk
@@ -1,7 +1,16 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <span class="govuk-caption-l">{{ offender.crn }}</span>
-    <h1 class="govuk-heading-l">{{ offender.name }}</h1>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+{% macro offenderDetails(offender) %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full cpb-offender-details">
+      <div>
+        <span class="govuk-caption-l">{{ offender.crn }}</span>
+        <h1 class="govuk-heading-l">{{ offender.name }}</h1>
+      </div>
+      {{ caller() }}
+    </div>
   </div>
-</div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    </div>
+  </div>
+{% endmacro %}

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -2,12 +2,22 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "./layout.njk" %}
 
 {% set pageTitle = 'Appointment details' %}
 
 {% set showContinue = showContinueButton %}
+
+{% block headerCallToAction %}
+  {% if showContinueButton %}
+    {{ govukButton({
+      text: "Update appointment",
+      href: nextPath
+    }) }}
+  {% endif %}
+{% endblock %}
 
 {% block beforeForm %}
   <div class="govuk-grid-row">
@@ -102,4 +112,7 @@
     </div>
   {% endif %}
 
+{% endblock %}
+
+{% block form %}
 {% endblock %}

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -35,7 +35,11 @@
     {% endfor %}
   {% endif %}
 
-  {% include "../_offenderDetails.njk" %}
+
+  {% call offenderDetails(offender) %}
+    {% block headerCallToAction %}
+    {% endblock %}
+  {% endcall %}
 
   {% block formHeader %}
     <div class="govuk-grid-row">

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "../_offenderDetails.njk" import offenderDetails %}
 
 {% from "../../showErrorSummary.njk" import showErrorSummary %}
 
@@ -51,6 +52,7 @@
 
   {% block beforeForm %}{% endblock %}
 
+  {% block form %}
   <form id="appointmentForm" action="{{ updatePath }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <input type="hidden" name="form" value="{{ form }}">
@@ -75,4 +77,5 @@
         </div>
       </div>
     </div>
+  {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Context

This moves the call to action for this page into the header, and updates to more appropriate wording. 
[CPB-909](https://dsdmoj.atlassian.net/browse/CPB-909)

## Changes in this PR

- Change offender details header to macro with `caller()` block to enable customisation. This is styled to float right.
- Enable override of form block in layout, where there is no form on the page. This includes the button block, as these are related to the form
- Add new button in the header on the appointment details page

### Screenshots of UI changes

Appointment details page with no outcome and CTA in header: 
<img width="1250" height="1786" alt="Appointment details page with no outcome and CTA in header" src="https://github.com/user-attachments/assets/f7e746c8-4d55-492f-8f67-b214b25e3a08" />

Appointment details page with outcome and no CTA:
<img width="1684" height="949" alt="Appointment details page with no outcome and CTA in header" src="https://github.com/user-attachments/assets/ea2d1895-46f4-4b92-8504-49bc09c93626" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-909]: https://dsdmoj.atlassian.net/browse/CPB-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ