### PR TITLE
Fix time credited on travel time e2e test

### DIFF
--- a/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
@@ -13,6 +13,7 @@ import { completeAttendedCompliedOutcome } from '../../steps/completeAttendanceO
 import searchForTravelTime from '../../steps/searchForTravelTime'
 import creditTravelTime from '../../steps/creditTravelTime'
 import completeChooseSupervisor from '../../steps/completeChooseSupervisor'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 
 test(
   'Credit travel time',
@@ -36,12 +37,11 @@ test(
 
     const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
 
-    // 4 hours of unpaid work will be required, credit for 2 hours
-    await logHoursPage.startTimeFieldLocator.clear()
-    await logHoursPage.startTimeFieldLocator.fill('14:00')
-
+    // 4 hours of unpaid work will be required, only credit for 2 hours
+    const startTime = appointment.date.toTimeString().split(' ')[0] // appointment start time should be current time so use date from appointment fixture
+    const endTime = DateTimeFormats.addHours(DateTimeFormats.stripTime(startTime), 2)
     await logHoursPage.endTimeFieldLocator.clear()
-    await logHoursPage.endTimeFieldLocator.fill('16:00')
+    await logHoursPage.endTimeFieldLocator.fill(endTime)
     await logHoursPage.continue()
 
     await completeCompliance(page)

--- a/server/utils/dateTimeUtils.test.ts
+++ b/server/utils/dateTimeUtils.test.ts
@@ -515,4 +515,18 @@ describe('DateTimeFormats', () => {
       expect(DateTimeFormats.datesAreWithinNDays(firstDate, secondDate, 3)).toBe(true)
     })
   })
+
+  describe('addHours', () => {
+    it.each([
+      ['09:00:00', 1, '10:00:00'],
+      ['09:00', 1, '10:00'],
+      ['23:59', 1, '00:59'],
+      ['23:59', 3, '02:59'],
+      ['08:30', 24, '08:30'],
+      ['09:30', 25, '10:30'],
+      ['', 1, ''],
+    ])('should return time with hours added', (time: string, hoursToAdd: number, expected: string) => {
+      expect(DateTimeFormats.addHours(time, hoursToAdd)).toEqual(expected)
+    })
+  })
 })

--- a/server/utils/dateTimeUtils.ts
+++ b/server/utils/dateTimeUtils.ts
@@ -364,6 +364,33 @@ export default class DateTimeFormats {
   }
 
   /**
+   * Calculates a time with added hours.
+   * @param time - a string like 09:56 or 08:23:23
+   * @param hours - a number
+   * @returns A string
+   */
+
+  static addHours(time: string, hoursToAdd: number = 1): string {
+    if (!time) {
+      return ''
+    }
+
+    const [hours, minutes, seconds] = time.split(':').map(Number)
+
+    const calculatedHour = (hours + hoursToAdd) % 24
+
+    if (seconds === undefined) {
+      return [String(calculatedHour).padStart(2, '0'), String(minutes).padStart(2, '0')].join(':')
+    }
+
+    return [
+      String(calculatedHour).padStart(2, '0'),
+      String(minutes).padStart(2, '0'),
+      String(seconds).padStart(2, '0'),
+    ].join(':')
+  }
+
+  /**
    * Convert a number to string and add a 0 at the start if a single digit.
    * @param number
    * @returns A string


### PR DESCRIPTION
## Context
Previously this was a hard-coded value which would fail validation if the
appointment was in the future.

This calculates a relative time based on the start time of the appointment to
avoid this.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Introduce `addHours` utility
* Calculate end time based on 2 hours of work when recording outcome for travel time test

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
