### PR TITLE
For all appointment outcomes, show radio options to inform practitioner

### DIFF
--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -23,7 +23,7 @@ export default class ConfirmPage extends AppointmentFormPage {
     this.details = new SummaryListComponent(page)
     this.confirmButtonLocator = page.getByRole('button', { name: 'Confirm' })
     this.alertPractitionerQuestionLocator = page.getByRole('group', {
-      name: 'Would you like to share this outcome with the probation practitioner?',
+      name: /Would you (?:also )?like this to be sent to the alert diary?/,
     })
     this.alertPractitionerMessageLocator = page.getByText(
       'This outcome will be shared with the practitioner as it requires enforcement action',

--- a/integration_tests/pages/components/radioGroupComponent.ts
+++ b/integration_tests/pages/components/radioGroupComponent.ts
@@ -21,6 +21,10 @@ export default class RadioGroupComponent {
     this.getAll().should('not.be.checked')
   }
 
+  shouldBeVisible() {
+    this.getAll().should('exist')
+  }
+
   shouldNotBeVisible() {
     this.getAll().should('not.exist')
   }

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -12,10 +12,10 @@
 //    Then I can see my completed answers without attendance
 
 //  Scenario: alerting the probation practitioner
-//    Scenario: Cannot alert if selected contact outcome already sends an alert
+//    Scenario: Can also alert if selected contact outcome already sends an alert
 //      Given I am on the confirm page
 //      And I have selected a contact outcome which will alert the enforcement diary
-//      Then I do not see a question asking if I want to alert the probation practitioner
+//      Then I also see a question asking if I want to alert the probation practitioner
 //    Scenario: Can alert if selected contact outcome does not send an alert
 //      Given I am on the confirm page
 //      And I have selected a contact outcome which will not alert the enforcement diary
@@ -160,7 +160,7 @@ context('Confirm appointment details page', () => {
 
   // Scenario: alerting the probation practitioner
   describe('alert practitioner question', function describe() {
-    //  Scenario: Cannot alert if selected contact outcome already sends an alert
+    //  Scenario: Can also alert if selected contact outcome already sends an alert
     it('selected contact outcome sends alert => does not display alert practitioner question', function test() {
       //  Given I am on the confirm page
       //  And I have selected a contact outcome which will alert the enforcement diary
@@ -176,8 +176,8 @@ context('Confirm appointment details page', () => {
       const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
       page.shouldShowCompletedDetails()
 
-      //  Then I do not see a question asking if I want to alert the probation practitioner
-      page.alertPractitionerQuestion.shouldNotBeVisible()
+      //  Then I also see a question asking if I want to alert the probation practitioner
+      page.alertPractitionerQuestion.shouldBeVisible()
       page.shouldShowAlertPractitionerMessage()
     })
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -94,12 +94,13 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: true },
         })
-
+        const items = [{ text: 'Yes', value: 'yes' }]
+        jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
         const result = page.viewData(appointment, form)
-        expect(result.alertPractitionerItems).toEqual([])
+        expect(result.alertPractitionerItems).toEqual(items)
       })
 
-      it('should return an object containing empty alert practitioner question items if contact outcome will not alert', () => {
+      it('should return an object containing alert practitioner question items if contact outcome will not alert', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: false },
         })
@@ -107,6 +108,24 @@ describe('ConfirmPage', () => {
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
         const result = page.viewData(appointment, form)
         expect(result.alertPractitionerItems).toEqual(items)
+      })
+    })
+
+    describe('alertDiaryText', () => {
+      it("should return alertDiaryText with 'also' if contact outcome will alert", () => {
+        form = appointmentOutcomeFormFactory.build({
+          contactOutcome: { code: 'some-code', willAlertEnforcementDiary: true },
+        })
+        const result = page.viewData(appointment, form)
+        expect(result.alertDiaryText).toContain('also')
+      })
+
+      it("should return alertDiaryText without 'also' if contact outcome will not alert", () => {
+        form = appointmentOutcomeFormFactory.build({
+          contactOutcome: { code: 'some-code', willAlertEnforcementDiary: false },
+        })
+        const result = page.viewData(appointment, form)
+        expect(result.alertDiaryText).not.toContain('also')
       })
     })
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -17,6 +17,7 @@ import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 interface ViewData extends AppointmentUpdatePageViewData {
   alertPractitionerItems: GovUkRadioOption[]
   showWillAlertPractitionerMessage: boolean
+  alertDiaryText: string
   submittedItems: GovUkSummaryListItem[]
 }
 
@@ -41,9 +42,10 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       ...this.commonViewData(appointment),
       submittedItems: this.formItems(form, appointment),
       showWillAlertPractitionerMessage,
-      alertPractitionerItems: showWillAlertPractitionerMessage
-        ? []
-        : GovUkRadioGroup.yesNoItems({ checkedValue: GovUkRadioGroup.determineCheckedValue(appointment.alertActive) }),
+      alertPractitionerItems: GovUkRadioGroup.yesNoItems({
+        checkedValue: GovUkRadioGroup.determineCheckedValue(appointment.alertActive),
+      }),
+      alertDiaryText: `Would you ${showWillAlertPractitionerMessage ? 'also' : ''} like this to be sent to the alert diary?`,
     }
   }
 

--- a/server/views/appointments/update/confirm.njk
+++ b/server/views/appointments/update/confirm.njk
@@ -41,7 +41,7 @@
     name: "alertPractitioner",
     fieldset: {
       legend: {
-        text: "Would you like to share this outcome with the probation practitioner?",
+        text: alertDiaryText,
         classes: "govuk-fieldset__legend--m"
       }
     },


### PR DESCRIPTION
* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-969)

This tweaks the logic so that we show the radio options about informing the probation practitioner regardless of the outcome.

If the banner is showing, we tweak the text slightly so it contains the word "also".

## Context

## Changes in this PR

### Screenshots of UI changes

Two variants:

<img width="1411" height="1473" alt="banner-and-options" src="https://github.com/user-attachments/assets/01364554-f0b1-4cd7-aac9-dedfbd7082de" />
<img width="1411" height="1473" alt="just-options" src="https://github.com/user-attachments/assets/ec033c94-f9d5-49a7-b99b-cd694a61b897" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
