### PR TITLE
CPB-861 Update course details page

### DIFF
--- a/e2e-tests/pages/courseCompletions/courseCompletionDetailsPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionDetailsPage.ts
@@ -15,7 +15,7 @@ export default class CourseCompletionDetailsPage extends BasePage {
   }
 
   async clickProcess() {
-    await this.page.getByRole('button', { name: 'Process' }).click()
+    await this.page.getByRole('button', { name: 'Process course' }).click()
   }
 }
 

--- a/integration_tests/pages/courseCompletions/courseCompletionPage.ts
+++ b/integration_tests/pages/courseCompletions/courseCompletionPage.ts
@@ -5,13 +5,20 @@ import Page from '../page'
 import dateTimeUtils from '../../../server/utils/dateTimeUtils'
 import { CourseCompletionPageInput } from '../../../server/pages/courseCompletionIndexPage'
 import { pathWithQuery } from '../../../server/utils/utils'
+import CourseCompletionUtils from '../../../server/utils/courseCompletionUtils'
 
 export default class CourseCompletionPage extends Page {
-  private courseCompletionDetails: SummaryListComponent
+  private learnerDetails: SummaryListComponent
+
+  private courseDetails: SummaryListComponent
+
+  private completionDetails: SummaryListComponent
 
   constructor(private readonly courseCompletion: EteCourseCompletionEventDto) {
     super(`${courseCompletion.firstName} ${courseCompletion.lastName}`)
-    this.courseCompletionDetails = new SummaryListComponent()
+    this.learnerDetails = new SummaryListComponent('Learner details')
+    this.courseDetails = new SummaryListComponent('Course details')
+    this.completionDetails = new SummaryListComponent('Completion details')
   }
 
   static visit(
@@ -25,27 +32,48 @@ export default class CourseCompletionPage extends Page {
   }
 
   shouldShowCourseCompletionDetails() {
-    const { id, firstName, lastName, office, importedOn, resolved, pdu, ...rowsToCheck } = this.courseCompletion
+    const summaryLists = [this.learnerDetails, this.courseDetails, this.completionDetails]
 
-    // turn `dateOfBirth` into `Date of birth`
-    const labels = Object.keys(rowsToCheck).map(key => {
-      if (key === 'completionDateTime') {
-        return 'Completion date'
-      }
-      return key
-        .replace(/([A-Z])/g, ' $1')
-        .toLowerCase()
-        .replace(/^./, s => s.toUpperCase())
-    })
-    const values = Object.entries(rowsToCheck).map(([key, value]) => {
-      if (key === 'completionDateTime') {
-        return dateTimeUtils.isoDateToUIDate(value as string)
-      }
-      return value
-    })
+    const learnerMap: { [index: string]: string } = {
+      'First name': this.courseCompletion.firstName,
+      'Last name': this.courseCompletion.lastName,
+      'Date of birth': dateTimeUtils.isoDateToUIDate(this.courseCompletion.dateOfBirth),
+      Email: this.courseCompletion.email,
+      Region: this.courseCompletion.region,
+      PDU: this.courseCompletion.pdu.name,
+      Office: this.courseCompletion.office,
+    }
 
-    labels.forEach((label, i) => {
-      this.courseCompletionDetails.getValueWithLabel(label).should('contain.text', values[i])
+    const expected = dateTimeUtils.totalMinutesToHoursAndMinutesParts(this.courseCompletion.expectedTimeMinutes)
+    const expectedPlus20 = dateTimeUtils.totalMinutesToHoursAndMinutesParts(
+      this.courseCompletion.expectedTimeMinutes * 1.2,
+    )
+    const total = dateTimeUtils.totalMinutesToHoursAndMinutesParts(this.courseCompletion.totalTimeMinutes)
+
+    const courseMap: { [index: string]: string } = {
+      'Course name': this.courseCompletion.courseName,
+      'Course type': this.courseCompletion.courseType,
+      Provider: this.courseCompletion.provider,
+      'Expected time': dateTimeUtils.hoursAndMinutesToHumanReadable(+expected.hours, +expected.minutes),
+      'Expected time with 20% allowance': dateTimeUtils.hoursAndMinutesToHumanReadable(
+        +expectedPlus20.hours,
+        Math.round(+expectedPlus20.minutes),
+      ),
+    }
+
+    const completionMap: { [index: string]: string } = {
+      'Completion status': CourseCompletionUtils.formattedCourseCompletionLabel(this.courseCompletion.status),
+      'Completion date': dateTimeUtils.isoDateToUIDate(this.courseCompletion.completionDateTime),
+      'Total time spent': dateTimeUtils.hoursAndMinutesToHumanReadable(+total.hours, +total.minutes),
+      'Course attempts': `${this.courseCompletion.attempts} out of 3`,
+    }
+
+    const maps = [learnerMap, courseMap, completionMap]
+
+    maps.forEach((map, i) => {
+      Object.entries(map).forEach(([label, value]) => {
+        summaryLists[i].getValueWithLabel(label).should('contain.text', value)
+      })
     })
   }
 

--- a/server/controllers/courseCompletions/index.test.ts
+++ b/server/controllers/courseCompletions/index.test.ts
@@ -17,6 +17,7 @@ import paths from '../../paths'
 import courseCompletionFormFactory from '../../testutils/factories/courseCompletionFormFactory'
 import AuditService from '../../services/auditService'
 import courseCompletionRecommendationFactory from '../../testutils/factories/courseCompletionRecommendationFactory'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 
 jest.mock('../../pages/courseCompletionIndexPage')
 jest.mock('../../utils/paginationUtils')
@@ -72,6 +73,8 @@ describe('CourseCompletionsController', () => {
     { html: 'View' },
   ]
 
+  const mockTime = '5 hours and 30 minutes'
+
   const form = courseCompletionFormFactory.build()
 
   beforeEach(() => {
@@ -103,6 +106,8 @@ describe('CourseCompletionsController', () => {
       sortDirection: 'asc',
     })
     getProvidersAndPdusMock.mockResolvedValue(providersAndPdus)
+
+    jest.spyOn(DateTimeFormats, 'hoursAndMinutesToHumanReadable').mockReturnValue(mockTime)
   })
 
   describe('index', () => {
@@ -246,7 +251,12 @@ describe('CourseCompletionsController', () => {
       await requestHandler(req, response, next)
 
       expect(response.render).toHaveBeenCalledWith('courseCompletions/show', {
-        courseCompletion,
+        courseCompletion: {
+          ...courseCompletion,
+          expectedTimeSpent: mockTime,
+          expectedPlus20: mockTime,
+          totalTimeSpent: mockTime,
+        },
         backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
         processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
           ...req.query,
@@ -277,7 +287,12 @@ describe('CourseCompletionsController', () => {
       await requestHandler(req, response, next)
 
       expect(response.render).toHaveBeenCalledWith('courseCompletions/show', {
-        courseCompletion,
+        courseCompletion: {
+          ...courseCompletion,
+          expectedTimeSpent: mockTime,
+          expectedPlus20: mockTime,
+          totalTimeSpent: mockTime,
+        },
         backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
         processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'person' }), {
           ...req.query,

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -10,6 +10,7 @@ import ProviderService from '../../services/providerService'
 import { pathWithQuery } from '../../utils/utils'
 import CourseCompletionFormService from '../../services/forms/courseCompletionFormService'
 import AuditService, { Page } from '../../services/auditService'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 
 const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime', 'status'] as const
 
@@ -63,8 +64,22 @@ export default class CourseCompletionsController {
         subjectId: `${courseCompletion.firstName} ${courseCompletion.lastName}`,
       }
 
+      const expected = DateTimeFormats.totalMinutesToHoursAndMinutesParts(courseCompletion.expectedTimeMinutes)
+      const expectedPlus20 = DateTimeFormats.totalMinutesToHoursAndMinutesParts(
+        courseCompletion.expectedTimeMinutes * 1.2,
+      )
+      const total = DateTimeFormats.totalMinutesToHoursAndMinutesParts(courseCompletion.totalTimeMinutes)
+
       res.render('courseCompletions/show', {
-        courseCompletion,
+        courseCompletion: {
+          ...courseCompletion,
+          expectedTimeSpent: DateTimeFormats.hoursAndMinutesToHumanReadable(+expected.hours, +expected.minutes),
+          expectedPlus20: DateTimeFormats.hoursAndMinutesToHumanReadable(
+            +expectedPlus20.hours,
+            Math.round(+expectedPlus20.minutes),
+          ),
+          totalTimeSpent: DateTimeFormats.hoursAndMinutesToHumanReadable(+total.hours, +total.minutes),
+        },
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
         processLink: pathWithQuery(
           paths.courseCompletions.process({ id: courseCompletion.id, page: firstProcessPage }),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -13,6 +13,7 @@ import GovUkRadioGroup from '../forms/GovUkRadioGroup'
 import LayoutUtils from './layoutUtils'
 import { paginationComponentParams } from './paginationUtils'
 import GovUKComponentUtils from './govUkComponentUtils'
+import CourseCompletionUtils from './courseCompletionUtils'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -54,6 +55,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('GovUkRadioGroup', GovUkRadioGroup)
   njkEnv.addGlobal('layoutUtils', LayoutUtils)
   njkEnv.addGlobal('dateTimeUtils', DateTimeUtils)
+  njkEnv.addGlobal('courseCompletionUtils', CourseCompletionUtils)
   njkEnv.addGlobal('paginationComponentParams', paginationComponentParams)
   njkEnv.addGlobal('mergeObjects', (obj1: Record<string, unknown>, obj2: Record<string, unknown>) => {
     return { ...(obj1 ?? {}), ...(obj2 ?? {}) }

--- a/server/views/courseCompletions/show.njk
+++ b/server/views/courseCompletions/show.njk
@@ -17,34 +17,59 @@
 {% block content %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <span class="govuk-caption-l">N1234567</span>
-    <h1 class="govuk-heading-l">{{ courseCompletion.firstName }} {{ courseCompletion.lastName }}</h1>
+  <div class="govuk-grid-column-full cpb-offender-details">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ courseCompletion.firstName }} {{ courseCompletion.lastName }}</h1>
 
     {{ govukButton({
-      text: "Process",
-      href: processLink
+      text: "Process course",
+      href: processLink,
+      classes: "govuk-!-margin-bottom-0 govuk-!-margin-top-2"
     }) }}
-
+  </div>
+  <div class="govuk-grid-column-full">
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">ETE Course completion</h2>
+    <h2 class="govuk-heading-m">Community Campus record</h2>
   </div>
 </div>
 
 {{ govukSummaryList({
   card: {
     title: {
-      text: 'Course details'
+      text: 'Learner details'
     }
   },
   rows: [
     {
       key: {
+        text: 'First name'
+      },
+      value: {
+        html: courseCompletion.firstName
+      }
+    },
+    {
+      key: {
+        text: 'Last name'
+      },
+      value: {
+        html: courseCompletion.lastName
+      }
+    },
+    {
+      key: {
         text: 'Date of birth'
       },
       value: {
-        html: courseCompletion.dateOfBirth
+        html: dateTimeUtils.dateObjtoUIDate(courseCompletion.dateOfBirth)
+      }
+    },
+    {
+      key: {
+        text: 'Email'
+      },
+      value: {
+        html: courseCompletion.email
       }
     },
     {
@@ -63,12 +88,21 @@
     },
     {
       key: {
-        text: 'Email'
-      },
-      value: {
-        html: courseCompletion.email
+        text: 'Office'
+      }, value: {
+        html: courseCompletion.office
       }
-    },
+    }
+  ]
+}) }}
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: 'Course details'
+    }
+  },
+  rows: [
     {
       key: {
         text: 'Course name'
@@ -95,6 +129,40 @@
     },
     {
       key: {
+        text: 'Expected time'
+      },
+      value: {
+        html: courseCompletion.expectedTimeSpent
+      }
+    },
+    {
+      key: {
+        text: 'Expected time with 20% allowance'
+      },
+      value: {
+        html: courseCompletion.expectedPlus20
+      }
+    }
+  ]
+}) }}
+
+{{ govukSummaryList({
+  card: {
+    title: {
+      text: 'Completion details'
+    }
+  },
+  rows: [
+    {
+      key: {
+        text: 'Completion status'
+      },
+      value: {
+        html: courseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status)
+      }
+    },
+    {
+      key: {
         text: 'Completion date'
       },
       value: {
@@ -103,42 +171,18 @@
     },
     {
       key: {
-        text: 'Status'
+        text: 'Total time spent'
       },
       value: {
-        html: htmlUtils.getStatusTag(courseCompletion.status, 'green')
+        html: courseCompletion.totalTimeSpent
       }
     },
     {
       key: {
-        text: 'Total time minutes'
+        text: 'Course attempts'
       },
       value: {
-        html: courseCompletion.totalTimeMinutes
-      }
-    },
-    {
-      key: {
-        text: 'Expected time minutes'
-      },
-      value: {
-        html: courseCompletion.expectedTimeMinutes
-      }
-    },
-    {
-      key: {
-        text: 'Attempts'
-      },
-      value: {
-        html: courseCompletion.attempts
-      }
-    },
-    {
-      key: {
-        text: 'External reference'
-      },
-      value: {
-        html: courseCompletion.externalReference
+        html: (courseCompletion.attempts ~ ' out of 3')
       }
     }
   ]


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-861)

This updates the course details page to match the new designs, with three summary list components for the learner details, course details, and completion details. There's a small amount of time wrangling needed for the view.

The integration test for this is now very declarative but should be easy to keep in sync.

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

<img width="1440" height="1521" alt="course-completion-details" src="https://github.com/user-attachments/assets/41344fd4-4a59-4461-9ac9-31c749b40acb" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
