### PR TITLE
CPB-991: Skip CRN question on navigating back (if applicable)

### DIFF
--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -26,6 +26,16 @@
 //    When I click the unable to credit time link
 //    Then I should see the unable to credit time page
 
+//  Scenario: Navigating back with recommended CRN
+//    Given I am on the page
+//    When I click back
+//    Then I should see the course completion details page
+
+//  Scenario: Navigating back with recommended CRN which has been changed by user
+//    Given I am on the page
+//    When I click back
+//    Then I should see the CRN page
+
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import {
   communityCampusPduFactory,
@@ -49,6 +59,7 @@ context('Person Page', () => {
   const offender = offenderFullFactory.build()
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender })
   const form = courseCompletionFormFactory.build({ crn: offender.crn })
+  const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
 
   beforeEach(() => {
     cy.task('reset')
@@ -57,6 +68,7 @@ context('Person Page', () => {
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
   })
 
   // Scenario: Viewing person details
@@ -86,8 +98,6 @@ context('Person Page', () => {
     const pdu = communityCampusPduFactory.build({ id: form.originalSearch.pdu })
     const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
     cy.task('stubFindCourseCompletion', { courseCompletion })
-    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
-    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
     //  Given I am on the page
     const page = PersonPage.visit(courseCompletion, offender)
 
@@ -138,5 +148,37 @@ context('Person Page', () => {
 
     // Then I should see the unable to credit time page
     Page.verifyOnPage(UnableToCreditTimePage, courseCompletion)
+  })
+
+  // Scenario: Navigating back with recommended CRN
+  it('navigates back to course completion details if recommended CRN is unchanged', () => {
+    const recommendation = courseCompletionRecommendationFactory.build({ crn: form.crn })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection: recommendation })
+    cy.task('stubSaveCourseCompletionForm', form)
+
+    //  Given I am on the page
+    const page = PersonPage.visit(courseCompletion, offender)
+
+    //  When I click back
+    page.clickBack()
+
+    // Then I should see the course completion details page
+    Page.verifyOnPage(CourseCompletionPage, courseCompletion)
+  })
+
+  // Scenario: Navigating back with recommended CRN which has been changed by user
+  it('navigates back to the CRN page if the recommended CRN has been changed by the user', () => {
+    const recommendation = courseCompletionRecommendationFactory.build()
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection: recommendation })
+    cy.task('stubSaveCourseCompletionForm', form)
+
+    //  Given I am on the page
+    const page = PersonPage.visit(courseCompletion, offender)
+
+    //  When I click back
+    page.clickBack()
+
+    // Then I should see the CRN page
+    Page.verifyOnPage(CrnPage, courseCompletion)
   })
 })

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -58,6 +58,7 @@ context('Crn Page', () => {
   const offender = offenderFullFactory.build()
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender })
   const form = courseCompletionFormFactory.build({ crn: undefined })
+  const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
 
   beforeEach(() => {
     cy.task('reset')
@@ -66,6 +67,7 @@ context('Crn Page', () => {
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
   })
 
   // Scenario: Submitting the form
@@ -118,8 +120,6 @@ context('Crn Page', () => {
 
     cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
     cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
-    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
-    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
 
     //  When I click back
     page.clickBack()
@@ -136,8 +136,6 @@ context('Crn Page', () => {
     const pdu = communityCampusPduFactory.build()
     const provider = providerSummaryFactory.build()
     cy.task('stubFindCourseCompletion', { courseCompletion })
-    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
-    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
     // Given I am on the page
     const page = CrnPage.visit(courseCompletion, '12', { pdu: pdu.id, provider: provider.code })
 

--- a/integration_tests/tests/courseCompletions/process/viewCourseHistory.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/viewCourseHistory.cy.ts
@@ -30,6 +30,7 @@ import PersonPage from '../../../pages/courseCompletions/process/personPage'
 import RequirementPage from '../../../pages/courseCompletions/process/requirementPage'
 import Page from '../../../pages/page'
 import UnableToCreditTimePage from '../../../pages/courseCompletions/process/unableToCreditTimePage'
+import courseCompletionRecommendationFactory from '../../../../server/testutils/factories/courseCompletionRecommendationFactory'
 
 context('Person Page', () => {
   const courseCompletion = courseCompletionFactory.build()
@@ -72,6 +73,9 @@ context('Person Page', () => {
   // Scenario: Navigating back
   it('navigates back', () => {
     const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender: { crn: form.crn } })
+    const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
+
     cy.task('stubGetOffenderSummary', {
       caseDetailsSummary,
     })

--- a/server/controllers/courseCompletions/process/personController.test.ts
+++ b/server/controllers/courseCompletions/process/personController.test.ts
@@ -9,6 +9,7 @@ import courseCompletionFormFactory from '../../../testutils/factories/courseComp
 import OffenderService from '../../../services/offenderService'
 import caseDetailsSummaryFactory from '../../../testutils/factories/caseDetailsSummaryFactory'
 import AuditService from '../../../services/auditService'
+import courseCompletionRecommendationFactory from '../../../testutils/factories/courseCompletionRecommendationFactory'
 
 describe('PersonController', () => {
   const response = createMock<Response>()
@@ -74,6 +75,62 @@ describe('PersonController', () => {
 
       expect(response.render).toHaveBeenCalledWith(templatePath, { ...viewData, ...stepViewData })
       expect(formService.getForm).toHaveBeenCalledTimes(1)
+      expect(page.stepViewData).toHaveBeenCalledWith(expect.objectContaining({ shouldSkipBackToCrn: false }))
+    })
+
+    it('passes shouldSkipBackToCrn to page view data method if recommended CRN which is unchanged on form', async () => {
+      const recommendation = courseCompletionRecommendationFactory.build({ crn: form.crn })
+      courseCompletionService.getRecommendedSelection.mockResolvedValue(recommendation)
+
+      const formId = '12'
+      const viewData = {
+        backLink: '/back',
+        updatePath: '/update',
+        communityCampusPerson: { name: 'Mary Smith' },
+        courseName: 'Customer service',
+        unableToCreditTimePath: '/unable-to-credit-time',
+      }
+      page.viewData.mockReturnValue(viewData)
+
+      const stepViewDataWithBackLink = {
+        ...stepViewData,
+        backLink: '/supersede',
+      }
+
+      page.stepViewData.mockReturnValue(stepViewDataWithBackLink)
+
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
+
+      const requestHandler = personController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(templatePath, expect.objectContaining({ backLink: '/supersede' }))
+      expect(page.stepViewData).toHaveBeenCalledWith(expect.objectContaining({ shouldSkipBackToCrn: true }))
+    })
+
+    it('should not pass shouldSkipBackToCrn to page view data method if recommended CRN which is changed on form', async () => {
+      const recommendation = courseCompletionRecommendationFactory.build()
+      courseCompletionService.getRecommendedSelection.mockResolvedValue(recommendation)
+
+      const formId = '12'
+      const viewData = {
+        backLink: '/back',
+        updatePath: '/update',
+        communityCampusPerson: { name: 'Mary Smith' },
+        courseName: 'Customer service',
+        unableToCreditTimePath: '/unable-to-credit-time',
+      }
+      page.viewData.mockReturnValue(viewData)
+
+      page.stepViewData.mockReturnValue(stepViewData)
+
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
+
+      const requestHandler = personController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(templatePath, expect.objectContaining({ backLink: '/back' }))
+      expect(page.stepViewData).toHaveBeenCalledWith(expect.objectContaining({ shouldSkipBackToCrn: false }))
     })
   })
 

--- a/server/controllers/courseCompletions/process/personController.ts
+++ b/server/controllers/courseCompletions/process/personController.ts
@@ -25,6 +25,12 @@ export default class PersonController extends BaseController<PersonPage> {
   }: StepViewDataParams): Promise<PersonPageViewData> {
     const crn = this.getPropertyValue({ propertyName: 'crn', req, formData })
     const { offender } = await this.offenderService.getOffenderSummary({ username: res.locals.user.username, crn })
+    const recommendation = await this.courseCompletionService.getRecommendedSelection({
+      id: req.params.id,
+      username: res.locals.user.username,
+    })
+
+    const shouldSkipBackToCrn = Boolean(recommendation.crn) && recommendation.crn === formData.crn
 
     this.auditService.sendAuditMessage({
       action: Page.VIEW_CONFIRM_CRN_MATCH,
@@ -35,6 +41,12 @@ export default class PersonController extends BaseController<PersonPage> {
       subjectId: crn,
     })
 
-    return this.page.stepViewData({ courseCompletion, offender, formId })
+    return this.page.stepViewData({
+      courseCompletion,
+      offender,
+      formId,
+      shouldSkipBackToCrn,
+      originalSearch: this.getOriginalSearch(req, formData) ?? {},
+    })
   }
 }

--- a/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
+++ b/server/pages/courseCompletions/process/baseCourseCompletionFormPage.ts
@@ -56,6 +56,7 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
   protected backPath({
     courseCompletionId,
     formId,
+    originalSearch,
   }: {
     courseCompletionId: string
     formId?: string
@@ -67,7 +68,7 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
       return this.pathWithFormId(paths.courseCompletions.process({ id: courseCompletionId, page: backPage }), formId)
     }
 
-    return this.exitPath(courseCompletionId)
+    return this.exitPath(courseCompletionId, originalSearch)
   }
 
   updatePath({
@@ -101,8 +102,12 @@ export default abstract class BaseCourseCompletionFormPage<TBody> extends PageWi
     }
   }
 
-  protected exitPath(courseCompletionId: string): string {
-    return paths.courseCompletions.show({ id: courseCompletionId })
+  protected exitPath(courseCompletionId: string, originalSearch?: CourseCompletionPageInput): string {
+    const path = paths.courseCompletions.show({ id: courseCompletionId })
+    if (!originalSearch || Object.keys(originalSearch).length === 0) {
+      return path
+    }
+    return pathWithQuery(path, originalSearch)
   }
 
   protected pathWithFormId(path: string, form?: string): string {

--- a/server/pages/courseCompletions/process/crnPage.ts
+++ b/server/pages/courseCompletions/process/crnPage.ts
@@ -81,20 +81,6 @@ export default class CrnPage extends BaseCourseCompletionFormPage<CrnPageBody> {
     })
   }
 
-  protected override backPath({
-    courseCompletionId,
-    originalSearch,
-  }: {
-    courseCompletionId: string
-    formId?: string
-    originalSearch?: CourseCompletionPageInput
-  }): string {
-    if (!originalSearch || Object.keys(originalSearch).length === 0) {
-      return this.exitPath(courseCompletionId)
-    }
-    return pathWithQuery(this.exitPath(courseCompletionId), originalSearch)
-  }
-
   private hintText(courseCompletion: EteCourseCompletionEventDto): string {
     const { name } = this.buildPerson(courseCompletion)
     return `Enter ${name}'s CRN to link the Community Campus account with nDelius.`

--- a/server/pages/courseCompletions/process/personPage.test.ts
+++ b/server/pages/courseCompletions/process/personPage.test.ts
@@ -89,7 +89,13 @@ describe('PersonPage', () => {
       jest.spyOn(CourseCompletionUtils, 'formattedLearnerDetails').mockReturnValue(learnerDetails)
       jest.spyOn(CourseCompletionUtils, 'formattedOffenderDetails').mockReturnValue(offenderDetails)
 
-      const result = page.stepViewData({ courseCompletion, offender, formId: form })
+      const result = page.stepViewData({
+        courseCompletion,
+        offender,
+        formId: form,
+        shouldSkipBackToCrn: false,
+        originalSearch: {},
+      })
       expect(result).toEqual({
         learnerDetails,
         offenderDetails,
@@ -97,6 +103,19 @@ describe('PersonPage', () => {
           form,
         }),
       })
+    })
+
+    it('includes backLink if shouldSkipBackToCrn is true', () => {
+      const result = page.stepViewData({
+        courseCompletion,
+        offender,
+        formId: form,
+        shouldSkipBackToCrn: true,
+        originalSearch: { provider: 'Lincoln' },
+      })
+      expect(result.backLink).toEqual(
+        pathWithQuery(paths.courseCompletions.show({ id: courseCompletion.id }), { provider: 'Lincoln' }),
+      )
     })
   })
 })

--- a/server/pages/courseCompletions/process/personPage.ts
+++ b/server/pages/courseCompletions/process/personPage.ts
@@ -5,6 +5,8 @@ import CourseCompletionUtils, {
   CourseCompletionOffenderDetails,
   LearnerDetails,
 } from '../../../utils/courseCompletionUtils'
+import { pathWithQuery } from '../../../utils/utils'
+import { CourseCompletionPageInput } from '../../courseCompletionIndexPage'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
 
@@ -16,6 +18,7 @@ export interface PersonPageViewData {
   learnerDetails: LearnerDetails
   offenderDetails: CourseCompletionOffenderDetails
   crnPagePath: string
+  backLink?: string
 }
 
 export default class PersonPage extends BaseCourseCompletionFormPage<Body> {
@@ -34,12 +37,16 @@ export default class PersonPage extends BaseCourseCompletionFormPage<Body> {
     courseCompletion,
     offender,
     formId,
+    shouldSkipBackToCrn,
+    originalSearch,
   }: {
     courseCompletion: EteCourseCompletionEventDto
     offender: OffenderDto
     formId: string
+    shouldSkipBackToCrn: boolean
+    originalSearch: CourseCompletionPageInput
   }): PersonPageViewData {
-    return {
+    const viewData: PersonPageViewData = {
       learnerDetails: CourseCompletionUtils.formattedLearnerDetails(courseCompletion),
       offenderDetails: CourseCompletionUtils.formattedOffenderDetails(offender),
       crnPagePath: this.pathWithFormId(
@@ -47,5 +54,9 @@ export default class PersonPage extends BaseCourseCompletionFormPage<Body> {
         formId,
       ),
     }
+    if (shouldSkipBackToCrn) {
+      viewData.backLink = pathWithQuery(this.exitPath(courseCompletion.id), originalSearch)
+    }
+    return viewData
   }
 }


### PR DESCRIPTION
## Context

When navigating back through the form, we can skip the CRN question if a recommended CRN has been provided, and has not been changed by the user.

[CPB-991](https://dsdmoj.atlassian.net/browse/CPB-991)

## Changes in this PR

- Add override for backLink logic on person page to skip CRN question: IF recommended CRN is available AND the form value matches the recommended value—so has not been edited by the user.
- Refactor exit path logic for the form, so that this is consistent across pages.

### Screenshots of UI changes

When navigating back, skip the CRN page if recommended CRN has not changed: 

https://github.com/user-attachments/assets/901bf120-199c-4b9c-be5e-bd0f0722c691

If the recommended CRN has changed, navigate back to the CRN question:


https://github.com/user-attachments/assets/48c6e5ef-385c-4602-825d-1da18127405e


If there was no recommended CRN, navigate back to the CRN question:


https://github.com/user-attachments/assets/8cfc3652-3122-439d-9c82-bef93f14ebaf


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-991]: https://dsdmoj.atlassian.net/browse/CPB-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ