### PR TITLE
CPB-988 Display status on course completion table

### DIFF
--- a/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -1,5 +1,6 @@
 import { CommunityCampusPduDto, EteCourseCompletionEventDto, ProviderSummaryDto } from '../../../server/@types/shared'
 import paths from '../../../server/paths'
+import CourseCompletionUtils from '../../../server/utils/courseCompletionUtils'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import SelectInput from '../components/selectComponent'
 import Page from '../page'
@@ -51,11 +52,13 @@ export default class SearchCourseCompletionsPage extends Page {
 
   shouldShowSearchResults(courseCompletion: EteCourseCompletionEventDto) {
     cy.get('td').eq(0).should('have.text', `${courseCompletion.firstName} ${courseCompletion.lastName}`)
-    cy.get('td').eq(1).should('have.text', courseCompletion.id)
-    cy.get('td').eq(2).should('have.text', courseCompletion.courseName)
+    cy.get('td').eq(1).should('have.text', courseCompletion.courseName)
+    cy.get('td')
+      .eq(2)
+      .should('have.text', DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime, { format: 'medium' }))
     cy.get('td')
       .eq(3)
-      .should('have.text', DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime, { format: 'medium' }))
+      .should('have.text', CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status))
     cy.get('td')
       .eq(4)
       .contains('Process')

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -206,7 +206,7 @@ export type TableCell = (TextItem | HtmlItem) & {
 
 export type AriaSortDirection = 'none' | 'ascending' | 'descending'
 
-export type CourseCompletionSortField = 'firstName' | 'lastName' | 'courseName' | 'completionDateTime'
+export type CourseCompletionSortField = 'firstName' | 'lastName' | 'courseName' | 'completionDateTime' | 'status'
 
 export type TravelTimeSortField = 'appointment.crn' | 'appointment.date'
 

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -11,7 +11,7 @@ import { pathWithQuery } from '../../utils/utils'
 import CourseCompletionFormService from '../../services/forms/courseCompletionFormService'
 import AuditService, { Page } from '../../services/auditService'
 
-const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime'] as const
+const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime', 'status'] as const
 
 export default class CourseCompletionsController {
   constructor(

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -38,9 +38,8 @@ describe('CourseCompletionIndexPage', () => {
           '/test',
           'search-results',
         ),
-        { text: 'ID' },
         sortHeader<CourseCompletionSortField>(
-          'Course',
+          'Course name',
           'courseName',
           ['firstName', 'lastName'],
           'asc',
@@ -51,6 +50,14 @@ describe('CourseCompletionIndexPage', () => {
           'Date completed',
           'completionDateTime',
           'lastName',
+          'asc',
+          '/test',
+          'search-results',
+        ),
+        sortHeader<CourseCompletionSortField>(
+          'Course status',
+          'status',
+          ['firstName', 'lastName'],
           'asc',
           '/test',
           'search-results',
@@ -66,11 +73,13 @@ describe('CourseCompletionIndexPage', () => {
     const fakeFormattedDate = '20 January 2026'
     const fakeLink = '<a>link</a>'
     const mockHiddenText = '<span></span>'
+    const mockStatus = '<strong>Fail</strong>'
 
     beforeEach(() => {
       jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(fakeFormattedDate)
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
+      jest.spyOn(HtmlUtils, 'getStatusTag').mockReturnValue(mockStatus)
       jest.spyOn(paths.courseCompletions, 'show')
     })
 
@@ -93,9 +102,9 @@ describe('CourseCompletionIndexPage', () => {
       expect(result).toEqual([
         [
           { text: `${courseCompletion.firstName} ${courseCompletion.lastName}` },
-          { text: courseCompletion.id },
           { text: courseCompletion.courseName },
           { text: fakeFormattedDate },
+          { html: mockStatus },
           { html: fakeLink },
         ],
       ])

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -1,6 +1,7 @@
 import { EteCourseCompletionEventDto } from '../@types/shared'
 import { CourseCompletionSortField, SortDirection, TableCell, ValidationErrors } from '../@types/user-defined'
 import paths from '../paths'
+import CourseCompletionUtils from '../utils/courseCompletionUtils'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import HtmlUtils from '../utils/htmlUtils'
 import sortHeader from '../utils/sortHeader'
@@ -42,11 +43,8 @@ export default class CourseCompletionIndexPage {
         hrefPrefix,
         'search-results',
       ),
-      {
-        text: 'ID',
-      },
       sortHeader<CourseCompletionSortField>(
-        'Course',
+        'Course name',
         'courseName',
         sortBy,
         sortDirection,
@@ -56,6 +54,14 @@ export default class CourseCompletionIndexPage {
       sortHeader<CourseCompletionSortField>(
         'Date completed',
         'completionDateTime',
+        sortBy,
+        sortDirection,
+        hrefPrefix,
+        'search-results',
+      ),
+      sortHeader<CourseCompletionSortField>(
+        'Course status',
+        'status',
         sortBy,
         sortDirection,
         hrefPrefix,
@@ -79,9 +85,14 @@ export default class CourseCompletionIndexPage {
 
       return [
         { text: `${courseCompletion.firstName} ${courseCompletion.lastName}` },
-        { text: courseCompletion.id },
         { text: courseCompletion.courseName },
         { text: DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime) },
+        {
+          html: HtmlUtils.getStatusTag(
+            CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status),
+            courseCompletion.status === 'Passed' ? 'green' : 'red',
+          ),
+        },
         { html: linkHtml },
       ]
     })

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -87,4 +87,13 @@ describe('CourseCompletionUtils', () => {
       })
     })
   })
+  describe('formattedCourseCompletionLabel', () => {
+    it('formats the course completion label appropriately', () => {
+      const failedCourseCompletion = courseCompletionFactory.build({ status: 'Failed' })
+      expect(CourseCompletionUtils.formattedCourseCompletionLabel(failedCourseCompletion.status)).toEqual('Fail')
+
+      const passedCourseCompletion = courseCompletionFactory.build({ status: 'Passed' })
+      expect(CourseCompletionUtils.formattedCourseCompletionLabel(passedCourseCompletion.status)).toEqual('Pass')
+    })
+  })
 })

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -68,4 +68,8 @@ export default class CourseCompletionUtils {
       isLimited: offenderData.isLimited,
     }
   }
+
+  static formattedCourseCompletionLabel(label: string): string {
+    return label === 'Passed' ? 'Pass' : 'Fail'
+  }
 }


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-988)

Here we add the pass/fail status tag to the course completion table, as a sortable header. (We're also removing the database ID column.)

## Changes in this PR

### Screenshots of UI changes

<img width="1547" height="1321" alt="course-completion-status-in-table" src="https://github.com/user-attachments/assets/e89ed00e-7f84-458d-b1e3-dc0c441231cc" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
