### PR TITLE
CPB-970 - Add "Supervising team" dropdown to choose supervisor page

### DIFF
--- a/e2e-tests/pages/appointments/chooseSupervisorPage.ts
+++ b/e2e-tests/pages/appointments/chooseSupervisorPage.ts
@@ -4,9 +4,23 @@ import AppointmentFormPage from './appointmentFormPage'
 export default class ChooseSupervisorPage extends AppointmentFormPage {
   readonly supervisorInputLocator: Locator
 
+  readonly supervisingTeamInputLocator: Locator
+
+  readonly selectTeamLocator: Locator
+
   constructor(page: Page) {
     super(page, 'Add supervisor details')
+    this.supervisingTeamInputLocator = page.getByLabel('Supervising team')
+    this.selectTeamLocator = page.getByText('Select team')
     this.supervisorInputLocator = page.getByLabel('Supervising officer')
+  }
+
+  chooseSupervisingTeam(team: string) {
+    this.supervisingTeamInputLocator.selectOption({ label: team })
+  }
+
+  clickSelectTeam() {
+    this.selectTeamLocator.click()
   }
 
   chooseSupervisor(supervisor: string) {

--- a/e2e-tests/steps/completeChooseSupervisor.ts
+++ b/e2e-tests/steps/completeChooseSupervisor.ts
@@ -1,11 +1,16 @@
 import { Page } from '@playwright/test'
 import AttendanceOutcomePage from '../pages/appointments/attendanceOutcomePage'
 import ChooseSupervisorPage from '../pages/appointments/chooseSupervisorPage'
+import { Team } from '../fixtures/testOptions'
 
-export default async (page: Page, chooseSupervisorPage: ChooseSupervisorPage, supervisor: string) => {
-  const attendanceOutcomePage = new AttendanceOutcomePage(page)
-  await chooseSupervisorPage.chooseSupervisor(supervisor)
+export default async (page: Page, chooseSupervisorPage: ChooseSupervisorPage, team: Team) => {
+  await chooseSupervisorPage.chooseSupervisingTeam(team.name)
+  await Promise.all([page.waitForURL(/team=/), chooseSupervisorPage.clickSelectTeam()])
+
+  await chooseSupervisorPage.chooseSupervisor(team.supervisor)
   await chooseSupervisorPage.continue()
+
+  const attendanceOutcomePage = new AttendanceOutcomePage(page)
   await attendanceOutcomePage.expect.toBeOnThePage()
 
   return attendanceOutcomePage

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -28,7 +28,7 @@ test('Update a session appointment', async ({ page, deliusUser, team, project, p
   const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
   const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
 
-  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
   const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
   await logHoursPage.enterPenaltyHours()

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -29,7 +29,7 @@ test('Update a session appointment with an enforceable outcome', async ({
   const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
   const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
 
-  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
   await attendanceOutcomePage.chooseEnforcementOutcome()
   await attendanceOutcomePage.continue()
 

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -30,7 +30,7 @@ test('Update a session appointment with an attended but enforceable outcome', as
   const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
   const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
 
-  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
   const logHoursPage = await completeAttendedEnforceableOutcome(page, attendanceOutcomePage)
 

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -29,7 +29,7 @@ test('Update a session appointment with a not attended but not enforceable outco
   const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
   const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
 
-  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
   await attendanceOutcomePage.chooseNotAttendedNotEnforcementOutcome()
   await attendanceOutcomePage.continue()

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -31,7 +31,7 @@ test('Update an individual placement appointment with attended complied', async 
   const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, projectPage, personOnProbation.crn)
   const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
 
-  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
   const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
   await logHoursPage.enterPenaltyHours()

--- a/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
@@ -33,7 +33,7 @@ test(
 
     const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
     const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
-    const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+    const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
     const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
 

--- a/e2e-tests/tests/travel-time/10_unable_to_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/10_unable_to_credit_travel_time.spec.ts
@@ -30,7 +30,7 @@ test(
 
     const checkAppointmentDetailsPage = await clickUpdateAnAppointment(page, sessionPage, personOnProbation.crn)
     const chooseSupervisorPage = await completeCheckAppointmentDetails(page, checkAppointmentDetailsPage)
-    const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team.supervisor)
+    const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
     const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
     await logHoursPage.continue()

--- a/integration_tests/pages/appointments/chooseSupervisorPage.ts
+++ b/integration_tests/pages/appointments/chooseSupervisorPage.ts
@@ -21,18 +21,13 @@ export default class ChooseSupervisorPage extends Page {
     this.supervisorInput = new SelectInput('supervisor')
   }
 
-  static visit(appointment: AppointmentDto, team?: string): ChooseSupervisorPage {
-    const query = { form: '123' } as { form: string; team?: string }
-    if (team) {
-      query.team = team
-    }
-
+  static visit(appointment: AppointmentDto): ChooseSupervisorPage {
     const path = pathWithQuery(
       paths.appointments.chooseSupervisor({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
       }),
-      query,
+      { form: '123' },
     )
 
     cy.visit(path)

--- a/integration_tests/pages/appointments/chooseSupervisorPage.ts
+++ b/integration_tests/pages/appointments/chooseSupervisorPage.ts
@@ -6,6 +6,8 @@ import Offender from '../../../server/models/offender'
 import { pathWithQuery } from '../../../server/utils/utils'
 
 export default class ChooseSupervisorPage extends Page {
+  readonly teamInput: SelectInput
+
   readonly supervisorInput: SelectInput
 
   readonly appointment: AppointmentDto
@@ -15,18 +17,22 @@ export default class ChooseSupervisorPage extends Page {
 
     super(offender.name)
     this.appointment = appointment
+    this.teamInput = new SelectInput('team')
     this.supervisorInput = new SelectInput('supervisor')
   }
 
-  static visit(appointment: AppointmentDto): ChooseSupervisorPage {
+  static visit(appointment: AppointmentDto, team?: string): ChooseSupervisorPage {
+    const query = { form: '123' } as { form: string; team?: string }
+    if (team) {
+      query.team = team
+    }
+
     const path = pathWithQuery(
       paths.appointments.chooseSupervisor({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
       }),
-      {
-        form: '123',
-      },
+      query,
     )
 
     cy.visit(path)

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -455,6 +455,12 @@ context('Session details', () => {
         supervisors: this.supervisors,
       })
 
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', {
+        teams: { providers: teams },
+        providerCode: appointmentWithoutContactOutcome.providerCode,
+      })
+
       // Given I am on an appointment 'check appointment details' page
       const page = CheckAppointmentDetailsPage.visit(appointmentWithoutContactOutcome, this.project, this.provider)
       page.shouldContainProjectDetails()
@@ -490,6 +496,9 @@ context('Session details', () => {
       })
       cy.task('stubGetContactOutcomes', { contactOutcomes })
       cy.task('stubGetAppointmentForm', {})
+
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: appointmentInThePast.providerCode })
 
       // Given I am on an appointment 'check appointment details' page for an appointment in the past
       const page = CheckAppointmentDetailsPage.visit(appointmentInThePast, this.project, this.provider)

--- a/integration_tests/tests/appointments/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/appointments/chooseSupervisor.cy.ts
@@ -109,7 +109,7 @@ context('Choose supervisor', () => {
         supervisorSummaryFactory.build({ code: appointment.supervisorOfficerCode }),
       ]
 
-      const teams = providerTeamSummaryFactory.buildList(2)
+      const teams = [providerTeamSummaryFactory.build({ code: appointment.supervisingTeamCode })]
       cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: appointment.providerCode })
 
       cy.task('stubFindAppointment', { appointment })
@@ -123,13 +123,15 @@ context('Choose supervisor', () => {
         'stubGetAppointmentForm',
         appointmentOutcomeFormFactory.build({
           supervisor: supervisors[1],
+          team: providerTeamSummaryFactory.build({ code: appointment.supervisingTeamCode }),
         }),
       )
 
       // Given I am on an appointment 'check your details' page
-      const page = ChooseSupervisorPage.visit(appointment, appointment.supervisingTeamCode)
+      const page = ChooseSupervisorPage.visit(appointment)
 
       // Then I see a supervisor input with a saved value
+      page.teamInput.shouldHaveValue(appointment.supervisingTeamCode)
       page.supervisorInput.shouldHaveValue(appointment.supervisorOfficerCode)
     })
   })

--- a/integration_tests/tests/appointments/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/appointments/chooseSupervisor.cy.ts
@@ -5,7 +5,7 @@
 
 // Scenario: Supervisor for an appointment has no previously saved value
 //    Given I am on the 'choose supervisor' page
-//    Then I see a blank supervisor input
+//    Then I see a blank supervising team input
 
 // Scenario: Supervisor for an appointment has a previously saved value
 //    Given I am on an 'choose supervisor' page
@@ -26,6 +26,7 @@ import locationFactory from '../../../server/testutils/factories/locationFactory
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import appointmentOutcomeFormFactory from '../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import providerTeamSummaryFactory from '../../../server/testutils/factories/providerTeamSummaryFactory'
 
 context('Choose supervisor', () => {
   beforeEach(() => {
@@ -83,6 +84,9 @@ context('Choose supervisor', () => {
       const appointment = appointmentFactory.build({ attendanceData: undefined, projectCode: this.project.projectCode })
       const supervisors = supervisorSummaryFactory.buildList(2)
 
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: appointment.providerCode })
+
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubGetSupervisors', {
         providerCode: appointment.providerCode,
@@ -93,8 +97,8 @@ context('Choose supervisor', () => {
       // Given I am on an appointment 'check appointment details' page
       const page = ChooseSupervisorPage.visit(appointment)
 
-      // Then I see a blank supervisor input
-      page.supervisorInput.shouldNotHaveAValue()
+      // Then I see a blank supervising team input
+      page.teamInput.shouldNotHaveAValue()
     })
 
     // Scenario: Supervisor for an appointment has a previously saved value
@@ -104,6 +108,9 @@ context('Choose supervisor', () => {
         supervisorSummaryFactory.build(),
         supervisorSummaryFactory.build({ code: appointment.supervisorOfficerCode }),
       ]
+
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: appointment.providerCode })
 
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubGetSupervisors', {
@@ -120,7 +127,7 @@ context('Choose supervisor', () => {
       )
 
       // Given I am on an appointment 'check your details' page
-      const page = ChooseSupervisorPage.visit(appointment)
+      const page = ChooseSupervisorPage.visit(appointment, appointment.supervisingTeamCode)
 
       // Then I see a supervisor input with a saved value
       page.supervisorInput.shouldHaveValue(appointment.supervisorOfficerCode)
@@ -130,6 +137,9 @@ context('Choose supervisor', () => {
   describe('Continue', () => {
     //  Scenario: Validating the check appointment details page
     it('validates form data', function test() {
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.appointment.providerCode })
+
       // Given I am on an appointment 'check appointment details' page
       const page = ChooseSupervisorPage.visit(this.appointment)
 
@@ -140,8 +150,8 @@ context('Choose supervisor', () => {
       page.clickSubmit()
 
       // Then I see the same page with errors
-      page.shouldShowErrorSummary('supervisor', 'Select a supervisor')
-      page.supervisorInput.shouldHaveValue('')
+      page.shouldShowErrorSummary('team', 'Select a supervising team')
+      page.teamInput.shouldHaveValue('')
     })
   })
 })

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -319,12 +319,14 @@ context('Confirm appointment details page', () => {
       })
       cy.task('stubFindProject', { project })
 
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.appointment.providerCode })
+
       // And I click change
       page.clickChange('Supervising officer')
 
-      // Then I can see the appointment details page
-      const appointmentDetailsPage = Page.verifyOnPage(ChooseSupervisorPage, this.appointment)
-      appointmentDetailsPage.supervisorInput.shouldHaveValue(form.supervisor.code)
+      // Then I can see the choose supervisor page
+      Page.verifyOnPage(ChooseSupervisorPage, this.appointment, this.appointment.providerCode)
     })
 
     it('navigates back to the log attendance page', function test() {

--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -55,6 +55,7 @@ import projectFactory from '../../../server/testutils/factories/projectFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import ConfirmDetailsPage from '../../pages/appointments/confirmDetailsPage'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
+import providerTeamSummaryFactory from '../../../server/testutils/factories/providerTeamSummaryFactory'
 
 context('Attendance outcome', () => {
   beforeEach(() => {
@@ -205,6 +206,9 @@ context('Attendance outcome', () => {
     })
     cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
     cy.task('stubFindProject', { project })
+
+    const teams = providerTeamSummaryFactory.buildList(2)
+    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.appointment.providerCode })
 
     const provider = providerSummaryFactory.build({ code: this.appointment.providerCode })
     cy.task('stubGetProviders', { providers: { providers: [provider] } })

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,5 +1,11 @@
 import type { Response } from 'express'
-import { AttendanceDataDto, ContactOutcomeDto, SupervisorSummaryDto, ProjectTypeDto } from '../shared'
+import {
+  AttendanceDataDto,
+  ContactOutcomeDto,
+  SupervisorSummaryDto,
+  ProjectTypeDto,
+  ProviderTeamSummaryDto,
+} from '../shared'
 import ReferenceDataService from '../../services/referenceDataService'
 
 export type AppointmentUpdatePageViewData = {
@@ -28,6 +34,7 @@ export type AppointmentOutcomeForm = {
   endTime: string
   contactOutcome?: ContactOutcomeDto
   supervisor?: SupervisorSummaryDto
+  team?: ProviderTeamSummaryDto
   attendanceData?: AttendanceDataDto
   enforcement?: EnforcementOutcomeForm
   originalSearch: Record<string, string>

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -18,7 +18,9 @@ jest.mock('../../utils/errorUtils')
 describe('ChooseSupervisorController', () => {
   const userName = 'user'
   const appointmentId = '1'
-  const request: DeepMocked<Request> = createMock<Request>({ params: { appointmentId } })
+  const projectCode = '2'
+  const team = 'X123'
+  const request: DeepMocked<Request> = createMock<Request>({ params: { appointmentId, projectCode }, query: { team } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const chooseSupervisorPageMock: jest.Mock = ChooseSupervisorPage as unknown as jest.Mock<ChooseSupervisorPage>
   const generateErrorSummaryMock: jest.Mock = generateErrorSummary as jest.Mock
@@ -65,6 +67,9 @@ describe('ChooseSupervisorController', () => {
       const formId = '123'
       const viewData = {
         someProp: '',
+        team,
+        form: formId,
+        chooseSupervisorPath: `/appointments/${projectCode}/${appointmentId}/choose-supervisor`,
       }
 
       chooseSupervisorPageMock.mockImplementationOnce(() => ({

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -24,7 +24,11 @@ export default class ChooseSupervisorController {
 
       const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
 
-      const team = _req.query.team?.toString()
+      const page = new ChooseSupervisorPage(_req.query, appointment)
+
+      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+
+      const team = _req.query.team?.toString() || form?.team?.code
 
       const supervisors = team
         ? await this.providerService.getSupervisors({
@@ -33,10 +37,6 @@ export default class ChooseSupervisorController {
             username: res.locals.user.username,
           })
         : []
-
-      const page = new ChooseSupervisorPage(_req.query, appointment)
-
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
 
       res.render('appointments/update/chooseSupervisor', {
         ...page.viewData(appointment, teams, supervisors, form),
@@ -83,7 +83,7 @@ export default class ChooseSupervisorController {
         })
       }
 
-      const toSave = page.updateForm(form, supervisors)
+      const toSave = page.updateForm(form, teams, supervisors)
       await this.appointmentFormService.saveForm(page.formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -5,6 +5,7 @@ import ProviderService from '../../services/providerService'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentParams } from '../../@types/user-defined'
+import paths from '../../paths'
 
 export default class ChooseSupervisorController {
   constructor(
@@ -21,18 +22,27 @@ export default class ChooseSupervisorController {
         username: res.locals.user.username,
       })
 
-      const supervisors = await this.providerService.getSupervisors({
-        providerCode: appointment.providerCode,
-        teamCode: appointment.supervisingTeamCode,
-        username: res.locals.user.username,
-      })
+      const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
+
+      const team = _req.query.team?.toString()
+
+      const supervisors = team
+        ? await this.providerService.getSupervisors({
+            providerCode: appointment.providerCode,
+            teamCode: team,
+            username: res.locals.user.username,
+          })
+        : []
 
       const page = new ChooseSupervisorPage(_req.query, appointment)
 
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
 
       res.render('appointments/update/chooseSupervisor', {
-        ...page.viewData(appointment, supervisors, form),
+        ...page.viewData(appointment, teams, supervisors, form),
+        chooseSupervisorPath: paths.appointments.chooseSupervisor(appointmentParams),
+        form: page.formId,
+        team,
       })
     }
   }
@@ -46,11 +56,17 @@ export default class ChooseSupervisorController {
         username: res.locals.user.username,
       })
 
-      const supervisors = await this.providerService.getSupervisors({
-        providerCode: appointment.providerCode,
-        teamCode: appointment.supervisingTeamCode,
-        username: res.locals.user.username,
-      })
+      const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
+
+      const team = _req.body.team?.toString()
+
+      const supervisors = team
+        ? await this.providerService.getSupervisors({
+            providerCode: appointment.providerCode,
+            teamCode: team,
+            username: res.locals.user.username,
+          })
+        : []
 
       const page = new ChooseSupervisorPage(_req.body, appointment)
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
@@ -59,9 +75,11 @@ export default class ChooseSupervisorController {
 
       if (page.hasErrors) {
         return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointment, supervisors, form),
+          ...page.viewData(appointment, teams, supervisors, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
+          chooseSupervisorPath: paths.appointments.chooseSupervisor(appointmentParams),
+          form: page.formId,
         })
       }
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/shared'
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
@@ -9,6 +9,7 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import projectFactory from '../../testutils/factories/projectFactory'
 import ChooseSupervisorPage from './chooseSupervisorPage'
+import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 
 jest.mock('../../models/offender')
 
@@ -24,6 +25,7 @@ describe('ChooseSupervisorPage', () => {
     let appointment: AppointmentDto
     let supervisors: SupervisorSummaryDto[]
     let form: AppointmentOutcomeForm
+    let teams: ProviderTeamSummariesDto
     const updatePath = '/update'
 
     beforeEach(() => {
@@ -31,11 +33,12 @@ describe('ChooseSupervisorPage', () => {
       page = new ChooseSupervisorPage({}, appointment)
       supervisors = supervisorSummaryFactory.buildList(2)
       form = appointmentOutcomeFormFactory.build()
+      teams = { providers: providerTeamSummaryFactory.buildList(3) }
       jest.spyOn(paths.appointments, 'chooseSupervisor').mockReturnValue(updatePath)
     })
 
     it('should return an object containing an update link for the form', async () => {
-      const result = page.viewData(appointment, supervisors, form)
+      const result = page.viewData(appointment, teams, supervisors, form)
       expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
@@ -51,9 +54,11 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      const result = page.viewData(appointment, supervisors, form)
+      page = new ChooseSupervisorPage({ team: '1234' }, appointment)
 
-      expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
+      const result = page.viewData(appointment, teams, supervisors, form)
+
+      expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
         'fullName',
         'code',
@@ -73,9 +78,11 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      const result = page.viewData(appointmentFactory.build(), supervisors, form)
+      page = new ChooseSupervisorPage({ team: '1234' }, appointment)
 
-      expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
+      const result = page.viewData(appointmentFactory.build(), teams, supervisors, form)
+
+      expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
         'fullName',
         'code',
@@ -94,10 +101,10 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ supervisor }, appointmentFactory.build())
+      page = new ChooseSupervisorPage({ team: '1234', supervisor }, appointmentFactory.build())
       page.validate()
 
-      const result = page.viewData(appointment, supervisors, appointmentOutcomeFormFactory.build())
+      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build())
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
         supervisors,
@@ -112,8 +119,8 @@ describe('ChooseSupervisorPage', () => {
   })
 
   describe('validate', () => {
-    it('has no errors if supervisor has value', () => {
-      const query = { supervisor: 'Jane' }
+    it('has no errors if team has value and supervisor has value', () => {
+      const query = { team: 'X123', supervisor: 'Jane' }
       const page = new ChooseSupervisorPage(query, appointmentFactory.build())
       page.validate()
 
@@ -121,8 +128,17 @@ describe('ChooseSupervisorPage', () => {
       expect(page.validationErrors).toStrictEqual({})
     })
 
+    it.each(['', undefined])('has errors if team is empty', (team: string | undefined) => {
+      const query = { team, supervisor: 'Jane' }
+      const page = new ChooseSupervisorPage(query, appointmentFactory.build())
+      page.validate()
+
+      expect(page.hasErrors).toBe(true)
+      expect(page.validationErrors).toStrictEqual({ team: { text: 'Select a supervising team' } })
+    })
+
     it.each(['', undefined])('has errors if supervisor is empty', (supervisor: string | undefined) => {
-      const query = { supervisor }
+      const query = { team: 'X123', supervisor }
       const page = new ChooseSupervisorPage(query, appointmentFactory.build())
       page.validate()
 

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -39,10 +39,16 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     return Object.keys(this.validationErrors).length > 0
   }
 
-  protected getForm(data: AppointmentOutcomeForm, supervisors: SupervisorSummaryDto[]): AppointmentOutcomeForm {
+  protected getForm(
+    data: AppointmentOutcomeForm,
+    teams: ProviderTeamSummariesDto,
+    supervisors: SupervisorSummaryDto[],
+  ): AppointmentOutcomeForm {
+    const selectedTeam = teams.providers.find(team => team.code === this.query.team)
     const selectedSupervisor = supervisors.find(supervisor => supervisor.code === this.query.supervisor)
     return {
       ...data,
+      team: selectedTeam,
       supervisor: selectedSupervisor,
     }
   }
@@ -53,7 +59,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     supervisors: SupervisorSummaryDto[],
     form: AppointmentOutcomeForm,
   ): ViewData {
-    const teamCode = this.query.team
+    const teamCode = this.query.team || form.team?.code
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
@@ -11,15 +11,18 @@ import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 
 interface ViewData extends AppointmentUpdatePageViewData {
+  teamItems: GovUkSelectOption[]
   supervisorItems: GovUkSelectOption[]
 }
 
 interface Body {
   supervisor: string
+  team: string
 }
 
 interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
   supervisor?: string
+  team?: string
 }
 
 export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
@@ -44,16 +47,30 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  viewData(appointment: AppointmentDto, supervisors: SupervisorSummaryDto[], form: AppointmentOutcomeForm): ViewData {
+  viewData(
+    appointment: AppointmentDto,
+    teams: ProviderTeamSummariesDto,
+    supervisors: SupervisorSummaryDto[],
+    form: AppointmentOutcomeForm,
+  ): ViewData {
+    const teamCode = this.query.team
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
       ...this.commonViewData(appointment),
-      supervisorItems: GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code),
+      teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
+      supervisorItems: teamCode
+        ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)
+        : [],
     }
   }
 
   validate() {
+    if (!this.query.team) {
+      this.validationErrors.team = { text: 'Select a supervising team' }
+      return
+    }
+
     if (!this.query.supervisor) {
       this.validationErrors.supervisor = { text: 'Select a supervisor' }
     }

--- a/server/views/appointments/update/chooseSupervisor.njk
+++ b/server/views/appointments/update/chooseSupervisor.njk
@@ -5,20 +5,49 @@
 
 {% set pageTitle = 'Add supervisor details' %}
 
-{% block formContent %}
+{% block beforeForm %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {{ govukSelect({
-        label: {
-            text: "Supervising officer",
-            classes: "govuk-label--s"
-        },
-        id: "supervisor",
-        name: "supervisor",
-        items: supervisorItems,
-        errorMessage: errors.supervisor
-      }) }}
+      <form action="{{ chooseSupervisorPath }}" method="get" class="govuk-!-margin-bottom-5">
+        <input type="hidden" name="form" value="{{ form }}">
+        <div class="search-and-filter__row">
+          {{ govukSelect({
+            label: {
+                text: "Supervising team",
+                classes: "govuk-label--s"
+            },
+            id: "team",
+            name: "team",
+            items: teamItems,
+            errorMessage: errors.team
+          }) }}
+          {{ govukButton({
+            "text": "Select team",
+            preventDoubleClick: true,
+            classes: "govuk-button--secondary"
+          }) }}
+        </div>
+      </form>
     </div>
   </div>
+{% endblock %}
 
+{% block formContent %}
+  {% if supervisorItems | length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <input type="hidden" name="team" value="{{ team }}">
+        {{ govukSelect({
+          label: {
+              text: "Supervising officer",
+              classes: "govuk-label--s"
+          },
+          id: "supervisor",
+          name: "supervisor",
+          items: supervisorItems,
+          errorMessage: errors.supervisor
+        }) }}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-970)

Previously the supervising team - and accordingly the officers belonging to that team - was determined based on the appointment. This was not adequate for some users, so this screen has now been updated to allow a user to choose the supervising team and then to choose a supervising officer within that team from a second dropdown menu.

We opted for a non-JavaScript solution here, but this could be iterated on in future.

### Future improvements

1. ~This PR doesn't particularly handle moving back to this page: it won't pre-fill in the team dropdown for you; it would do this if the `team` param is set on the query string, which wouldn't be a huge amendment, but `team` would need to be stored somewhere for that to work properly.~ Now implemented!
2. A JavaScript solution, which we use in a few other places, where the second dropdown is populated dynamically, would be nice, and would save the user a click.

## Changes in this PR

### Screenshots of UI changes

<img width="1736" height="1455" alt="choose-supervisor-choose-team" src="https://github.com/user-attachments/assets/d04391f4-18da-43e0-964c-f01a779d397a" />

<img width="1736" height="1455" alt="choose-supervisor-choose-officer" src="https://github.com/user-attachments/assets/5045ce7f-3e3a-42ee-b3e0-96fc883ac809" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
