### PR TITLE
CPB-967 Validate adjustment date is not before sentence date

### DIFF
--- a/integration_tests/tests/appointments/adjustTravelTime.cy.ts
+++ b/integration_tests/tests/appointments/adjustTravelTime.cy.ts
@@ -55,7 +55,9 @@ import { ContactOutcomeDto, ProjectDto } from '../../../server/@types/shared'
 import { ProviderSummaryDto } from '../../../server/@types/shared/models/ProviderSummaryDto'
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
 import appointmentTaskSummaryFactory from '../../../server/testutils/factories/appointmentTaskSummaryFactory'
+import caseDetailsSummaryFactory from '../../../server/testutils/factories/caseDetailsSummaryFactory'
 import { contactOutcomeFactory } from '../../../server/testutils/factories/contactOutcomeFactory'
+import offenderFullFactory from '../../../server/testutils/factories/offenderFullFactory'
 import pagedMetadataFactory from '../../../server/testutils/factories/pagedMetadataFactory'
 import pagedModelAppointmentTaskSummaryFactory from '../../../server/testutils/factories/pagedModelAppointmentTaskSummaryFactory'
 import projectFactory from '../../../server/testutils/factories/projectFactory'
@@ -65,7 +67,8 @@ import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
 import Page from '../../pages/page'
 
 context('Update travel time page', () => {
-  const appointment = appointmentFactory.build()
+  const offender = offenderFullFactory.build()
+  const appointment = appointmentFactory.build({ offender })
   let providers: Array<ProviderSummaryDto>
   let provider: ProviderSummaryDto
   let contactOutcome: ContactOutcomeDto
@@ -75,6 +78,7 @@ context('Update travel time page', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.signIn()
+
     cy.task('stubFindAppointment', { appointment })
 
     providers = providerSummaryFactory.buildList(2)
@@ -85,6 +89,8 @@ context('Update travel time page', () => {
     cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes } })
     project = projectFactory.build({ projectCode: appointment.projectCode })
     cy.task('stubFindProject', { project })
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender: appointment.offender })
+    cy.task('stubGetOffenderSummary', { caseDetailsSummary })
   })
 
   // Scenario: viewing the 'Adjust travel time' page

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -18,6 +18,8 @@ import pagedModelAppointmentTaskSummaryFactory from '../../testutils/factories/p
 import pagedMetadataFactory from '../../testutils/factories/pagedMetadataFactory'
 import { getPaginationRequestParams } from '../../utils/paginationUtils'
 import AuditService from '../../services/auditService'
+import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
+import unpaidWorkDetailsFactory from '../../testutils/factories/unpaidWorkDetailsFactory'
 
 jest.mock('../../utils/paginationUtils')
 jest.mock('../../pages/appointments/searchTravelTimePage')
@@ -316,7 +318,14 @@ describe('AdjustTravelTimeController', () => {
       it('rerenders page if validation errors', async () => {
         const errorSummary = [{ text: 'Error 1', href: '#1', attributes: { 'some-attr': 'value' } }]
         const errors = { hours: { text: 'Error' } }
+
+        const appointment = appointmentFactory.build()
+        appointmentService.getAppointment.mockResolvedValue(appointment)
         page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+
+        const upwDetails = unpaidWorkDetailsFactory.build({ eventNumber: appointment.deliusEventNumber })
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [upwDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
 
         const body = { hours: 't', minutes: 'r' }
         const request = createMock<Request>({ params, body })
@@ -331,7 +340,7 @@ describe('AdjustTravelTimeController', () => {
           time: body,
         })
 
-        expect(page.validationErrors).toHaveBeenCalledWith(body)
+        expect(page.validationErrors).toHaveBeenCalledWith(body, upwDetails)
       })
     })
   })

--- a/server/controllers/appointments/adjustTravelTimeController.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.ts
@@ -12,6 +12,7 @@ import ProjectService from '../../services/projectService'
 import { getPaginationRequestParams } from '../../utils/paginationUtils'
 import { TravelTimeSortField } from '../../@types/user-defined'
 import AuditService, { Page } from '../../services/auditService'
+import { AppointmentDto } from '../../@types/shared'
 
 export const travelTimeSortFields = ['appointment.crn', 'appointment.date'] as const
 
@@ -58,6 +59,8 @@ export default class AdjustTravelTimeController {
 
       const project = await this.projectService.getProject({ projectCode, username: res.locals.user.username })
 
+      const upwDetails = await this.getUnpaidWorkDetails(res, appointment)
+
       const viewData = this.page.viewData({
         appointment,
         taskId,
@@ -65,6 +68,7 @@ export default class AdjustTravelTimeController {
         project,
         originalSearch: req.query as SearchTravelTimePageInput,
         req,
+        upwDetails,
       })
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
@@ -83,7 +87,9 @@ export default class AdjustTravelTimeController {
         username: res.locals.user.username,
       })
 
-      const { hasErrors, errorSummary, errors } = this.page.validationErrors(req.body)
+      const upwDetails = await this.getUnpaidWorkDetails(res, appointment)
+
+      const { hasErrors, errorSummary, errors } = this.page.validationErrors(req.body, upwDetails)
 
       if (hasErrors) {
         const { hours, minutes } = req.body
@@ -108,6 +114,7 @@ export default class AdjustTravelTimeController {
             project,
             originalSearch: req.query as SearchTravelTimePageInput,
             req,
+            upwDetails,
           }),
           errorSummary,
           errors,
@@ -251,5 +258,14 @@ export default class AdjustTravelTimeController {
     }
     const providerItems = GovUkSelectInput.getOptions(providers, 'name', 'code', 'Choose region', providerCode)
     return { providerItems }
+  }
+
+  private async getUnpaidWorkDetails(res: Response, appointment: AppointmentDto) {
+    const { unpaidWorkDetails } = await this.offenderService.getOffenderSummary({
+      username: res.locals.user.username,
+      crn: appointment.offender.crn,
+    })
+
+    return unpaidWorkDetails.find(upwDetail => upwDetail.eventNumber === appointment.deliusEventNumber)
   }
 }

--- a/server/forms/GovUkFrontendDateInput.test.ts
+++ b/server/forms/GovUkFrontendDateInput.test.ts
@@ -281,4 +281,48 @@ describe('GovUkFrontendDateInput', () => {
       expect(result).toBe(false)
     })
   })
+
+  describe('dateIsOnOrAfterDate', () => {
+    it('returns true if dates are the same', () => {
+      const date = {
+        'date-day': '15',
+        'date-month': '01',
+        'date-year': '2020',
+      }
+
+      const dateToCompare = '2020-01-15'
+
+      const result = GovukFrontendDateInput.dateIsOnOrAfterDate(date, 'date', dateToCompare)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true if date is after date to compare', () => {
+      const date = {
+        'date-day': '16',
+        'date-month': '01',
+        'date-year': '2020',
+      }
+
+      const dateToCompare = '2020-01-15'
+
+      const result = GovukFrontendDateInput.dateIsOnOrAfterDate(date, 'date', dateToCompare)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false if date is before date to compare', () => {
+      const date = {
+        'date-day': '14',
+        'date-month': '01',
+        'date-year': '2020',
+      }
+
+      const dateToCompare = '2020-01-15'
+
+      const result = GovukFrontendDateInput.dateIsOnOrAfterDate(date, 'date', dateToCompare)
+
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/server/forms/GovukFrontendDateInput.ts
+++ b/server/forms/GovukFrontendDateInput.ts
@@ -1,3 +1,4 @@
+import { isAfter, isSameDay } from 'date-fns'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import { ObjectWithDateParts, StructuredDate } from '../@types/user-defined'
 import InvalidDateStringError from '../errors/invalidDateStringError'
@@ -78,6 +79,14 @@ export default class GovukFrontendDateInput {
   static dateIsInTheFuture<K extends string>(dateInputObj: ObjectWithDateParts<K>, key: K) {
     const date = DateTimeFormats.dateAndTimeInputsToIsoString(dateInputObj, key)[key]
     return DateTimeFormats.dateIsInFuture(date)
+  }
+
+  static dateIsOnOrAfterDate<K extends string>(dateInputObj: ObjectWithDateParts<K>, key: K, dateToCompare: string) {
+    const isoDateString = DateTimeFormats.dateAndTimeInputsToIsoString(dateInputObj, key)[key]
+    const dateObj = DateTimeFormats.isoToDateObj(isoDateString)
+    const dateObjToCompare = DateTimeFormats.isoToDateObj(dateToCompare)
+
+    return isSameDay(dateObj, dateObjToCompare) || isAfter(dateObj, dateObjToCompare)
   }
 
   static getStructuredDate<K extends string>(

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -9,28 +9,41 @@ import projectFactory from '../../testutils/factories/projectFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import { pathWithQuery } from '../../utils/utils'
 import UpdateTravelTimePage from './updateTravelTimePage'
+import unpaidWorkDetailsFactory from '../../testutils/factories/unpaidWorkDetailsFactory'
+import { UnpaidWorkDetailsDto } from '../../@types/shared'
 
 jest.mock('../../models/offender')
 
 describe('UpdateTravelTimePage', () => {
   let page: UpdateTravelTimePage
   let req = createMock<Request>()
+  let upwDetails: UnpaidWorkDetailsDto
 
   beforeEach(() => {
     jest.resetAllMocks()
     page = new UpdateTravelTimePage()
-    req = createMock<Request>()
+    req = createMock<Request>({
+      body: {
+        'date-day': '01',
+        'date-month': '05',
+        'date-year': '2026',
+      },
+    })
+    upwDetails = unpaidWorkDetailsFactory.build({ sentenceDate: '2026-04-01' })
   })
 
   describe('validationErrors', () => {
     it('returns no errors if valid body', () => {
-      const result = page.validationErrors({
-        hours: '2',
-        minutes: '20',
-        'date-day': '01',
-        'date-month': '05',
-        'date-year': '2026',
-      })
+      const result = page.validationErrors(
+        {
+          hours: '2',
+          minutes: '20',
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '2026',
+        },
+        upwDetails,
+      )
       expect(result.errors).toEqual({})
       expect(result.hasErrors).toBe(false)
     })
@@ -39,7 +52,7 @@ describe('UpdateTravelTimePage', () => {
       it('should not return error for hours or minutes if no validation errors', () => {
         const body = { hours: '2' }
         jest.spyOn(HoursAndMinutesInput, 'validationErrors').mockReturnValue({})
-        const result = page.validationErrors(body).errors
+        const result = page.validationErrors(body, upwDetails).errors
         expect(result.hours).toBeUndefined()
         expect(result.minutes).toBeUndefined()
       })
@@ -52,7 +65,7 @@ describe('UpdateTravelTimePage', () => {
           .spyOn(HoursAndMinutesInput, 'validationErrors')
           .mockReturnValue({ hours: hoursError, minutes: minutesError })
 
-        const result = page.validationErrors(body)
+        const result = page.validationErrors(body, upwDetails)
         expect(result.errors.minutes).toEqual(minutesError)
         expect(result.errors.hours).toEqual(hoursError)
         expect(result.hasErrors).toBe(true)
@@ -67,7 +80,7 @@ describe('UpdateTravelTimePage', () => {
           'date-month': '05',
           'date-year': '2026',
         }
-        const result = page.validationErrors(body).errors
+        const result = page.validationErrors(body, upwDetails).errors
         expect(result['date-day']).toBeUndefined()
         expect(result['date-month']).toBeUndefined()
         expect(result['date-year']).toBeUndefined()
@@ -80,7 +93,7 @@ describe('UpdateTravelTimePage', () => {
           'date-month': '05',
           'date-year': '',
         }
-        const result = page.validationErrors(body).errors
+        const result = page.validationErrors(body, upwDetails).errors
         expect(result['date-day']).toEqual(error)
       })
 
@@ -91,7 +104,7 @@ describe('UpdateTravelTimePage', () => {
           'date-month': '05',
           'date-year': '1111111',
         }
-        const result = page.validationErrors(body).errors
+        const result = page.validationErrors(body, upwDetails).errors
         expect(result['date-day']).toEqual(error)
       })
 
@@ -102,7 +115,19 @@ describe('UpdateTravelTimePage', () => {
           'date-month': '05',
           'date-year': '9999',
         }
-        const result = page.validationErrors(body).errors
+        const result = page.validationErrors(body, upwDetails).errors
+        expect(result['date-day']).toEqual(error)
+      })
+
+      it('should return an error for date if date is earlier than sentence date', () => {
+        const error = { text: 'Adjustment date must not be earlier than the sentence date' }
+        const body = {
+          'date-day': '01',
+          'date-month': '04',
+          'date-year': '2026',
+        }
+        upwDetails = unpaidWorkDetailsFactory.build({ sentenceDate: '2026-05-01' })
+        const result = page.validationErrors(body, upwDetails).errors
         expect(result['date-day']).toEqual(error)
       })
     })
@@ -168,6 +193,7 @@ describe('UpdateTravelTimePage', () => {
         project,
         originalSearch: {},
         req,
+        upwDetails,
       })
 
       expect(result).toEqual({
@@ -213,6 +239,7 @@ describe('UpdateTravelTimePage', () => {
         project,
         originalSearch: {},
         req,
+        upwDetails,
       })
 
       expect(result.appointment.contactOutcome).toBe(contactOutcomeName)
@@ -231,6 +258,7 @@ describe('UpdateTravelTimePage', () => {
         project,
         originalSearch,
         req,
+        upwDetails,
       })
 
       expect(result.backLink).toBe(pathWithQuery(paths.appointments.travelTime.filter({}), originalSearch))
@@ -249,6 +277,7 @@ describe('UpdateTravelTimePage', () => {
         project,
         originalSearch,
         req,
+        upwDetails,
       })
 
       expect(result.completeTaskPath).toBe(
@@ -265,14 +294,6 @@ describe('UpdateTravelTimePage', () => {
 
     describe('dateItems', () => {
       it('returns date items', () => {
-        req = createMock<Request>({
-          body: {
-            'date-day': '01',
-            'date-month': '05',
-            'date-year': '2026',
-          },
-        })
-
         const appointment = appointmentFactory.build()
         const originalSearch = { provider: 'provider' }
 
@@ -285,6 +306,7 @@ describe('UpdateTravelTimePage', () => {
           project,
           originalSearch,
           req,
+          upwDetails,
         })
 
         expect(result.dateItems).toEqual([
@@ -327,6 +349,7 @@ describe('UpdateTravelTimePage', () => {
           project,
           originalSearch,
           req,
+          upwDetails,
         })
 
         expect(result.dateItems).toEqual([

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -1,5 +1,11 @@
 import type { Request } from 'express'
-import { AppointmentDto, ContactOutcomeDto, CreateAdjustmentDto, ProjectDto } from '../../@types/shared'
+import {
+  AppointmentDto,
+  ContactOutcomeDto,
+  CreateAdjustmentDto,
+  ProjectDto,
+  UnpaidWorkDetailsDto,
+} from '../../@types/shared'
 import { ValidationErrors } from '../../@types/user-defined'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../forms/hoursAndMinutesInput'
 import Offender from '../../models/offender'
@@ -40,10 +46,13 @@ type DateBody = {
 type ObjectWithDateTimeAndMinutes = DateBody & ObjectWithHoursAndMinutes
 
 export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithDateTimeAndMinutes> {
-  protected getValidationErrors(query: ObjectWithDateTimeAndMinutes): ValidationErrors<ObjectWithHoursAndMinutes> {
+  protected getValidationErrors(
+    query: ObjectWithDateTimeAndMinutes,
+    additionalParams: UnpaidWorkDetailsDto,
+  ): ValidationErrors<ObjectWithHoursAndMinutes> {
     return {
       ...HoursAndMinutesInput.validationErrors(query, 'travel time'),
-      ...this.getDateErrors(query),
+      ...this.getDateErrors(query, additionalParams),
     }
   }
 
@@ -54,6 +63,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithD
     project,
     originalSearch,
     req,
+    upwDetails,
   }: {
     appointment: AppointmentDto
     taskId: string
@@ -61,6 +71,7 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithD
     project: ProjectDto
     originalSearch: SearchTravelTimePageInput
     req: Request
+    upwDetails: UnpaidWorkDetailsDto
   }): PageViewData {
     return {
       offender: new Offender(appointment.offender),
@@ -80,21 +91,22 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithD
         name: project.projectName,
         type: project.projectType.name,
       },
-      dateItems: this.getDateItems(req),
+      dateItems: this.getDateItems(req, upwDetails),
     }
   }
 
-  getDateItems(req: Request): Array<GovUkFrontendDateInputItem> {
+  getDateItems(req: Request, upwDetails: UnpaidWorkDetailsDto): Array<GovUkFrontendDateInputItem> {
     const date = {
       day: req.body?.['date-day'] ?? '',
       month: req.body?.['date-month'] ?? '',
       year: req.body?.['date-year'] ?? '',
     }
-    const hasDateError = (this.getDateErrors(req.body) as ValidationErrors<DateBody>)['date-day'] !== undefined
+    const hasDateError =
+      (this.getDateErrors(req.body, upwDetails) as ValidationErrors<DateBody>)['date-day'] !== undefined
     return GovukFrontendDateInput.getDateItemsFromStructuredDate(date, hasDateError)
   }
 
-  getDateErrors(body: DateBody) {
+  getDateErrors(body: DateBody, upwDetails: UnpaidWorkDetailsDto) {
     if (!body) {
       return {}
     }
@@ -109,6 +121,10 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithD
 
     if (GovukFrontendDateInput.dateIsInTheFuture(body, 'date')) {
       return { 'date-day': { text: 'Adjustment date must not be in the future' } }
+    }
+
+    if (upwDetails && !GovukFrontendDateInput.dateIsOnOrAfterDate(body, 'date', upwDetails.sentenceDate)) {
+      return { 'date-day': { text: 'Adjustment date must not be earlier than the sentence date' } }
     }
 
     return {}

--- a/server/pages/pageWithValidation.ts
+++ b/server/pages/pageWithValidation.ts
@@ -1,14 +1,14 @@
 import { ValidationErrors } from '../@types/user-defined'
 import { ErrorViewData, generateErrorSummary } from '../utils/errorUtils'
 
-export default abstract class PageWithValidation<TBody> {
-  validationErrors(query: TBody): ErrorViewData<TBody> {
-    const errors = this.getValidationErrors(query)
+export default abstract class PageWithValidation<TBody, TContext = unknown> {
+  validationErrors(query: TBody, additionalParams?: TContext): ErrorViewData<TBody> {
+    const errors = this.getValidationErrors(query, additionalParams)
 
     const errorSummary = generateErrorSummary(errors)
 
     return { errors, hasErrors: Object.keys(errors).length > 0, errorSummary }
   }
 
-  protected abstract getValidationErrors(query: TBody): ValidationErrors<TBody>
+  protected abstract getValidationErrors(query: TBody, additionalParams?: TContext): ValidationErrors<TBody>
 }


### PR DESCRIPTION
## Context
We previously implemented the ability to change the date of a travel time adjustment. This left out validation present in Delius which prevents using a date before the sentence date of the work requirement. This PR implements that validation.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Introduce `dateIsOnOrAfterDate` method for our govuk date input class
* Add additional params to our page validation abstract class
* Validate date is not before sentence date

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1259" height="1222" alt="Screenshot 2026-05-26 at 14 48 50" src="https://github.com/user-attachments/assets/e8e82f65-ca3a-4b0e-a324-13b5b0fc15ae" />

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
