### PR TITLE
CPB-991: Add test data workflow for course completion events

### DIFF
--- a/.github/workflows/create_session_test_data.yml
+++ b/.github/workflows/create_session_test_data.yml
@@ -10,11 +10,6 @@ on:
         type: choice
         options:
           - seed_data.yml
-      node_version_file:
-        description: 'Passed to setup-node action to specify where to source the version of node from'
-        required: false
-        type: string
-        default: '.nvmrc'
 
 permissions:
   contents: read
@@ -29,11 +24,11 @@ jobs:
           # Repository is specified to run the workflow from the API repository
           repository: 'ministryofjustice/hmpps-community-payback-ui'
 
-      - name: Use Node.js ${{ inputs.node_version_file }}
+      - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version-file: ${{ inputs.node_version_file }}
-          cache: npm
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: install dependencies
         shell: bash

--- a/.github/workflows/create_session_test_data.yml
+++ b/.github/workflows/create_session_test_data.yml
@@ -1,4 +1,4 @@
-name: Seed projects, offenders and allocations
+name: Seed unpaid work data
 
 on:
   workflow_dispatch:
@@ -10,6 +10,14 @@ on:
         type: choice
         options:
           - seed_data.yml
+      project:
+        description: 'Select the test project to run'
+        required: true
+        default: project-allocations
+        type: choice
+        options:
+          - project-allocations
+          - course-completions
 
 permissions:
   contents: read
@@ -50,11 +58,11 @@ jobs:
           DELIUS_USERNAME: ${{ secrets.DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.DELIUS_PASSWORD }}
           DELIUS_URL: ${{ vars.DELIUS_URL }}
-          SEED_DATA_PATH: "seed_data/${{ github.event.inputs.seed_data_file }}"
+          SEED_DATA_PATH: 'seed_data/${{ github.event.inputs.seed_data_file }}'
           TIMEOUT_INTERVAL: 3600000
         shell: bash
         run: |
-          npx playwright test --project project-allocations
+          npx playwright test --project ${{ inputs.project }}
       - name: upload results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/create_session_test_data.yml
+++ b/.github/workflows/create_session_test_data.yml
@@ -59,7 +59,7 @@ jobs:
           TIMEOUT_INTERVAL: 3600000
         shell: bash
         run: |
-          npx playwright test --project seedData
+          npx playwright test --project project-allocations
       - name: upload results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -6,18 +6,25 @@ import { Team } from '../fixtures/testOptions'
 import PersonOnProbation from '../delius/personOnProbation'
 import { EteCourseCompletionEventDto } from '../../server/@types/shared'
 
-export default async (
-  externalApiClient: {
+export default async ({
+  eteExternalApiClient,
+  team,
+  personOnProbation,
+  status = 'Passed',
+  courseName,
+}: {
+  eteExternalApiClient: {
     enabled: boolean
     certBase64: string
     apiKey: string
     privateKeyBase64: string
     url: string
-  },
-  team: Team,
-  personOnProbation?: PersonOnProbation,
-  status: EteCourseCompletionEventDto['status'] = 'Passed',
-) => {
+  }
+  team: Team
+  personOnProbation?: PersonOnProbation
+  status?: EteCourseCompletionEventDto['status']
+  courseName?: string
+}) => {
   const firstName = personOnProbation?.firstName ?? faker.person.firstName()
   const lastName = personOnProbation?.lastName ?? faker.person.lastName()
   let messageContent = {
@@ -25,14 +32,16 @@ export default async (
     firstName,
     lastName,
     completionDateTime: new Date().toISOString(),
-    courseName: faker.helpers.arrayElement([
-      'First Aid',
-      'Customer Service Excellence',
-      'Food Hygiene Level 2',
-      'Business Communication Skills',
-      'Construction Skills',
-      'Health and Safety Basics',
-    ]),
+    courseName:
+      courseName ??
+      faker.helpers.arrayElement([
+        'First Aid',
+        'Customer Service Excellence',
+        'Food Hygiene Level 2',
+        'Business Communication Skills',
+        'Construction Skills',
+        'Health and Safety Basics',
+      ]),
     pdu: team.pdu,
     region: team.provider,
     email: `${`${firstName}.${lastName}`.replace(/[^a-zA-Z0-9.]/g, '').toLowerCase()}@example.com`,
@@ -54,17 +63,17 @@ export default async (
     }
   }
 
-  if (externalApiClient.enabled) {
+  if (eteExternalApiClient.enabled) {
     const payload = JSON.parse(CourseCompletionMessageBuilder.toExternalApiMessage(messageContent))
 
-    const cert = Buffer.from(externalApiClient.certBase64, 'base64').toString('binary')
-    const privateKey = Buffer.from(externalApiClient.privateKeyBase64, 'base64').toString('binary')
+    const cert = Buffer.from(eteExternalApiClient.certBase64, 'base64').toString('binary')
+    const privateKey = Buffer.from(eteExternalApiClient.privateKeyBase64, 'base64').toString('binary')
 
     await request
-      .post(externalApiClient.url)
+      .post(eteExternalApiClient.url)
       .cert(cert)
       .key(privateKey)
-      .set('x-api-key', externalApiClient.apiKey)
+      .set('x-api-key', eteExternalApiClient.apiKey)
       .set('Content-Type', 'application/json')
       .send(payload)
       .ok(r => r.status === 202)

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -17,7 +17,7 @@ test('Process course completion - credit time on existing appointment', async ({
   appointment,
 }) => {
   await test.step('Send Course Completion Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation })
   })
 
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -16,7 +16,7 @@ test('Process course completion - create new appointment', async ({
   personOnProbation,
 }) => {
   await test.step('Send Course Completion Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation })
   })
 
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
+++ b/e2e-tests/tests/ete/08_course_completion_unable_to_credit_time.spec.ts
@@ -13,7 +13,7 @@ test('Process course completion - unable to credit time', async ({
   personOnProbation,
 }) => {
   await test.step('Send Course Completion Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation })
   })
 
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
+++ b/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
@@ -18,7 +18,7 @@ test('Process course completion - use recommended CRN', async ({
   const [firstProject, secondProject] = e2eProjects
   // Record first course for a person
   await test.step('Send Course Completion Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation })
   })
 
   const homePage = await signIn(page, deliusUser)
@@ -73,7 +73,7 @@ test('Process course completion - use recommended CRN', async ({
   // Record second course for the same account
 
   await test.step('Send Course Completion Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation)
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation })
   })
 
   await searchCourseCompletions(page, team)

--- a/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
+++ b/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
@@ -16,7 +16,7 @@ test('Process course completion failure', async ({
   personOnProbation,
 }) => {
   await test.step('Send Course Completion Failure Message', async () => {
-    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation, 'Failed')
+    return sendCourseCompletionMessage({ eteExternalApiClient, team, personOnProbation, status: 'Failed' })
   })
 
   const homePage = await signIn(page, deliusUser)

--- a/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/03_search_for_course_completions.spec.ts
@@ -11,7 +11,7 @@ test.describe('Without javascript', () => {
     await page.goto('/sign-out')
     await expect(page.locator('h1')).toContainText('Sign in')
 
-    await sendCourseCompletionMessage(eteExternalApiClient, team)
+    await sendCourseCompletionMessage({ eteExternalApiClient, team })
 
     const homePage = await signIn(page, deliusUser)
 

--- a/e2e-tests/tests/seed-data/course_completions.spec.ts
+++ b/e2e-tests/tests/seed-data/course_completions.spec.ts
@@ -1,0 +1,32 @@
+/* eslint no-console: "off" -- we want to print out the created events  */
+/* eslint no-await-in-loop: "off" -- this is easier to read */
+
+import test from '../../fixtures/test'
+import loadSeedData, { SeedData } from '../../utils/seed_utils'
+import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
+
+const seedDataPath = process.env.SEED_DATA_PATH
+
+if (seedDataPath) {
+  const seedData: SeedData = loadSeedData(seedDataPath)
+
+  seedData.seed_data.forEach(regionData => {
+    const courseCount = regionData.course_completions.length
+    test(`Creating ${courseCount} course completions for offender in Region: ${regionData.region} - Team: ${regionData.team.name}`, async ({
+      eteExternalApiClient,
+      personOnProbation,
+    }) => {
+      console.log(`Course completion details:`)
+      for (const projectName of regionData.course_completions) {
+        await sendCourseCompletionMessage({ eteExternalApiClient, team: regionData.team, personOnProbation })
+        console.log(`- ${projectName}`)
+      }
+    })
+  })
+} else {
+  test.describe('Seed Data', () => {
+    test('Seed data from YAML (skipped)', async () => {
+      test.skip(true, 'SEED_DATA_PATH environment variable is not configured')
+    })
+  })
+}

--- a/e2e-tests/tests/seed-data/project_allocations.spec.ts
+++ b/e2e-tests/tests/seed-data/project_allocations.spec.ts
@@ -10,9 +10,9 @@ import {
 import { createUpwProject } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/create-upw-project'
 import fs from 'fs'
 import path from 'path'
-import test from '../fixtures/test'
-import loadSeedData, { SeedData, uniqueProjectName } from '../utils/seed_utils'
-import DateTimeUtils from '../utils/DateTimeUtils'
+import test from '../../fixtures/test'
+import loadSeedData, { SeedData, uniqueProjectName } from '../../utils/seed_utils'
+import DateTimeUtils from '../../utils/DateTimeUtils'
 
 const seedDataPath = process.env.SEED_DATA_PATH
 const timeout = process.env.TIMEOUT_INTERVAL || 3600000 // One hour (or ~50 offenders)

--- a/e2e-tests/utils/seed_utils.ts
+++ b/e2e-tests/utils/seed_utils.ts
@@ -9,6 +9,7 @@ export interface RegionData {
   region: string
   team: Team
   projects: ProjectData[]
+  course_completions: string[]
 }
 
 export interface ProjectData {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,5 +59,14 @@ export default defineConfig<TestOptions>({
       },
       dependencies: ['setupDev'],
     },
+    {
+      name: 'course-completions',
+      testMatch: /seed-data\/course_completions\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:3000',
+      },
+      dependencies: ['setupDev'],
+    },
   ],
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,8 +51,8 @@ export default defineConfig<TestOptions>({
       dependencies: ['setupLocal'],
     },
     {
-      name: 'seedData',
-      testMatch: /seed_data\.spec\.ts/,
+      name: 'project-allocations',
+      testMatch: /seed-data\/project_allocations\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         baseURL: 'http://localhost:3000',

--- a/seed_data/seed_data.yml
+++ b/seed_data/seed_data.yml
@@ -4,6 +4,7 @@ seed_data:
       name: CPB Automated Test Team
       provider: East of England
       supervisor: some supervisor
+      pdu: Northamptonshire
     projects:
       - projectName: Test Group Project - Pre hours
         projectType: Group Placement - Regional Project
@@ -41,3 +42,7 @@ seed_data:
           count: 7
           percentage_with_pickup_specified: 0.3
           percentage_that_are_rescheduled: 0.3
+    course_completions:
+      - Community Campus Test
+      - ETE Automated Test Bucket
+      - CC A Beginners Guide to Microsoft Outlook


### PR DESCRIPTION
## Context

In #588 I introduced behaviour to skip a form question if a person has a previous recorded course in delius through our system. Testing this depends on multiple course completion messages for one account, so adding a workflow which enables us to seed this from the repository.

## Changes in this PR

- Update additional seed data workflow to take a project option
- Add new test project for sending course completion messages


## Pre merge

Have tested this [in the pipeline](https://github.com/ministryofjustice/hmpps-community-payback-ui/actions/runs/26833268190/job/79120196521) and seen the 3 given courses added for the generated person (a matching CRN will also be created):

<img width="1210" height="141" alt="Screenshot 2026-06-03 at 11 38 28" src="https://github.com/user-attachments/assets/0ee3173b-e891-4d8e-afdb-154a5b19adbd" />

Will need to verify the workflow inputs work correctly after merge
