### PR TITLE
CPB-968 - Prevent additional clicks being sent to AppInsights

### DIFF
--- a/server/views/courseCompletions/process/layout.njk
+++ b/server/views/courseCompletions/process/layout.njk
@@ -81,7 +81,16 @@
             <a class="govuk-link" href="{{ unableToCreditTimePath }}">Unable to credit hours</a>
           </div>
           <script nonce="{{ cspNonce }}" type="text/javascript">
-            document.querySelector(".unable-to-credit-hours-button a").addEventListener("click", async (event) => {
+            const redirect = (event) => {
+              window.location.href = event.target.href;
+            }
+
+            let fired = false;
+            document.querySelector(".unable-to-credit-hours-button a").addEventListener("click", (event) => {
+              if (fired) return;
+
+              fired = true;
+
               event.preventDefault();
 
               if (typeof(appInsights) !== "undefined") {
@@ -92,10 +101,14 @@
                   page: window.location.pathname
                 });
 
-                await appInsights.flush(true);
-              }
+                appInsights.flush();
 
-              window.location.href = event.target.href;
+                setTimeout(() => {
+                  redirect(event);
+                }, 300);
+              } else {
+                redirect(event);
+              }
             });
           </script>
         {% endif %}


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-968)

We're seeing duplicate events being sent to AppInsights on Windows devices. This (speculatively) should make it harder for this to happen by setting `fired` after the initial click event and returning early on any further events. We also introduce a slight delay after calling flush().

If this doesn't work, the problem may be due to our configuration of AppInsights, and further investigation will be required.

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
