### PR TITLE
CPB-991: Use recommended CRN in course completion form

### DIFF
--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -80,6 +80,7 @@ export default base.extend<TestOptions>({
     },
     { scope: 'test' },
   ],
+  e2eProjects: ['ETE Automated Test Bucket', 'Community Campus Test'],
 })
 
 function getPlacementType(testInfo: TestInfo): TestOptions['placementType'] {

--- a/e2e-tests/fixtures/testOptions.ts
+++ b/e2e-tests/fixtures/testOptions.ts
@@ -20,6 +20,7 @@ export interface TestOptions {
   project: Project
   placementType: PlacementType
   appointment: { date: Date }
+  e2eProjects: Array<string>
 }
 
 export type PlacementType = 'group' | 'individual' | 'ete'

--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -6,7 +6,6 @@ import { CourseCompletionPage } from '../../../server/pages/courseCompletions/pr
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 import DateInputComponent from '../components/dateInputComponent'
 import { Team } from '../../fixtures/testOptions'
-import Project from '../../delius/project'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 
 export default class CourseCompletionFormPage extends BasePage {
@@ -79,10 +78,10 @@ export default class CourseCompletionFormPage extends BasePage {
       .check()
   }
 
-  async selectProject(team: Team, project: Project) {
+  async selectProject(team: Team, projectName: string) {
     await this.teamFieldLocator.selectOption({ label: team.name })
     await this.applyTeamButtonLocator.click()
-    await this.projectFieldLocator.selectOption({ label: project.name })
+    await this.projectFieldLocator.selectOption({ label: projectName })
   }
 
   async completeOutcomeForm(

--- a/e2e-tests/steps/searchCourseCompletions.ts
+++ b/e2e-tests/steps/searchCourseCompletions.ts
@@ -1,15 +1,13 @@
 import { Page } from '@playwright/test'
-import HomePage from '../pages/homePage'
 import SearchCourseCompletionsPage from '../pages/courseCompletions/searchCourseCompletionsPage'
 import { Team } from '../fixtures/testOptions'
 
-export default async (page: Page, homePage: HomePage, team: Team) => {
+export default async (page: Page, team: Team) => {
   const searchCourseCompletionsPage = new SearchCourseCompletionsPage(
     page,
     'Process Community Campus course completions',
   )
 
-  await homePage.courseCompletionsLink.click()
   await searchCourseCompletionsPage.expect.toBeOnThePage()
 
   await searchCourseCompletionsPage.completeSearchForm(team)

--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -16,10 +16,12 @@ export default async (
   team: Team,
   personOnProbation?: PersonOnProbation,
 ) => {
+  const firstName = personOnProbation?.firstName ?? faker.person.firstName()
+  const lastName = personOnProbation?.lastName ?? faker.person.lastName()
   const messageContent = {
     externalRef: randomUUID(),
-    firstName: personOnProbation?.firstName ?? faker.person.firstName(),
-    lastName: personOnProbation?.lastName ?? faker.person.lastName(),
+    firstName,
+    lastName,
     completionDateTime: new Date().toISOString(),
     courseName: faker.helpers.arrayElement([
       'First Aid',
@@ -31,7 +33,7 @@ export default async (
     ]),
     pdu: team.pdu,
     region: team.provider,
-    email: faker.internet.email(),
+    email: `${`${firstName}.${lastName}`.replace(/[^a-zA-Z0-9.]/g, '').toLowerCase()}@example.com`,
     office: 'Northampton',
     dateOfBirth: personOnProbation?.dateOfBirth.toISOString() ?? faker.date.birthdate().toISOString(),
     courseType: faker.helpers.arrayElement(['Accredited', 'Certified']),

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -12,7 +12,7 @@ test('Process course completion - credit time on existing appointment', async ({
   page,
   deliusUser,
   team,
-  project,
+  e2eProjects,
   personOnProbation,
   appointment,
 }) => {
@@ -50,7 +50,8 @@ test('Process course completion - credit time on existing appointment', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, project)
+  const [projectName] = e2eProjects
+  await courseCompletionFormPage.selectProject(team, projectName)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')
@@ -73,7 +74,7 @@ test('Process course completion - credit time on existing appointment', async ({
   await deliusLogin(page)
   await verifyTimeCredited(page, {
     crn: personOnProbation.crn,
-    projectName: project.name,
+    projectName,
     hoursCredited: `${timeCredited.hours}:${timeCredited.minutes}`,
     outcome: 'Attended - Complied',
     date,

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -21,7 +21,8 @@ test('Process course completion - credit time on existing appointment', async ({
   })
 
   const homePage = await signIn(page, deliusUser)
-  const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
+  await homePage.courseCompletionsLink.click()
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, team)
 
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
 

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -20,7 +20,8 @@ test('Process course completion - create new appointment', async ({
   })
 
   const homePage = await signIn(page, deliusUser)
-  const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
+  await homePage.courseCompletionsLink.click()
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, team)
 
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
 

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -11,7 +11,7 @@ test('Process course completion - create new appointment', async ({
   eteExternalApiClient,
   page,
   deliusUser,
-  project,
+  e2eProjects,
   team,
   personOnProbation,
 }) => {
@@ -48,8 +48,9 @@ test('Process course completion - create new appointment', async ({
   await courseCompletionFormPage.selectRequirement()
   await courseCompletionFormPage.continue()
 
+  const [projectName] = e2eProjects
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, project)
+  await courseCompletionFormPage.selectProject(team, projectName)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')
@@ -71,7 +72,7 @@ test('Process course completion - create new appointment', async ({
   await deliusLogin(page)
   await verifyTimeCredited(page, {
     crn: personOnProbation.crn,
-    projectName: project.name,
+    projectName,
     hoursCredited: `${timeCredited.hours}:${timeCredited.minutes}`,
     outcome: 'Attended - Complied',
     date,

--- a/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
+++ b/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
@@ -17,7 +17,8 @@ test('Process course completion - unable to credit time', async ({
   })
 
   const homePage = await signIn(page, deliusUser)
-  const searchCourseCompletionsPage = await searchCourseCompletions(page, homePage, team)
+  await homePage.courseCompletionsLink.click()
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, team)
 
   await searchCourseCompletionsPage.expect.toSeeSearchResults()
 

--- a/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
+++ b/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
@@ -1,0 +1,134 @@
+import { login as deliusLogin } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
+import verifyTimeCredited from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/verify-time-credited'
+import test from '../../fixtures/test'
+import CourseCompletionDetailsPage from '../../pages/courseCompletions/courseCompletionDetailsPage'
+import CourseCompletionFormPage from '../../pages/courseCompletions/courseCompletionFormPage'
+import searchCourseCompletions from '../../steps/searchCourseCompletions'
+import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
+import signIn from '../../steps/signIn'
+
+test('Process course completion - use recommended CRN', async ({
+  eteExternalApiClient,
+  page,
+  deliusUser,
+  e2eProjects,
+  team,
+  personOnProbation,
+}) => {
+  const [firstProject, secondProject] = e2eProjects
+  // Record first course for a person
+  await test.step('Send Course Completion Message', async () => {
+    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+  })
+
+  const homePage = await signIn(page, deliusUser)
+  await homePage.courseCompletionsLink.click()
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, team)
+
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+
+  const personName = personOnProbation.getFullName()
+
+  await searchCourseCompletionsPage.clickCourseCompletion(personName)
+
+  const courseCompletionsDetailsPage = new CourseCompletionDetailsPage(page, personName)
+  await courseCompletionsDetailsPage.expect.toBeOnThePage()
+  await courseCompletionsDetailsPage.clickProcess()
+
+  const courseCompletionFormPage = new CourseCompletionFormPage(page)
+
+  await courseCompletionFormPage.expect.toBeOnThePage('crn')
+  await courseCompletionFormPage.fillCrn(personOnProbation.crn)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('person')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('history')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('requirement')
+  await courseCompletionFormPage.selectRequirement()
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('project')
+  await courseCompletionFormPage.selectProject(team, firstProject)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('appointments')
+  await courseCompletionFormPage.createNewAppointmentButton.click()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('outcome')
+  const date = new Date()
+  await courseCompletionFormPage.completeOutcomeForm({ hours: '0', minutes: '20' }, date)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.continue()
+
+  await searchCourseCompletionsPage.expect.toBeOnThePage()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
+
+  // Record second course for the same account
+
+  await test.step('Send Course Completion Message', async () => {
+    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+  })
+
+  await searchCourseCompletions(page, team)
+
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+
+  await searchCourseCompletionsPage.clickCourseCompletion(personName)
+
+  await courseCompletionsDetailsPage.expect.toBeOnThePage()
+  await courseCompletionsDetailsPage.clickProcess()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('person')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('history')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('requirement')
+  await courseCompletionFormPage.selectRequirement()
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('project')
+  await courseCompletionFormPage.selectProject(team, secondProject)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('appointments')
+  await courseCompletionFormPage.createNewAppointmentButton.click()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('outcome')
+  await courseCompletionFormPage.completeOutcomeForm({ hours: '0', minutes: '25' }, date)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.continue()
+
+  await searchCourseCompletionsPage.expect.toBeOnThePage()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
+
+  await deliusLogin(page)
+  // Verify first course outcome was recorded
+  await verifyTimeCredited(page, {
+    crn: personOnProbation.crn,
+    projectName: firstProject,
+    hoursCredited: '0:20',
+    outcome: 'Attended - Complied',
+    date,
+  })
+
+  // Verify second course outcome was recorded
+  await verifyTimeCredited(page, {
+    crn: personOnProbation.crn,
+    projectName: secondProject,
+    hoursCredited: '0:25',
+    outcome: 'Attended - Complied',
+    date,
+  })
+})

--- a/integration_tests/mockApis/courseCompletions.ts
+++ b/integration_tests/mockApis/courseCompletions.ts
@@ -1,7 +1,11 @@
 import type { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import paths from '../../server/paths/api'
-import type { EteCourseCompletionEventDto, PagedModelEteCourseCompletionEventDto } from '../../server/@types/shared'
+import type {
+  CourseCompletionRecommendationDto,
+  EteCourseCompletionEventDto,
+  PagedModelEteCourseCompletionEventDto,
+} from '../../server/@types/shared'
 import { GetCourseCompletionsRequest } from '../../server/@types/user-defined'
 
 export default {
@@ -88,6 +92,27 @@ export default {
           userMessage,
           developerMessage: 'Bad request',
         },
+      },
+    })
+  },
+
+  stubGetRecommendedSelection: ({
+    id,
+    recommendedSelection,
+  }: {
+    id: string
+    recommendedSelection: CourseCompletionRecommendationDto
+  }): SuperAgentRequest => {
+    const urlPath = paths.courseCompletions.recommendedSelection({ id })
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: recommendedSelection,
       },
     })
   },

--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -42,6 +42,7 @@ import PersonPage from '../../../pages/courseCompletions/process/personPage'
 import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
 import UnableToCreditTimePage from '../../../pages/courseCompletions/process/unableToCreditTimePage'
 import Page from '../../../pages/page'
+import courseCompletionRecommendationFactory from '../../../../server/testutils/factories/courseCompletionRecommendationFactory'
 
 context('Person Page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -85,6 +86,8 @@ context('Person Page', () => {
     const pdu = communityCampusPduFactory.build({ id: form.originalSearch.pdu })
     const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
     cy.task('stubFindCourseCompletion', { courseCompletion })
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
     //  Given I am on the page
     const page = PersonPage.visit(courseCompletion, offender)
 

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -51,6 +51,7 @@ import PersonPage from '../../../pages/courseCompletions/process/personPage'
 import SearchCourseCompletionsPage from '../../../pages/courseCompletions/searchCourseCompletionsPage'
 import UnableToCreditTimePage from '../../../pages/courseCompletions/process/unableToCreditTimePage'
 import Page from '../../../pages/page'
+import courseCompletionRecommendationFactory from '../../../../server/testutils/factories/courseCompletionRecommendationFactory'
 
 context('Crn Page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -117,6 +118,9 @@ context('Crn Page', () => {
 
     cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
     cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
+
     //  When I click back
     page.clickBack()
 
@@ -132,6 +136,8 @@ context('Crn Page', () => {
     const pdu = communityCampusPduFactory.build()
     const provider = providerSummaryFactory.build()
     cy.task('stubFindCourseCompletion', { courseCompletion })
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
     // Given I am on the page
     const page = CrnPage.visit(courseCompletion, '12', { pdu: pdu.id, provider: provider.code })
 

--- a/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
@@ -37,6 +37,7 @@ import {
   communityCampusPdusFactory,
 } from '../../../../server/testutils/factories/communityCampusPduFactory'
 import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
+import courseCompletionRecommendationFactory from '../../../../server/testutils/factories/courseCompletionRecommendationFactory'
 
 context('Unable to credit time', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -107,6 +108,8 @@ context('Unable to credit time', () => {
 
   // Scenario: Navigating back
   it('navigates back', () => {
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
     //  Given I am on the form page
     const page = UnableToCreditTimePage.visit(courseCompletion)
 

--- a/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
+++ b/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
@@ -56,6 +56,7 @@
 import { communityCampusPduFactory } from '../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../server/testutils/factories/courseCompletionFormFactory'
+import courseCompletionRecommendationFactory from '../../../server/testutils/factories/courseCompletionRecommendationFactory'
 import pagedMetadataFactory from '../../../server/testutils/factories/pagedMetadataFactory'
 import pagedModelCourseCompletionEventFactory from '../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
@@ -253,6 +254,9 @@ context('Search course completions', () => {
     const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
       content: [courseCompletion],
     })
+
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
 
     cy.task('stubGetCourseCompletions', {
       request: {

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -5,23 +5,33 @@
 //    Given I am on the course completion page
 //    When I click process
 //    Then I should see the first page of the form
+//  Scenario: Skips CRN page if recommendation
+//    Given I am on the course completion page
+//    When I click process
+//    Then I should see the confirm person page
 
+import caseDetailsSummaryFactory from '../../../server/testutils/factories/caseDetailsSummaryFactory'
 import {
   communityCampusPduFactory,
   communityCampusPdusFactory,
 } from '../../../server/testutils/factories/communityCampusPduFactory'
 import courseCompletionFactory from '../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../server/testutils/factories/courseCompletionFormFactory'
+import courseCompletionRecommendationFactory from '../../../server/testutils/factories/courseCompletionRecommendationFactory'
+import offenderFullFactory from '../../../server/testutils/factories/offenderFullFactory'
 import pagedModelCourseCompletionEventFactory from '../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import CourseCompletionPage from '../../pages/courseCompletions/courseCompletionPage'
 import CrnPage from '../../pages/courseCompletions/process/crnPage'
+import PersonPage from '../../pages/courseCompletions/process/personPage'
 import SearchCourseCompletionsPage from '../../pages/courseCompletions/searchCourseCompletionsPage'
 import Page from '../../pages/page'
 
-const form = courseCompletionFormFactory.build()
-
 context('Project page', () => {
+  const form = courseCompletionFormFactory.build()
+  const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+  const courseCompletion = courseCompletionFactory.build()
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -29,13 +39,12 @@ context('Project page', () => {
 
     cy.task('stubSaveCourseCompletionForm', form)
     cy.task('stubGetCourseCompletionForm', form)
+    cy.task('stubFindCourseCompletion', { courseCompletion })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
   })
 
   // Scenario: Processing a course completion
   it('enables processing a course completion', () => {
-    const courseCompletion = courseCompletionFactory.build()
-    cy.task('stubFindCourseCompletion', { courseCompletion })
-
     //  Given I am on the course completion page
     const page = CourseCompletionPage.visit(courseCompletion)
     page.shouldShowCourseCompletionDetails()
@@ -47,10 +56,29 @@ context('Project page', () => {
     Page.verifyOnPage(CrnPage)
   })
 
+  // Scenario: Skips CRN page if recommendation
+  it('skips the CRN page when a recommendation is available', () => {
+    const recommendation = courseCompletionRecommendationFactory.build()
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection: recommendation })
+
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({
+      offender: offenderFullFactory.build({ crn: form.crn }),
+    })
+    cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+    //  Given I am on the course completion page
+    const page = CourseCompletionPage.visit(courseCompletion)
+    page.shouldShowCourseCompletionDetails()
+
+    //  When I click process
+    page.clickProcess()
+
+    // Then I should see the confirm person page
+    Page.verifyOnPage(PersonPage)
+  })
+
   // Scenario: Navigating back
   it('navigates back', () => {
-    const courseCompletion = courseCompletionFactory.build()
-    cy.task('stubFindCourseCompletion', { courseCompletion })
     //  Given I am on the page
     const page = CourseCompletionPage.visit(courseCompletion)
 
@@ -69,8 +97,6 @@ context('Project page', () => {
   it('navigates back to search results', () => {
     const pdu = communityCampusPduFactory.build()
     const provider = providerSummaryFactory.build()
-    const courseCompletion = courseCompletionFactory.build()
-    cy.task('stubFindCourseCompletion', { courseCompletion })
     //  Given I am on the page
     const page = CourseCompletionPage.visit(courseCompletion, { pdu: pdu.id, provider: provider.code })
 

--- a/server/controllers/courseCompletions/index.test.ts
+++ b/server/controllers/courseCompletions/index.test.ts
@@ -16,6 +16,7 @@ import { pathWithQuery } from '../../utils/utils'
 import paths from '../../paths'
 import courseCompletionFormFactory from '../../testutils/factories/courseCompletionFormFactory'
 import AuditService from '../../services/auditService'
+import courseCompletionRecommendationFactory from '../../testutils/factories/courseCompletionRecommendationFactory'
 
 jest.mock('../../pages/courseCompletionIndexPage')
 jest.mock('../../utils/paginationUtils')
@@ -229,6 +230,9 @@ describe('CourseCompletionsController', () => {
       const courseCompletion = courseCompletionFactory.build()
 
       courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
+      courseCompletionService.getRecommendedSelection.mockResolvedValue(
+        courseCompletionRecommendationFactory.build({ crn: null }),
+      )
 
       const req: DeepMocked<Request> = createMock<Request>({
         query: {
@@ -244,6 +248,37 @@ describe('CourseCompletionsController', () => {
         courseCompletion,
         backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
         processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
+          ...req.query,
+          form: '1',
+        }),
+      })
+    })
+
+    it('should return person page with process link if recommended CRN', async () => {
+      const response = createMock<Response>()
+
+      const courseCompletion = courseCompletionFactory.build()
+
+      courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
+
+      const recommendation = courseCompletionRecommendationFactory.build()
+
+      courseCompletionService.getRecommendedSelection.mockResolvedValue(recommendation)
+
+      const req: DeepMocked<Request> = createMock<Request>({
+        query: {
+          provider: '1',
+          pdu: '123',
+        },
+      })
+
+      const requestHandler = courseCompletionsController.show()
+      await requestHandler(req, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('courseCompletions/show', {
+        courseCompletion,
+        backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
+        processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'person' }), {
           ...req.query,
           form: '1',
         }),

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -46,9 +46,17 @@ export default class CourseCompletionsController {
         id: req.params.id,
       })
 
+      const { crn } = await this.courseCompletionService.getRecommendedSelection({
+        id: courseCompletion.id,
+        username: res.locals.user.username,
+      })
+
       const { formId } = await this.formService.createForm(res.locals.user.username, {
+        crn,
         originalSearch: req.query as CourseCompletionPageInput,
       })
+
+      const firstProcessPage = crn ? 'person' : 'crn'
 
       res.locals.audit = {
         subjectType: 'SEARCH_TERM',
@@ -58,10 +66,13 @@ export default class CourseCompletionsController {
       res.render('courseCompletions/show', {
         courseCompletion,
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
-        processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
-          ...(req.query as CourseCompletionPageInput),
-          form: formId,
-        }),
+        processLink: pathWithQuery(
+          paths.courseCompletions.process({ id: courseCompletion.id, page: firstProcessPage }),
+          {
+            ...(req.query as CourseCompletionPageInput),
+            form: formId,
+          },
+        ),
       })
     }
   }

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -46,10 +46,9 @@ export default class CourseCompletionsController {
         id: req.params.id,
       })
 
-      const { formId } = await this.formService.createForm(
-        res.locals.user.username,
-        req.query as CourseCompletionPageInput,
-      )
+      const { formId } = await this.formService.createForm(res.locals.user.username, {
+        originalSearch: req.query as CourseCompletionPageInput,
+      })
 
       res.locals.audit = {
         subjectType: 'SEARCH_TERM',

--- a/server/data/courseCompletionClient.test.ts
+++ b/server/data/courseCompletionClient.test.ts
@@ -4,6 +4,7 @@ import CourseCompletionClient from './courseCompletionClient'
 import config from '../config'
 import paths from '../paths/api'
 import courseCompletionFactory from '../testutils/factories/courseCompletionFactory'
+import courseCompletionRecommendationFactory from '../testutils/factories/courseCompletionRecommendationFactory'
 import courseCompletionResolutionFactory from '../testutils/factories/courseCompletionResolutionFactory'
 import pagedModelCourseCompletionEventFactory from '../testutils/factories/pagedModelCourseCompletionEventFactory'
 import { CourseCompletionResolutionStatus } from '../@types/user-defined'
@@ -89,6 +90,22 @@ describe('CourseCompletionClient', () => {
       const response = await courseCompletionClient.save({ username: 'some-username', id }, courseCompletionData)
 
       expect(response).toBeTruthy()
+    })
+  })
+
+  describe('getRecommendedSelection', () => {
+    it('should make a GET request to the recommended selection path using user token and return the response body', async () => {
+      const id = '1'
+      const recommendedSelection = courseCompletionRecommendationFactory.build()
+
+      nock(config.apis.communityPaybackApi.url)
+        .get(paths.courseCompletions.recommendedSelection({ id }))
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200, recommendedSelection)
+
+      const response = await courseCompletionClient.getRecommendedSelection({ username: 'some-username', id })
+
+      expect(response).toEqual(recommendedSelection)
     })
   })
 })

--- a/server/data/courseCompletionClient.ts
+++ b/server/data/courseCompletionClient.ts
@@ -4,6 +4,7 @@ import config from '../config'
 import logger from '../../logger'
 import paths from '../paths/api'
 import {
+  CourseCompletionRecommendationDto,
   CourseCompletionResolutionDto,
   EteCourseCompletionEventDto,
   PagedModelEteCourseCompletionEventDto,
@@ -36,5 +37,13 @@ export default class CourseCompletionClient extends RestClient {
       { path, data, retry: true, headers: idempotencyKey('post-course-completion-resolution', id) },
       asSystem(username),
     )
+  }
+
+  async getRecommendedSelection({
+    username,
+    id,
+  }: GetCourseCompletionRequest): Promise<CourseCompletionRecommendationDto> {
+    const path = paths.courseCompletions.recommendedSelection({ id })
+    return (await this.get({ path }, asSystem(username))) as CourseCompletionRecommendationDto
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -40,6 +40,7 @@ export default {
     singleCourseCompletion: singleCourseCompletionPath,
     save: singleCourseCompletionPath.path('resolution'),
     filter: providersPath.path(':providerCode/course-completions'),
+    recommendedSelection: singleCourseCompletionPath.path('recommended-selection'),
   },
   referenceData: {
     projectTypes: referenceDataPath.path('project-types'),

--- a/server/services/courseCompletionService.test.ts
+++ b/server/services/courseCompletionService.test.ts
@@ -1,5 +1,6 @@
 import CourseCompletionClient from '../data/courseCompletionClient'
 import courseCompletionFactory from '../testutils/factories/courseCompletionFactory'
+import courseCompletionRecommendationFactory from '../testutils/factories/courseCompletionRecommendationFactory'
 import courseCompletionResolutionFactory from '../testutils/factories/courseCompletionResolutionFactory'
 import pagedModelCourseCompletionEventFactory from '../testutils/factories/pagedModelCourseCompletionEventFactory'
 import CourseCompletionService from './courseCompletionService'
@@ -117,5 +118,22 @@ describe('CourseCompletionService', () => {
     await courseCompletionService.saveResolution({ id: 'test-id', username: 'some-username' }, courseCompletionData)
 
     expect(courseCompletionClient.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call getRecommendedSelection on the api client and return its result', async () => {
+    const recommendation = courseCompletionRecommendationFactory.build()
+
+    courseCompletionClient.getRecommendedSelection.mockResolvedValue(recommendation)
+
+    const result = await courseCompletionService.getRecommendedSelection({
+      id: 'abc-123',
+      username: 'some-username',
+    })
+
+    expect(courseCompletionClient.getRecommendedSelection).toHaveBeenCalledWith({
+      id: 'abc-123',
+      username: 'some-username',
+    })
+    expect(result).toEqual(recommendation)
   })
 })

--- a/server/services/courseCompletionService.ts
+++ b/server/services/courseCompletionService.ts
@@ -1,4 +1,5 @@
 import {
+  CourseCompletionRecommendationDto,
   CourseCompletionResolutionDto,
   EteCourseCompletionEventDto,
   PagedModelEteCourseCompletionEventDto,
@@ -38,5 +39,9 @@ export default class CourseCompletionService {
 
   async saveResolution(details: GetCourseCompletionRequest, data: CourseCompletionResolutionDto): Promise<void> {
     return this.courseCourseCompletionClient.save(details, data)
+  }
+
+  async getRecommendedSelection(details: GetCourseCompletionRequest): Promise<CourseCompletionRecommendationDto> {
+    return this.courseCourseCompletionClient.getRecommendedSelection(details)
   }
 }

--- a/server/services/forms/courseCompletionFormService.test.ts
+++ b/server/services/forms/courseCompletionFormService.test.ts
@@ -62,10 +62,26 @@ describe('CourseCompletionFormService', () => {
         provider: '2',
       }
 
-      const result = await courseCompletionFormService.createForm('some-name', originalSearch)
+      const result = await courseCompletionFormService.createForm('some-name', { originalSearch })
 
       expect(result.formId).toBeTruthy()
       expect(result.formData).toEqual({ originalSearch })
+      expect(formClient.save).toHaveBeenCalled()
+    })
+
+    it('should create a new form with any data', async () => {
+      const originalSearch: CourseCompletionPageInput = {
+        pdu: '1',
+        provider: '2',
+      }
+
+      const crn = '123'
+      const data = { crn, originalSearch }
+
+      const result = await courseCompletionFormService.createForm('some-name', data)
+
+      expect(result.formId).toBeTruthy()
+      expect(result.formData).toEqual({ crn, originalSearch })
       expect(formClient.save).toHaveBeenCalled()
     })
   })

--- a/server/services/forms/courseCompletionFormService.ts
+++ b/server/services/forms/courseCompletionFormService.ts
@@ -35,10 +35,9 @@ export default class CourseCompletionFormService extends BaseFormService<CourseC
 
   async createForm(
     username: string,
-    query?: CourseCompletionPageInput,
+    formData: CourseCompletionForm = {},
   ): Promise<{ formId: string; formData: CourseCompletionForm }> {
     const formId = randomUUID()
-    const formData = { originalSearch: query }
 
     await this.saveForm(formId, username, formData)
 

--- a/server/testutils/factories/courseCompletionRecommendationFactory.ts
+++ b/server/testutils/factories/courseCompletionRecommendationFactory.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { CourseCompletionRecommendationDto } from '../../@types/shared'
+
+export default Factory.define<CourseCompletionRecommendationDto>(() => ({
+  crn: faker.string.alphanumeric(8),
+}))


### PR DESCRIPTION
## Context

If a course completion for an account has already been processed, we can recommend the CRN associated with that appointment and skip the CRN question.

[CPB-991](https://dsdmoj.atlassian.net/browse/CPB-991)

## Changes in this PR

- Fetch and save recommended CRN to form (if any)
- Skip CRN page if recommended CRN

Navigation back through the form will be handled in a subsequent PR.

Also includes a few e2e test setup changes to enable a new test for 2 course completions for 1 account:
  - Associate email with person provided in course completion message to enable multiple messages for 1 account
  - Add a e2e project names test fixture
  - Remove homepage link from search course completions step
 
### Screenshots of UI changes

User can confirm and proceed with recommended CRN: 


https://github.com/user-attachments/assets/81e66cd2-06c4-4ed9-9b89-a8387c8ea23c

User can view recommended CRN but enter another:


https://github.com/user-attachments/assets/aa6efbbf-ae90-4504-a4ed-f3ad50517b35



## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-991]: https://dsdmoj.atlassian.net/browse/CPB-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ