### PR TITLE
Remove data from form when CRN is changed

### DIFF
--- a/server/pages/courseCompletions/process/crnPage.test.ts
+++ b/server/pages/courseCompletions/process/crnPage.test.ts
@@ -102,7 +102,7 @@ describe('CrnPage', () => {
       const crn = '1'
 
       const result = page.getFormData(form, { crn })
-      expect(result).toEqual({ ...form, crn })
+      expect(result).toEqual({ originalSearch: form.originalSearch, crn })
     })
   })
 

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -26,7 +26,10 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
   protected page: CourseCompletionPage = 'crn'
 
   getFormData(formData: CourseCompletionForm, body: CrnPageBody): CourseCompletionForm {
-    return { ...formData, crn: body.crn.trim() }
+    return {
+      originalSearch: formData.originalSearch,
+      crn: body.crn.trim(),
+    }
   }
 
   protected getValidationErrors(query: CrnPageBody): ValidationErrors<CrnPageBody> {


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-875#icft=CPB-875)

## Context
When changing the CRN when recording an outcome of a course completion, ensure that stale data is removed. Only preserve the search terms.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
