### PR TITLE
Fix time travel e2e tests to sort travel time tasks by date and ensure the test does not go through all pages of the result.

### DIFF
--- a/e2e-tests/pages/components/dataTableComponent.ts
+++ b/e2e-tests/pages/components/dataTableComponent.ts
@@ -50,4 +50,45 @@ class DataTableAssertions {
 
     return expect(rowLocator).not.toBeVisible()
   }
+
+  async notToHaveTodaysRowWithContent(content: string): Promise<void> {
+    const today = new Date().toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+
+    const rows = await this.component.itemsLocator.all()
+
+    for (const row of rows) {
+      // eslint-disable-next-line no-await-in-loop
+      const rowText = await row.innerText()
+
+      if (rowText.includes(today) && rowText.includes(content)) {
+        throw new Error(`Expected not to find row containing "${content}" for today's date "${today}"`)
+      }
+
+      if (this.rowContainsDateNotToday(rowText)) {
+        return
+      }
+    }
+
+    if (await this.component.nextPageButtonLocator.isVisible()) {
+      await this.component.nextPageButtonLocator.click()
+      await this.notToHaveTodaysRowWithContent(content)
+    }
+  }
+
+  private rowContainsDateNotToday(rowText: string): boolean {
+    const dateMatch = rowText.match(/\b\d{1,2} [A-Z][a-z]+ \d{4}\b/)
+
+    if (!dateMatch) {
+      return false
+    }
+
+    const rowDate = new Date(dateMatch[0])
+    const today = new Date()
+
+    return rowDate.toDateString() !== today.toDateString()
+  }
 }

--- a/e2e-tests/pages/travelTime/searchTravelTimePage.ts
+++ b/e2e-tests/pages/travelTime/searchTravelTimePage.ts
@@ -1,6 +1,6 @@
 /* eslint max-classes-per-file: "off" -- splitting out these classes would cause an import dependency loop */
 
-import { Page, expect } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import BasePage from '../basePage'
 import DataTableComponent from '../components/dataTableComponent'
 import PduFilterComponent from '../components/pduFilterComponent'
@@ -13,11 +13,14 @@ export default class SearchTravelTimePage extends BasePage {
 
   readonly pduFilter: PduFilterComponent
 
+  private readonly page: Page
+
   constructor(page: Page) {
     super(page)
     this.pduFilter = new PduFilterComponent(page)
     this.expect = new SearchTravelTimePageAssertions(this)
     this.results = new DataTableComponent(page)
+    this.page = page
   }
 
   async clickUpdateAnAppointment(crn: string) {
@@ -27,6 +30,15 @@ export default class SearchTravelTimePage extends BasePage {
 
   async completeSearchForm(team: Team) {
     await this.pduFilter.selectRegion(team.provider)
+  }
+
+  async clickSortByDate() {
+    await this.page.locator('a.moj-sortable-table__button').filter({ hasText: 'Date' }).click()
+  }
+
+  async clickSortByDateAscending() {
+    await this.clickSortByDate()
+    await this.clickSortByDate()
   }
 
   async submitForm() {

--- a/e2e-tests/steps/searchForTravelTime.ts
+++ b/e2e-tests/steps/searchForTravelTime.ts
@@ -13,6 +13,7 @@ export default async (page: Page, homePage: HomePage, team: Team, personOnProbat
 
   await searchTravelTimePage.completeSearchForm(team)
   await searchTravelTimePage.submitForm()
+  await searchTravelTimePage.clickSortByDateAscending()
 
   await searchTravelTimePage.clickUpdateAnAppointment(personOnProbation.crn)
 

--- a/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
@@ -61,8 +61,12 @@ test(
     const searchTravelTimePage = await creditTravelTime(page, travelTimePage, timeCredited)
 
     await searchTravelTimePage.expect.toBeOnThePage()
+
+    await searchTravelTimePage.clickSortByDateAscending()
+
     await searchTravelTimePage.expect.toSeeResults()
-    await searchTravelTimePage.results.expect.notToHaveRowWithContent(personOnProbation.crn)
+
+    await searchTravelTimePage.results.expect.notToHaveTodaysRowWithContent(personOnProbation.crn)
 
     await deliusLogin(page)
     await verifyAdjustment(page, {


### PR DESCRIPTION
## Context

We have alot of travel time tasks in dev, which causes alot of the pages for the results. Before the tests goes through all the pages, it times out. We need to sort by date, this will stop the need of going through the pages.

## Changes in this PR

- Click on the date field twice, so the results are in ascending order. The PoP's travel time task should be on the first page.
- On asserting the row is no longer there (once the task has been completed), it will go through all the rows with todays date, and will end when the row's date changes. This is once the results are sorted in ascending order by date.
