### PR TITLE
Track "Unable to credit hours" button click with AppInsights

### DIFF
--- a/server/views/courseCompletions/process/layout.njk
+++ b/server/views/courseCompletions/process/layout.njk
@@ -77,9 +77,27 @@
         </div>
 
         {% if showUnableToCreditTime %}
-          <div class="govuk-button-group">
+          <div class="govuk-button-group unable-to-credit-hours-button">
             <a class="govuk-link" href="{{ unableToCreditTimePath }}">Unable to credit hours</a>
           </div>
+          <script nonce="{{ cspNonce }}" type="text/javascript">
+            document.querySelector(".unable-to-credit-hours-button a").addEventListener("click", async (event) => {
+              event.preventDefault();
+
+              if (typeof(appInsights) !== "undefined") {
+                appInsights.trackEvent({
+                  name: 'UnableToCreditHours'
+                }, {
+                  buttonName: 'Unable to credit hours',
+                  page: window.location.pathname
+                });
+
+                await appInsights.flush(true);
+              }
+
+              window.location.href = event.target.href;
+            });
+          </script>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
This sets up an AppInsights event tracker for when a user clicks the "Unable to credit hours" button on course completions. You'll need `APPLICATIONINSIGHTS_CONNECTION_STRING` to be set to something appropriate in nunjucksSetup.ts.

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
