### PR TITLE
CPB-982: Show negative numbers for unpaid work details, as this can surface from Delius.

### DIFF
--- a/server/utils/dateTimeUtils.test.ts
+++ b/server/utils/dateTimeUtils.test.ts
@@ -198,6 +198,9 @@ describe('DateTimeFormats', () => {
       [90, '1 hour 30 minutes'],
       [240, '4 hours'],
       [61, '1 hour 1 minute'],
+      [-90, '-1 hour 30 minutes'],
+      [-61, '-1 hour 1 minute'],
+      [-1, '-1 minute'],
     ])('formats %d to %s', (minutes: number, expected: string) => {
       expect(DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(minutes)).toEqual(expected)
     })
@@ -210,16 +213,14 @@ describe('DateTimeFormats', () => {
       [61, { hours: 1, minutes: 1 }],
       [90, { hours: 1, minutes: 30 }],
       [640, { hours: 10, minutes: 40 }],
+      [-90, { hours: 1, minutes: 30 }],
     ])('formats %d to %o', (totalMinutes: number, expected: { hours: number; minutes: number }) => {
       expect(DateTimeFormats.totalMinutesToHoursAndMinutesNumberParts(totalMinutes)).toEqual(expected)
     })
 
-    it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])(
-      'throws for invalid totalMinutes %s',
-      (totalMinutes: number) => {
-        expect(() => DateTimeFormats.totalMinutesToHoursAndMinutesNumberParts(totalMinutes)).toThrow(RangeError)
-      },
-    )
+    it.each([Number.NaN, Number.POSITIVE_INFINITY])('throws for invalid totalMinutes %s', (totalMinutes: number) => {
+      expect(() => DateTimeFormats.totalMinutesToHoursAndMinutesNumberParts(totalMinutes)).toThrow(RangeError)
+    })
   })
 
   describe('totalMinutesToHoursAndMinutesParts', () => {
@@ -229,16 +230,14 @@ describe('DateTimeFormats', () => {
       [61, { hours: '1', minutes: '01' }],
       [90, { hours: '1', minutes: '30' }],
       [640, { hours: '10', minutes: '40' }],
+      [-90, { hours: '1', minutes: '30' }],
     ])('formats %d to %o', (totalMinutes: number, expected: { hours: string; minutes: string }) => {
       expect(DateTimeFormats.totalMinutesToHoursAndMinutesParts(totalMinutes)).toEqual(expected)
     })
 
-    it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])(
-      'throws for invalid totalMinutes %s',
-      (totalMinutes: number) => {
-        expect(() => DateTimeFormats.totalMinutesToHoursAndMinutesParts(totalMinutes)).toThrow(RangeError)
-      },
-    )
+    it.each([Number.NaN, Number.POSITIVE_INFINITY])('throws for invalid totalMinutes %s', (totalMinutes: number) => {
+      expect(() => DateTimeFormats.totalMinutesToHoursAndMinutesParts(totalMinutes)).toThrow(RangeError)
+    })
   })
 
   describe('hoursAndMinutesToMinutes', () => {

--- a/server/utils/dateTimeUtils.ts
+++ b/server/utils/dateTimeUtils.ts
@@ -171,9 +171,14 @@ export default class DateTimeFormats {
    * @returns A string in the format: '2 hours 10 minutes'
    */
   static totalMinutesToHumanReadableHoursAndMinutes(minutes: number): string {
-    const hoursAndMinutesObj = DateTimeFormats.totalMinutesToHoursAndMinutesNumberParts(minutes)
+    const isNegative = minutes < 0
+    const hoursAndMinutesObj = DateTimeFormats.totalMinutesToHoursAndMinutesNumberParts(Math.abs(minutes))
 
-    return DateTimeFormats.hoursAndMinutesToHumanReadable(hoursAndMinutesObj.hours, hoursAndMinutesObj.minutes)
+    const formatted = DateTimeFormats.hoursAndMinutesToHumanReadable(
+      hoursAndMinutesObj.hours,
+      hoursAndMinutesObj.minutes,
+    )
+    return isNegative ? `-${formatted}` : formatted
   }
 
   /**
@@ -181,12 +186,13 @@ export default class DateTimeFormats {
    * @param totalMinutes number of minutes (must be >= 0)
    */
   static totalMinutesToHoursAndMinutesNumberParts(totalMinutes: number): { hours: number; minutes: number } {
-    if (!Number.isFinite(totalMinutes) || totalMinutes < 0) {
+    if (!Number.isFinite(totalMinutes)) {
       throw new RangeError(`Invalid totalMinutes: ${totalMinutes}`)
     }
 
-    const hours = Math.floor(totalMinutes / 60)
-    const minutesRemaining = totalMinutes % 60
+    const absoluteTotalMinutes = Math.abs(totalMinutes)
+    const hours = Math.floor(absoluteTotalMinutes / 60)
+    const minutesRemaining = absoluteTotalMinutes % 60
 
     return {
       hours,


### PR DESCRIPTION
## Context

On Prod/Pre-production - the screen shot below occurs because the formatting for events/UPW details, throws an error for negative numbers. We need to display them, as this is whats in Delius.

<img width="1231" height="307" alt="Screenshot 2026-05-22 at 13 43 02" src="https://github.com/user-attachments/assets/4e57dee5-6780-4cf2-8f5d-ad369c9bbf1f" />

## Changes in this PR

Updated hoursAndMinutesToHumanReadable to handle negative numbers for display.