### PR TITLE
Removed AppointmentSummaryDto from AppointmentTaskSummaryDto, and used top level properties.

### DIFF
--- a/integration_tests/pages/appointments/searchAttendedPage.ts
+++ b/integration_tests/pages/appointments/searchAttendedPage.ts
@@ -47,13 +47,11 @@ export default class SearchAttendedPage extends Page {
 
   shouldShowAttendedAppointments(appointments = this.appointments) {
     const expectedRowValues = appointments.map(row => {
-      const { appointment } = row
-
       return [
-        new Offender(appointment.offender).name,
-        appointment.offender.crn,
-        DateTimeFormats.isoDateToUIDate(appointment.date),
-        appointment.projectTypeName,
+        new Offender(row.offender).name,
+        row.offender.crn,
+        DateTimeFormats.isoDateToUIDate(row.date),
+        row.projectTypeName,
         'Update',
       ]
     })

--- a/server/@types/shared/models/AppointmentTaskSummaryDto.ts
+++ b/server/@types/shared/models/AppointmentTaskSummaryDto.ts
@@ -2,30 +2,32 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { AppointmentSummaryDto } from './AppointmentSummaryDto';
-import type { OffenderFullDto } from './OffenderFullDto';
-import type { OffenderLimitedDto } from './OffenderLimitedDto';
-import type { OffenderNotFoundDto } from './OffenderNotFoundDto';
+import type { OffenderFullDto } from './OffenderFullDto'
+import type { OffenderLimitedDto } from './OffenderLimitedDto'
+import type { OffenderNotFoundDto } from './OffenderNotFoundDto'
 export type AppointmentTaskSummaryDto = {
-    /**
-     * The unique identifier for the appointment task
-     */
-    taskId: string;
-    /**
-     * Deprecated: use top-level properties of this response instead.
-     *
-     * Summary details of the appointment associated with this task
-     * @deprecated
-     */
-    appointment: AppointmentSummaryDto;
-    offender: (OffenderFullDto | OffenderLimitedDto | OffenderNotFoundDto);
-    /**
-     * The date of the appointment.
-     */
-    date?: string | null;
-    /**
-     * The name of the project attended in this appointment.
-     */
-    projectTypeName?: string | null;
-};
-
+  /**
+   * The unique identifier for the appointment task
+   */
+  taskId: string
+  /**
+   * The id of the appointment in Delius.
+   */
+  deliusAppointmentId: number
+  /**
+   * The project code for the appointment.
+   */
+  projectCode: string
+  /**
+   * The offender details for the appointment.
+   */
+  offender: OffenderFullDto | OffenderLimitedDto | OffenderNotFoundDto
+  /**
+   * The date of the appointment.
+   */
+  date?: string | null
+  /**
+   * The name of the project attended in this appointment.
+   */
+  projectTypeName?: string | null
+}

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -181,14 +181,14 @@ export default class AdjustTravelTimeController {
       })
 
       tasks.content.forEach(task => {
-        if (task.appointment.offender?.crn) {
+        if (task.offender?.crn) {
           this.auditService.hmppsAuditClient.sendAuditMessage(
             Page.VIEW_TRAVEL_TIME_TASKS,
             res.locals.user.username,
             _req.params,
             _req.id,
             'CRN',
-            task.appointment.offender.crn,
+            task.offender.crn,
           )
         }
       })

--- a/server/pages/appointments/searchTravelTimePage.test.ts
+++ b/server/pages/appointments/searchTravelTimePage.test.ts
@@ -36,7 +36,6 @@ describe('SearchTravelTimePage', () => {
   describe('getRows', () => {
     it('returns appropriate rows of data', () => {
       const task = appointmentTaskSummaryFactory.build()
-      const { appointment } = task
       const tasks = {
         content: [task],
       }
@@ -52,18 +51,18 @@ describe('SearchTravelTimePage', () => {
       const searchParams = { provider: 'provider' }
       const row = SearchTravelTimePage.getRows(tasks as PagedModelAppointmentTaskSummaryDto, searchParams)[0]
 
-      expect(row[0].text).toEqual(new Offender(appointment.offender).name)
-      expect(row[1].text).toEqual(appointment.offender.crn)
+      expect(row[0].text).toEqual(new Offender(task.offender).name)
+      expect(row[1].text).toEqual(task.offender.crn)
       expect(row[2].text).toEqual(date)
-      expect(row[3].text).toEqual(appointment.projectTypeName)
+      expect(row[3].text).toEqual(task.projectTypeName)
       expect(row[4].html).toEqual(linkHtml)
 
       expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
         'Update',
         pathWithQuery(
           paths.appointments.travelTime.update({
-            projectCode: appointment.projectCode,
-            appointmentId: appointment.id.toString(),
+            projectCode: task.projectCode,
+            appointmentId: task.deliusAppointmentId.toString(),
             taskId: task.taskId,
           }),
           searchParams,

--- a/server/pages/appointments/searchTravelTimePage.ts
+++ b/server/pages/appointments/searchTravelTimePage.ts
@@ -45,13 +45,12 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
     }
 
     return tasks.content.map(row => {
-      const { appointment } = row
       const link = HtmlUtils.getAnchor(
         'Update',
         pathWithQuery(
           paths.appointments.travelTime.update({
-            appointmentId: appointment.id.toString(),
-            projectCode: appointment.projectCode,
+            appointmentId: row.deliusAppointmentId.toString(),
+            projectCode: row.projectCode,
             taskId: row.taskId,
           }),
           originalSearch,
@@ -59,10 +58,10 @@ export default class SearchTravelTimePage extends PageWithValidation<SearchTrave
       )
 
       return [
-        { text: new Offender(appointment.offender).name },
-        { text: appointment.offender.crn },
-        { text: DateTimeFormats.isoDateToUIDate(appointment.date) },
-        { text: appointment.projectTypeName },
+        { text: new Offender(row.offender).name },
+        { text: row.offender.crn },
+        { text: DateTimeFormats.isoDateToUIDate(row.date) },
+        { text: row.projectTypeName },
         { html: link },
       ]
     })

--- a/server/testutils/factories/appointmentTaskSummaryFactory.ts
+++ b/server/testutils/factories/appointmentTaskSummaryFactory.ts
@@ -1,11 +1,13 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
 import { AppointmentTaskSummaryDto } from '../../@types/shared'
-import appointmentSummaryFactory from './appointmentSummaryFactory'
 import offenderFullFactory from './offenderFullFactory'
 
 export default Factory.define<AppointmentTaskSummaryDto>(() => ({
   taskId: faker.string.alphanumeric(),
-  appointment: appointmentSummaryFactory.build(),
+  deliusAppointmentId: faker.number.int(),
+  projectCode: faker.string.alphanumeric(),
   offender: offenderFullFactory.build(),
+  date: faker.date.recent().toISOString(),
+  projectTypeName: faker.commerce.productName(),
 }))


### PR DESCRIPTION
Removed AppointmentSummaryDto from AppointmentTaskSummaryDto, and used top level properties.

## Context

The API is doing an unnecessary query to the delius appointment endpoint, therefore we need the UI to use top level properties.

## Changes in this PR

Removed AppointmentSummaryDto from AppointmentTaskSummaryDto, and used top level properties.

