### PR TITLE
CPB-816: Add retry and idempotency for submitting course completion resolutions

### DIFF
--- a/server/data/courseCompletionClient.ts
+++ b/server/data/courseCompletionClient.ts
@@ -10,6 +10,7 @@ import {
 } from '../@types/shared'
 import { GetCourseCompletionRequest, GetCourseCompletionsRequest } from '../@types/user-defined'
 import { createQueryString } from '../utils/utils'
+import idempotencyKey from '../utils/restClientUtils'
 
 export default class CourseCompletionClient extends RestClient {
   constructor(authenticationClient: AuthenticationClient) {
@@ -31,6 +32,9 @@ export default class CourseCompletionClient extends RestClient {
 
   async save({ username, id }: GetCourseCompletionRequest, data: CourseCompletionResolutionDto): Promise<void> {
     const path = paths.courseCompletions.save({ id })
-    return this.post({ path, data }, asSystem(username))
+    return this.post(
+      { path, data, retry: true, headers: idempotencyKey('post-course-completion-resolution', id) },
+      asSystem(username),
+    )
   }
 }

--- a/server/data/offenderClient.ts
+++ b/server/data/offenderClient.ts
@@ -5,6 +5,7 @@ import logger from '../../logger'
 import paths from '../paths/api'
 import { CaseDetailsSummaryDto, CreateAdjustmentDto } from '../@types/shared'
 import { BaseRequest } from '../@types/user-defined'
+import idempotencyKey from '../utils/restClientUtils'
 
 export interface OffenderRequirementRequest extends BaseRequest {
   crn: string
@@ -27,7 +28,7 @@ export default class OffenderClient extends RestClient {
   ): Promise<void> {
     const path = paths.offender.adjustments({ crn, deliusEventNumber: deliusEventNumber.toString() })
     return this.post(
-      { path, data, retry: true, headers: { 'Idempotency-Key': `post-adjustment:${data.taskId}` } },
+      { path, data, retry: true, headers: idempotencyKey('post-adjustment', data.taskId) },
       asSystem(username),
     )
   }

--- a/server/utils/restClientUtils.test.ts
+++ b/server/utils/restClientUtils.test.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test'
+import { describe } from 'node:test'
+import idempotencyKey from './restClientUtils'
+
+describe('idempotencyKey', () => {
+  it('should return a record with the correct key and value', () => {
+    const testCases = [
+      { group: 'put-appointment', key: '12345', expectedHeaderValue: 'put-appointment:12345' },
+      { group: 'post-adjustment', key: '67890', expectedHeaderValue: 'post-adjustment:67890' },
+      {
+        group: 'post-course-completion-resolution',
+        key: '02468',
+        expectedHeaderValue: 'post-course-completion-resolution:02468',
+      },
+    ]
+
+    testCases.forEach(({ group, key, expectedHeaderValue }) => {
+      expect(idempotencyKey(group, key)).toEqual({ 'Idempotency-Key': expectedHeaderValue })
+    })
+  })
+})

--- a/server/utils/restClientUtils.ts
+++ b/server/utils/restClientUtils.ts
@@ -1,0 +1,3 @@
+export default function idempotencyKey(group: string, key: string): Record<string, string> {
+  return { 'Idempotency-Key': `${group}:${key}` }
+}


### PR DESCRIPTION
## Context

The API supports the use of the `Idempotency-Key` header to indicate that a request may occur multiple times.

Using this when submitting a course completion resolution allows retrying failed requests to be a safe operation, as the API will not process subsequent requests if it has already successfully processed a request with the same key and request body.

See [CPB-816](https://dsdmoj.atlassian.net/browse/CPB-816).

## Changes in this PR

- An `idempotencyKey` utility function has been introduced to build the header in a consistent way across multiple REST client functions. The `OffenderClient.saveAdjustment` method has been refactored to use this new utility.
- The `CourseCompletionClient.save` method now retries the request if it fails, and includes the `Idempotency-Key` header to indicate to the API which request is being tried/retried so that it can be handled correctly.

### Screenshots of UI changes

No visual changes have been introduced.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-816]: https://dsdmoj.atlassian.net/browse/CPB-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ