### PR TITLE
CPB-874 Retrieve third attempt failures when searching for course completions

### DIFF
--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
 import { Team } from '../fixtures/testOptions'
 import PersonOnProbation from '../delius/personOnProbation'
+import { EteCourseCompletionEventDto } from '../../server/@types/shared'
 
 export default async (
   externalApiClient: {
@@ -15,10 +16,11 @@ export default async (
   },
   team: Team,
   personOnProbation?: PersonOnProbation,
+  status: EteCourseCompletionEventDto['status'] = 'Passed',
 ) => {
   const firstName = personOnProbation?.firstName ?? faker.person.firstName()
   const lastName = personOnProbation?.lastName ?? faker.person.lastName()
-  const messageContent = {
+  let messageContent = {
     externalRef: randomUUID(),
     firstName,
     lastName,
@@ -42,6 +44,14 @@ export default async (
     attempts: 1,
     totalTimeMinutes: 120,
     expectedTimeMinutes: 150,
+  }
+
+  if (status === 'Failed') {
+    messageContent = {
+      ...messageContent,
+      status: 'Failed',
+      attempts: 3,
+    }
   }
 
   if (externalApiClient.enabled) {

--- a/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
+++ b/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
@@ -1,0 +1,81 @@
+import { login as deliusLogin } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
+import verifyTimeCredited from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/verify-time-credited'
+import test from '../../fixtures/test'
+import CourseCompletionDetailsPage from '../../pages/courseCompletions/courseCompletionDetailsPage'
+import CourseCompletionFormPage from '../../pages/courseCompletions/courseCompletionFormPage'
+import searchCourseCompletions from '../../steps/searchCourseCompletions'
+import sendCourseCompletionMessage from '../../steps/sendCourseCompletionMessage'
+import signIn from '../../steps/signIn'
+
+test('Process course completion failure', async ({
+  eteExternalApiClient,
+  page,
+  deliusUser,
+  e2eProjects,
+  team,
+  personOnProbation,
+}) => {
+  await test.step('Send Course Completion Failure Message', async () => {
+    return sendCourseCompletionMessage(eteExternalApiClient, team, personOnProbation, 'Failed')
+  })
+
+  const homePage = await signIn(page, deliusUser)
+  await homePage.courseCompletionsLink.click()
+  const searchCourseCompletionsPage = await searchCourseCompletions(page, team)
+
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+
+  const personName = personOnProbation.getFullName()
+
+  await searchCourseCompletionsPage.clickCourseCompletion(personName)
+
+  const courseCompletionsDetailsPage = new CourseCompletionDetailsPage(page, personName)
+  await courseCompletionsDetailsPage.expect.toBeOnThePage()
+  await courseCompletionsDetailsPage.clickProcess()
+
+  const courseCompletionFormPage = new CourseCompletionFormPage(page)
+
+  await courseCompletionFormPage.expect.toBeOnThePage('crn')
+  await courseCompletionFormPage.fillCrn(personOnProbation.crn)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('person')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('history')
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('requirement')
+  await courseCompletionFormPage.selectRequirement()
+  await courseCompletionFormPage.continue()
+
+  const [projectName] = e2eProjects
+  await courseCompletionFormPage.expect.toBeOnThePage('project')
+  await courseCompletionFormPage.selectProject(team, projectName)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('appointments')
+  await courseCompletionFormPage.createNewAppointmentButton.click()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('outcome')
+  const timeCredited = { hours: '1', minutes: '10' }
+  const date = new Date()
+  await courseCompletionFormPage.completeOutcomeForm(timeCredited, date)
+  await courseCompletionFormPage.continue()
+
+  await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.continue()
+
+  await searchCourseCompletionsPage.expect.toBeOnThePage()
+  await searchCourseCompletionsPage.expect.toSeeSearchResults()
+  await searchCourseCompletionsPage.courseCompletions.expect.notToHaveRowWithContent(personName)
+
+  await deliusLogin(page)
+  await verifyTimeCredited(page, {
+    crn: personOnProbation.crn,
+    projectName,
+    hoursCredited: `${timeCredited.hours}:${timeCredited.minutes}`,
+    outcome: 'Attended - Complied',
+    date,
+  })
+})

--- a/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
+++ b/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
@@ -15,6 +15,13 @@
 //    And I click submit
 //    Then I see the search results
 //
+//  Scenario: searching for course completions with failures
+//    Given I am logged in
+//    When I visit the 'search course completions' page
+//    And I complete the search form
+//    And I click submit
+//    Then I see the search results
+//
 //  Scenario: navigating through paginated results
 //    Given I am on the search course completions page
 //    When I complete the search form
@@ -126,6 +133,37 @@ context('Search course completions', () => {
 
     // Then I see the search results
     page.shouldShowSearchResults(courseCompletion)
+  })
+
+  //  Scenario: searching for course completions with failures
+  it('searches for course completions and displays results with failures', function test() {
+    //  When I visit the 'search course completions' page
+    SearchCourseCompletionsPage.visit()
+    const page = Page.verifyOnPage(SearchCourseCompletionsPage)
+
+    // And I complete the search form
+    page.selectRegion(this.provider)
+    page.selectPdu(this.pdu)
+
+    // And I click submit
+    const courseCompletionFailure = courseCompletionFactory.build({ status: 'Failed' })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletionFailure],
+    })
+
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: this.provider.code,
+        pduId: this.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
+
+    page.submitForm()
+
+    // Then I see the search results
+    page.shouldShowSearchResults(courseCompletionFailure)
   })
 
   // Scenario: navigating through paginated results

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -102,12 +102,15 @@ export interface GetCourseCompletionRequest extends BaseRequest {
 
 export type CourseCompletionResolutionStatus = 'Resolved' | 'Unresolved'
 
+export type CourseCompletionShowCourseFailures = 'No' | 'Yes' | 'OnlyWhenMaxAttemptsReached'
+
 export interface GetCourseCompletionsRequest extends BaseRequest, PagedRequest {
   providerCode: string
   pduId?: string
   dateFrom?: string
   dateTo?: string
   resolutionStatus?: CourseCompletionResolutionStatus
+  showCourseFailures?: CourseCompletionShowCourseFailures
 }
 
 export interface GetCourseCompletionsParams extends BaseRequest, PagedRequest, GetCourseCompletionsRequest {

--- a/server/controllers/courseCompletions/index.test.ts
+++ b/server/controllers/courseCompletions/index.test.ts
@@ -180,6 +180,7 @@ describe('CourseCompletionsController', () => {
         sortBy: 'someField',
         sortDirection: 'asc',
         resolutionStatus: 'Unresolved',
+        showCourseFailures: 'OnlyWhenMaxAttemptsReached',
         username,
       })
 

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -126,6 +126,7 @@ export default class CourseCompletionsController {
         sortBy,
         sortDirection,
         resolutionStatus: 'Unresolved',
+        showCourseFailures: 'OnlyWhenMaxAttemptsReached',
       })
 
       courseCompletions.content.forEach(courseCompletion => {


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-874?atlOrigin=eyJpIjoiNDhhZmU1NzVhMzQzNGZjOTg0MmI0Y2EwMWRmY2QwZGQiLCJwIjoiaiJ9)

## Context
In a recent change, we added the status column to the course completion results
table to show whether the course completion was a pass or a fail.

Here we change the query to include course completions that have been failed
the max number of times (3).

**Note**: In a follow-up change, I'll include the completion details which I'll reference in the e2e tests.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Show course completion failures in results table
* Update integration and e2e tests

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1258" height="517" alt="Screenshot 2026-06-02 at 16 33 08" src="https://github.com/user-attachments/assets/067fb3f0-1d0d-49a6-a82a-c606392dea2e" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
