### PR TITLE
CPB-967 Add date to travel time adjustment form

### DIFF
--- a/e2e-tests/pages/travelTime/travelTimePage.ts
+++ b/e2e-tests/pages/travelTime/travelTimePage.ts
@@ -4,11 +4,14 @@ import { expect, Locator, Page } from '@playwright/test'
 import BasePage from '../basePage'
 import PersonOnProbation from '../../delius/personOnProbation'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
+import DateInputComponent from '../components/dateInputComponent'
 
 export default class TravelTimePage extends BasePage {
   readonly expect: TravelTimePageAssertions
 
   private readonly hoursMinutesInput: HoursMinutesInputComponent
+
+  private readonly dateInput: DateInputComponent
 
   private readonly creditTravelTimeButtonLocator: Locator
 
@@ -18,11 +21,14 @@ export default class TravelTimePage extends BasePage {
     super(page)
     this.expect = new TravelTimePageAssertions(this, personOnProbation.getFullName())
     this.hoursMinutesInput = new HoursMinutesInputComponent(page)
+    this.dateInput = new DateInputComponent(page)
     this.creditTravelTimeButtonLocator = page.getByRole('button', { name: 'Credit travel time' })
     this.notEligibleForTravelTimeButtonLocator = page.getByRole('button', { name: 'Not eligible for travel time' })
   }
 
   async completeTravelTimeForm(timeCredited: { hours: string; minutes: string } = { hours: '1', minutes: '10' }) {
+    const date = new Date()
+    await this.dateInput.enterDate(date)
     await this.hoursMinutesInput.enterHours(timeCredited.hours, timeCredited.minutes)
   }
 

--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -3,12 +3,15 @@ import Offender from '../../../server/models/offender'
 import paths from '../../../server/paths'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import { pathWithQuery } from '../../../server/utils/utils'
+import DateComponent from '../components/dateComponent'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 import SummaryListComponent from '../components/summaryListComponent'
 import Page from '../page'
 
 export default class UpdateTravelTimePage extends Page {
   readonly timeInput = new HoursMinutesInputComponent()
+
+  readonly dateInput = new DateComponent('date')
 
   readonly appointmentDetails = new SummaryListComponent('Appointment details')
 
@@ -36,6 +39,11 @@ export default class UpdateTravelTimePage extends Page {
 
   clickNotEligible() {
     cy.get('button').contains('Not eligible').click()
+  }
+
+  completeForm() {
+    this.timeInput.enterTime()
+    this.dateInput.enterDates('01', '05', '2026')
   }
 
   override clickSubmit() {

--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -170,7 +170,7 @@ context('Update travel time page', () => {
     page.shouldShowAppointmentDetails(contactOutcome.name, project)
 
     //  When I complete the form
-    page.timeInput.enterTime()
+    page.completeForm()
 
     cy.task('stubSaveAdjustment', { appointment })
     cy.task('stubGetAdjustmentReasons')
@@ -188,7 +188,7 @@ context('Update travel time page', () => {
     page.shouldShowAppointmentDetails(contactOutcome.name, project)
 
     //  When I complete the form
-    page.timeInput.enterTime()
+    page.completeForm()
 
     // And I submit
 
@@ -229,7 +229,7 @@ context('Update travel time page', () => {
     const page = UpdateTravelTimePage.visit(appointment)
 
     //  When I complete the form
-    page.timeInput.enterTime()
+    page.completeForm()
 
     cy.task('stubGetAdjustmentReasons')
 

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -146,6 +146,23 @@ describe('AdjustTravelTimeController', () => {
         type: 'Group',
       },
       preventDoubleClick: true,
+      dateItems: [
+        {
+          classes: 'govuk-input--width-2',
+          name: 'day',
+          value: '23',
+        },
+        {
+          classes: 'govuk-input--width-2',
+          name: 'month',
+          value: '05',
+        },
+        {
+          classes: 'govuk-input--width-4',
+          name: 'year',
+          value: '2026',
+        },
+      ],
     }
     const appointmentId = '1'
     const projectCode = '2'
@@ -204,6 +221,23 @@ describe('AdjustTravelTimeController', () => {
         type: 'Group',
       },
       preventDoubleClick: true,
+      dateItems: [
+        {
+          classes: 'govuk-input--width-2',
+          name: 'day',
+          value: '23',
+        },
+        {
+          classes: 'govuk-input--width-2',
+          name: 'month',
+          value: '05',
+        },
+        {
+          classes: 'govuk-input--width-4',
+          name: 'year',
+          value: '2026',
+        },
+      ],
     }
     const appointmentId = '1'
     const projectCode = '2'

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -64,6 +64,7 @@ export default class AdjustTravelTimeController {
         contactOutcome,
         project,
         originalSearch: req.query as SearchTravelTimePageInput,
+        req,
       })
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
@@ -106,6 +107,7 @@ export default class AdjustTravelTimeController {
             contactOutcome,
             project,
             originalSearch: req.query as SearchTravelTimePageInput,
+            req,
           }),
           errorSummary,
           errors,

--- a/server/forms/GovUkFrontendDateInput.test.ts
+++ b/server/forms/GovUkFrontendDateInput.test.ts
@@ -242,4 +242,43 @@ describe('GovUkFrontendDateInput', () => {
       })
     })
   })
+
+  describe('dateIsInTheFuture', () => {
+    it('returns true if date is in the future', () => {
+      const date = {
+        'date-day': '15',
+        'date-month': '01',
+        'date-year': '9999',
+      }
+
+      const result = GovukFrontendDateInput.dateIsInTheFuture(date, 'date')
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false if date is in the past', () => {
+      const date = {
+        'date-day': '15',
+        'date-month': '01',
+        'date-year': '2020',
+      }
+
+      const result = GovukFrontendDateInput.dateIsInTheFuture(date, 'date')
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false if date is today', () => {
+      const today = new Date()
+      const date = {
+        'date-day': String(today.getDate()).padStart(2, '0'),
+        'date-month': String(today.getMonth() + 1).padStart(2, '0'),
+        'date-year': String(today.getFullYear()),
+      }
+
+      const result = GovukFrontendDateInput.dateIsInTheFuture(date, 'date')
+
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/server/forms/GovukFrontendDateInput.ts
+++ b/server/forms/GovukFrontendDateInput.ts
@@ -75,6 +75,11 @@ export default class GovukFrontendDateInput {
     return true
   }
 
+  static dateIsInTheFuture<K extends string>(dateInputObj: ObjectWithDateParts<K>, key: K) {
+    const date = DateTimeFormats.dateAndTimeInputsToIsoString(dateInputObj, key)[key]
+    return DateTimeFormats.dateIsInFuture(date)
+  }
+
   static getStructuredDate<K extends string>(
     dateInputObj: ObjectWithDateParts<K>,
     key: K,

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -1,3 +1,5 @@
+import { Request } from 'express'
+import { createMock } from '@golevelup/ts-jest'
 import HoursAndMinutesInput from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
 import paths from '../../paths'
@@ -12,9 +14,12 @@ jest.mock('../../models/offender')
 
 describe('UpdateTravelTimePage', () => {
   let page: UpdateTravelTimePage
+  let req = createMock<Request>()
+
   beforeEach(() => {
     jest.resetAllMocks()
     page = new UpdateTravelTimePage()
+    req = createMock<Request>()
   })
 
   describe('validationErrors', () => {
@@ -22,6 +27,9 @@ describe('UpdateTravelTimePage', () => {
       const result = page.validationErrors({
         hours: '2',
         minutes: '20',
+        'date-day': '01',
+        'date-month': '05',
+        'date-year': '2026',
       })
       expect(result.errors).toEqual({})
       expect(result.hasErrors).toBe(false)
@@ -51,10 +59,64 @@ describe('UpdateTravelTimePage', () => {
         expect(HoursAndMinutesInput.validationErrors).toHaveBeenCalledWith(body, 'travel time')
       })
     })
+
+    describe('date', () => {
+      it('should not return an error for date if no validation errors', () => {
+        const body = {
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '2026',
+        }
+        const result = page.validationErrors(body).errors
+        expect(result['date-day']).toBeUndefined()
+        expect(result['date-month']).toBeUndefined()
+        expect(result['date-year']).toBeUndefined()
+      })
+
+      it('should return an error for date if date is incomplete', () => {
+        const error = { text: 'Enter a day, month and year for this adjustment' }
+        const body = {
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '',
+        }
+        const result = page.validationErrors(body).errors
+        expect(result['date-day']).toEqual(error)
+      })
+
+      it('should return an error for date if date is not valid', () => {
+        const error = { text: 'Adjustment date must be a valid date' }
+        const body = {
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '1111111',
+        }
+        const result = page.validationErrors(body).errors
+        expect(result['date-day']).toEqual(error)
+      })
+
+      it('should return an error for date if date is in the future', () => {
+        const error = { text: 'Adjustment date must not be in the future' }
+        const body = {
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '9999',
+        }
+        const result = page.validationErrors(body).errors
+        expect(result['date-day']).toEqual(error)
+      })
+    })
   })
 
   describe('viewData', () => {
     it('returns offender, paths and appointmentDetails', () => {
+      req = createMock<Request>({
+        body: {
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '2026',
+        },
+      })
       const taskId = '1'
       const appointment = appointmentFactory.build()
       const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
@@ -73,6 +135,24 @@ describe('UpdateTravelTimePage', () => {
       const startTime = '09:00'
       const endTime = '17:00'
 
+      const dateItems = [
+        {
+          classes: 'govuk-input--width-2',
+          name: 'day',
+          value: '01',
+        },
+        {
+          classes: 'govuk-input--width-2',
+          name: 'month',
+          value: '05',
+        },
+        {
+          classes: 'govuk-input--width-4',
+          name: 'year',
+          value: '2026',
+        },
+      ]
+
       jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(uiDate)
       jest.spyOn(DateTimeFormats, 'stripTime').mockImplementation((time: string) => {
         return time === appointment.startTime ? startTime : endTime
@@ -87,6 +167,7 @@ describe('UpdateTravelTimePage', () => {
         contactOutcome,
         project,
         originalSearch: {},
+        req,
       })
 
       expect(result).toEqual({
@@ -112,6 +193,7 @@ describe('UpdateTravelTimePage', () => {
           name: project.projectName,
           type: project.projectType.name,
         },
+        dateItems,
       })
 
       expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(appointment.date)
@@ -130,6 +212,7 @@ describe('UpdateTravelTimePage', () => {
         contactOutcome: contactOutcomeFactory.build({ name: contactOutcomeName }),
         project,
         originalSearch: {},
+        req,
       })
 
       expect(result.appointment.contactOutcome).toBe(contactOutcomeName)
@@ -147,6 +230,7 @@ describe('UpdateTravelTimePage', () => {
         contactOutcome: contactOutcomeFactory.build(),
         project,
         originalSearch,
+        req,
       })
 
       expect(result.backLink).toBe(pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch))
@@ -164,6 +248,7 @@ describe('UpdateTravelTimePage', () => {
         contactOutcome: contactOutcomeFactory.build(),
         project,
         originalSearch,
+        req,
       })
 
       expect(result.completeTaskPath).toBe(
@@ -177,17 +262,110 @@ describe('UpdateTravelTimePage', () => {
         ),
       )
     })
+
+    describe('dateItems', () => {
+      it('returns date items', () => {
+        req = createMock<Request>({
+          body: {
+            'date-day': '01',
+            'date-month': '05',
+            'date-year': '2026',
+          },
+        })
+
+        const appointment = appointmentFactory.build()
+        const originalSearch = { provider: 'provider' }
+
+        const project = projectFactory.build()
+
+        const result = page.viewData({
+          appointment,
+          taskId: '1',
+          contactOutcome: contactOutcomeFactory.build(),
+          project,
+          originalSearch,
+          req,
+        })
+
+        expect(result.dateItems).toEqual([
+          {
+            classes: 'govuk-input--width-2',
+            name: 'day',
+            value: '01',
+          },
+          {
+            classes: 'govuk-input--width-2',
+            name: 'month',
+            value: '05',
+          },
+          {
+            classes: 'govuk-input--width-4',
+            name: 'year',
+            value: '2026',
+          },
+        ])
+      })
+
+      it('returns date items with error', () => {
+        req = createMock<Request>({
+          body: {
+            'date-day': '01',
+            'date-month': '05',
+            'date-year': '',
+          },
+        })
+
+        const appointment = appointmentFactory.build()
+        const originalSearch = { provider: 'provider' }
+
+        const project = projectFactory.build()
+
+        const result = page.viewData({
+          appointment,
+          taskId: '1',
+          contactOutcome: contactOutcomeFactory.build(),
+          project,
+          originalSearch,
+          req,
+        })
+
+        expect(result.dateItems).toEqual([
+          {
+            classes: 'govuk-input--width-2 govuk-input--error',
+            name: 'day',
+            value: '01',
+          },
+          {
+            classes: 'govuk-input--width-2 govuk-input--error',
+            name: 'month',
+            value: '05',
+          },
+          {
+            classes: 'govuk-input--width-4 govuk-input--error',
+            name: 'year',
+            value: '',
+          },
+        ])
+      })
+    })
   })
 
   describe('requestBody', () => {
     it('returns object with total minutes and taskId', () => {
       const taskId = '12'
-      const body = { hours: '1', minutes: '30' }
+      const body = {
+        hours: '1',
+        minutes: '30',
+        'date-day': '20',
+        'date-month': '05',
+        'date-year': '2026',
+      }
       const minutes = 123
+      const adjustmentDate = '2026-05-20'
       jest.spyOn(DateTimeFormats, 'hoursAndMinutesToMinutes').mockReturnValue(minutes)
 
       const result = page.requestBody(body, taskId)
-      expect(result).toEqual({ taskId, minutes })
+      expect(result).toEqual({ taskId, minutes, adjustmentDate })
       expect(DateTimeFormats.hoursAndMinutesToMinutes).toHaveBeenCalledWith(body.hours, body.minutes)
     })
   })

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -1,3 +1,4 @@
+import type { Request } from 'express'
 import { AppointmentDto, ContactOutcomeDto, CreateAdjustmentDto, ProjectDto } from '../../@types/shared'
 import { ValidationErrors } from '../../@types/user-defined'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../forms/hoursAndMinutesInput'
@@ -7,6 +8,7 @@ import DateTimeFormats from '../../utils/dateTimeUtils'
 import { pathWithQuery } from '../../utils/utils'
 import PageWithValidation from '../pageWithValidation'
 import { SearchTravelTimePageInput } from './searchTravelTimePage'
+import GovukFrontendDateInput, { GovUkFrontendDateInputItem } from '../../forms/GovukFrontendDateInput'
 
 interface AppointmentDetails {
   date: string
@@ -25,11 +27,24 @@ interface PageViewData {
     name: string
     type: string
   }
+  dateItems: Array<GovUkFrontendDateInputItem>
 }
 
-export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithHoursAndMinutes> {
-  protected getValidationErrors(query: ObjectWithHoursAndMinutes): ValidationErrors<ObjectWithHoursAndMinutes> {
-    return HoursAndMinutesInput.validationErrors(query, 'travel time')
+type TimePeriods = 'day' | 'month' | 'year'
+type DateKeys = `date-${TimePeriods}`
+
+type DateBody = {
+  [K in DateKeys]?: string
+}
+
+type ObjectWithDateTimeAndMinutes = DateBody & ObjectWithHoursAndMinutes
+
+export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithDateTimeAndMinutes> {
+  protected getValidationErrors(query: ObjectWithDateTimeAndMinutes): ValidationErrors<ObjectWithHoursAndMinutes> {
+    return {
+      ...HoursAndMinutesInput.validationErrors(query, 'travel time'),
+      ...this.getDateErrors(query),
+    }
   }
 
   viewData({
@@ -38,12 +53,14 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     contactOutcome,
     project,
     originalSearch,
+    req,
   }: {
     appointment: AppointmentDto
     taskId: string
     contactOutcome?: ContactOutcomeDto
     project: ProjectDto
     originalSearch: SearchTravelTimePageInput
+    req: Request
   }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
@@ -63,7 +80,38 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
         name: project.projectName,
         type: project.projectType.name,
       },
+      dateItems: this.getDateItems(req),
     }
+  }
+
+  getDateItems(req: Request): Array<GovUkFrontendDateInputItem> {
+    const date = {
+      day: req.body?.['date-day'] ?? '',
+      month: req.body?.['date-month'] ?? '',
+      year: req.body?.['date-year'] ?? '',
+    }
+    const hasDateError = (this.getDateErrors(req.body) as ValidationErrors<DateBody>)['date-day'] !== undefined
+    return GovukFrontendDateInput.getDateItemsFromStructuredDate(date, hasDateError)
+  }
+
+  getDateErrors(body: DateBody) {
+    if (!body) {
+      return {}
+    }
+
+    if (!GovukFrontendDateInput.dateIsComplete(body, 'date')) {
+      return { 'date-day': { text: 'Enter a day, month and year for this adjustment' } }
+    }
+
+    if (!GovukFrontendDateInput.dateIsValid(body, 'date')) {
+      return { 'date-day': { text: 'Adjustment date must be a valid date' } }
+    }
+
+    if (GovukFrontendDateInput.dateIsInTheFuture(body, 'date')) {
+      return { 'date-day': { text: 'Adjustment date must not be in the future' } }
+    }
+
+    return {}
   }
 
   exitPath(originalSearch: SearchTravelTimePageInput): string {
@@ -73,10 +121,14 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithH
     return pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch)
   }
 
-  requestBody(body: ObjectWithHoursAndMinutes, taskId: string): Pick<CreateAdjustmentDto, 'taskId' | 'minutes'> {
+  requestBody(
+    body: ObjectWithDateTimeAndMinutes,
+    taskId: string,
+  ): Pick<CreateAdjustmentDto, 'taskId' | 'minutes' | 'adjustmentDate'> {
     return {
       taskId,
       minutes: DateTimeFormats.hoursAndMinutesToMinutes(body.hours, body.minutes),
+      adjustmentDate: DateTimeFormats.dateAndTimeInputsToIsoString(body, 'date').date,
     }
   }
 

--- a/server/views/appointments/update/travelTime/update.njk
+++ b/server/views/appointments/update/travelTime/update.njk
@@ -1,5 +1,6 @@
 {% from "../../../partials/hoursMinutesInputs.njk" import hoursMinutesInputs %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% extends "../layout.njk" %}
 
@@ -33,6 +34,22 @@
 {% block formContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {{ govukDateInput({
+        id: "date",
+        namePrefix: "date",
+        fieldset: {
+          legend: {
+            html: '<h2 class="govuk-fieldset__heading">Choose a date for this adjustment</h2>',
+            classes: 'govuk-fieldset__legend govuk-fieldset__legend--m'
+          }
+        },
+        hint: {
+          text: "For example, this could be today's date or the date of the appointment"
+        },
+        items: dateItems,
+        errorMessage: errors['date-day']
+      }) }}
+
       {{ hoursMinutesInputs(time, errors, 'How much time should be credited for travel?') }}
     </div>
   </div>


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-967?atlOrigin=eyJpIjoiYzgwMThmMWQyYjNmNDI0OGEyYmEzZmFiMjIzYWUwMGUiLCJwIjoiaiJ9)

## Context
Due to regional variations in how travel time is processed we need to allow case admins to input a date.

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1295" height="1026" alt="Screenshot 2026-05-21 at 12 29 05" src="https://github.com/user-attachments/assets/92c8f20f-4838-4e33-9774-65ddd5004999" />
<img width="1291" height="1225" alt="Screenshot 2026-05-21 at 12 31 37" src="https://github.com/user-attachments/assets/ec024a0b-244c-4813-93f9-9c04eb336157" />
<img width="1295" height="1221" alt="Screenshot 2026-05-21 at 12 31 59" src="https://github.com/user-attachments/assets/1a7af840-f90b-4502-9e0b-48d9aed06042" />
<img width="1302" height="1213" alt="Screenshot 2026-05-21 at 16 11 11" src="https://github.com/user-attachments/assets/c40825f2-1e67-4ec6-9831-e284f0d043a1" />
<img width="1560" height="497" alt="Screenshot 2026-05-22 at 12 53 36" src="https://github.com/user-attachments/assets/91586a8b-b470-42eb-97d3-337d9a716baa" />
<img width="1261" height="210" alt="Screenshot 2026-05-22 at 12 53 15" src="https://github.com/user-attachments/assets/5053d07e-3358-475a-a9ea-da7997ebf72d" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
