### PR TITLE
Use 2 workers when running e2e tests on CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig<TestOptions>({
   forbidOnly: !!process.env.CI,
   retries: 1,
   maxFailures: 2,
-  workers: 1,
+  workers: process.env.CI ? 2 : undefined,
   reporter: [['html', { outputFolder: './e2e-tests/playwright-report/index.html' }]],
   timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,
   use: {


### PR DESCRIPTION
## Context
Use 2 workers when running e2e tests on CI. When running locally, let playwright auto detect how many workers should be used based on CPU.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
Local run using 2 workers
<img width="571" height="81" alt="image" src="https://github.com/user-attachments/assets/875db324-ed8d-4c04-913e-26a6ba98e5a2" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
