### PR TITLE
Update appointment routes

### DIFF
--- a/integration_tests/pages/appointments/attendanceOutcomePage.ts
+++ b/integration_tests/pages/appointments/attendanceOutcomePage.ts
@@ -20,9 +20,10 @@ export default class AttendanceOutcomePage extends Page {
 
   static visit(appointment: AppointmentDto): AttendanceOutcomePage {
     const path = pathWithQuery(
-      paths.appointments.attendanceOutcome({
+      paths.appointments.update({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'attendance-outcome',
       }),
       {
         form: '123',

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -50,9 +50,10 @@ export default class CheckAppointmentDetailsPage extends Page {
     originalSearch?: Record<string, string>,
   ): CheckAppointmentDetailsPage {
     const path = pathWithQuery(
-      paths.appointments.appointmentDetails({
+      paths.appointments.update({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'appointment-details',
       }),
       originalSearch,
     )

--- a/integration_tests/pages/appointments/chooseSupervisorPage.ts
+++ b/integration_tests/pages/appointments/chooseSupervisorPage.ts
@@ -23,9 +23,10 @@ export default class ChooseSupervisorPage extends Page {
 
   static visit(appointment: AppointmentDto): ChooseSupervisorPage {
     const path = pathWithQuery(
-      paths.appointments.chooseSupervisor({
+      paths.appointments.update({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'choose-supervisor',
       }),
       { form: '123' },
     )

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -24,7 +24,11 @@ export default class ConfirmDetailsPage extends Page {
 
   static visit(appointment: AppointmentDto, form: AppointmentOutcomeForm, formId: string): ConfirmDetailsPage {
     const path = pathWithQuery(
-      paths.appointments.confirm({ projectCode: appointment.projectCode, appointmentId: appointment.id.toString() }),
+      paths.appointments.update({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'confirm-details',
+      }),
       {
         form: formId,
       },

--- a/integration_tests/pages/appointments/logCompliancePage.ts
+++ b/integration_tests/pages/appointments/logCompliancePage.ts
@@ -21,9 +21,10 @@ export default class LogCompliancePage extends Page {
 
   static visit(appointment: AppointmentDto): LogCompliancePage {
     const path = pathWithQuery(
-      paths.appointments.logCompliance({
+      paths.appointments.update({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'log-compliance',
       }),
       {
         form: '123',

--- a/integration_tests/pages/appointments/logHoursPage.ts
+++ b/integration_tests/pages/appointments/logHoursPage.ts
@@ -20,7 +20,11 @@ export default class LogHoursPage extends Page {
 
   static visit(appointment: AppointmentDto): LogHoursPage {
     const path = pathWithQuery(
-      paths.appointments.logHours({ projectCode: appointment.projectCode, appointmentId: appointment.id.toString() }),
+      paths.appointments.update({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'log-hours',
+      }),
       {
         form: '123',
       },

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,4 +1,4 @@
-import type { Response } from 'express'
+import type { Response, RequestHandler } from 'express'
 import {
   AttendanceDataDto,
   ContactOutcomeDto,
@@ -235,4 +235,9 @@ export type ViewDataWithTimeToCredit = {
 export type BodyWithNotes = {
   notes?: string
   isSensitive?: YesOrNo
+}
+
+export interface IFormPageController {
+  show(): RequestHandler
+  submit(): RequestHandler
 }

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -4,9 +4,9 @@ import ReferenceDataService from '../../services/referenceDataService'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams } from '../../@types/user-defined'
+import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
 
-export default class AttendanceOutcomeController {
+export default class AttendanceOutcomeController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly referenceDataService: ReferenceDataService,

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -40,7 +40,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       res.render('appointments/update/chooseSupervisor', {
         ...page.viewData(appointment, teams, supervisors, form),
-        chooseSupervisorPath: paths.appointments.chooseSupervisor(appointmentParams),
+        chooseSupervisorPath: paths.appointments.update({ ...appointmentParams, page: 'choose-supervisor' }),
         form: page.formId,
         team,
       })
@@ -78,7 +78,7 @@ export default class ChooseSupervisorController implements IFormPageController {
           ...page.viewData(appointment, teams, supervisors, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
-          chooseSupervisorPath: paths.appointments.chooseSupervisor(appointmentParams),
+          chooseSupervisorPath: paths.appointments.update({ ...appointmentParams, page: 'choose-supervisor' }),
           form: page.formId,
         })
       }

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -4,10 +4,10 @@ import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams } from '../../@types/user-defined'
+import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
 import paths from '../../paths'
 
-export default class ChooseSupervisorController {
+export default class ChooseSupervisorController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -3,12 +3,12 @@ import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared'
-import { AppointmentOutcomeForm, AppointmentParams } from '../../@types/user-defined'
+import { AppointmentOutcomeForm, AppointmentParams, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 import NotesUtils from '../../utils/notesUtils'
 
-export default class ConfirmController {
+export default class ConfirmController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -9,6 +9,8 @@ import AppointmentDetailsController from './appointmentDetailsController'
 import AdjustTravelTimeController from './adjustTravelTimeController'
 import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
 import ChooseSupervisorController from './chooseSupervisorController'
+import { AppointmentFormPage } from '../../pages/appointments/pathMap'
+import { IFormPageController } from '../../@types/user-defined'
 
 const controllers = (services: Services) => {
   const attendanceOutcomeController = new AttendanceOutcomeController(
@@ -53,13 +55,17 @@ const controllers = (services: Services) => {
     services.projectService,
   )
 
+  const updateControllers: Record<AppointmentFormPage, IFormPageController> = {
+    'choose-supervisor': chooseSupervisorController,
+    'attendance-outcome': attendanceOutcomeController,
+    'log-hours': logHoursController,
+    'log-compliance': logComplianceController,
+    'confirm-details': confirmController,
+    'appointment-details': appointmentDetailsController,
+  }
+
   return {
-    attendanceOutcomeController,
-    confirmController,
-    logComplianceController,
-    logHoursController,
-    appointmentDetailsController,
-    chooseSupervisorController,
+    updateControllers,
     adjustTravelTimeController,
   }
 }

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -3,9 +3,9 @@ import AppointmentService from '../../services/appointmentService'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams } from '../../@types/user-defined'
+import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
 
-export default class LogComplianceController {
+export default class LogComplianceController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly formService: AppointmentFormService,

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -3,9 +3,9 @@ import AppointmentService from '../../services/appointmentService'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams } from '../../@types/user-defined'
+import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
 
-export default class LogHoursController {
+export default class LogHoursController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly formService: AppointmentFormService,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -237,14 +237,15 @@ describe('AttendanceOutcomePage', () => {
         { checked: false, text: 'No, they are not sensitive', value: 'no' },
       ]
 
-      jest.spyOn(paths.appointments, 'attendanceOutcome')
+      jest.spyOn(paths.appointments, 'update')
       jest.spyOn(paths.appointments, 'chooseSupervisor')
 
       const result = page.viewData(formWithOutcomes)
 
-      expect(paths.appointments.attendanceOutcome).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'attendance-outcome',
       })
       expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -376,10 +376,10 @@ describe('AttendanceOutcomePage', () => {
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] }).contactOutcomes,
         })
 
-        jest.spyOn(paths.appointments, 'logHours').mockReturnValue(path)
+        jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
         expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-        expect(paths.appointments.logHours).toHaveBeenCalledWith({ projectCode, appointmentId })
+        expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-hours' })
       })
     })
     describe('when the contact outcome is not attended', () => {
@@ -396,10 +396,10 @@ describe('AttendanceOutcomePage', () => {
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }).contactOutcomes,
         })
 
-        jest.spyOn(paths.appointments, 'confirm').mockReturnValue(path)
+        jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
         expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-        expect(paths.appointments.confirm).toHaveBeenCalledWith({ projectCode, appointmentId })
+        expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
       })
     })
   })

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -238,7 +238,6 @@ describe('AttendanceOutcomePage', () => {
       ]
 
       jest.spyOn(paths.appointments, 'update')
-      jest.spyOn(paths.appointments, 'chooseSupervisor')
 
       const result = page.viewData(formWithOutcomes)
 
@@ -247,9 +246,10 @@ describe('AttendanceOutcomePage', () => {
         appointmentId: appointment.id.toString(),
         page: 'attendance-outcome',
       })
-      expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'choose-supervisor',
       })
 
       expect(result).toEqual({

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -12,6 +12,7 @@ import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import NotesUtils from '../../utils/notesUtils'
+import { AppointmentFormPage } from './pathMap'
 
 export type AttendanceOutcomeBody = {
   attendanceOutcome: string
@@ -29,6 +30,8 @@ type ViewData = {
   AppointmentUpdatePageViewData
 
 export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'attendance-outcome'
+
   private query: AttendanceOutcomeQuery
 
   private appointment: AppointmentDto
@@ -108,15 +111,6 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
 
     return this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId }))
-  }
-
-  updatePath(): string {
-    return this.pathWithFormId(
-      paths.appointments.attendanceOutcome({
-        projectCode: this.appointment.projectCode,
-        appointmentId: this.appointment.id.toString(),
-      }),
-    )
   }
 
   private items(form: AppointmentOutcomeForm, hasErrors: boolean): { text: string; value: string }[] {

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -8,7 +8,6 @@ import {
   ViewDataWithNotes,
 } from '../../@types/user-defined'
 import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
-import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import NotesUtils from '../../utils/notesUtils'
@@ -98,14 +97,14 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return 'choose-supervisor'
   }
 
-  protected nextPath(projectCode: string, appointmentId: string): string {
+  protected nextPage(): AppointmentFormPage {
     const contactOutcome = this.contactOutcomes.find(outcome => outcome.code === this.query.attendanceOutcome)
 
     if (!contactOutcome?.attended) {
-      return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
+      return 'confirm-details'
     }
 
-    return this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId }))
+    return 'log-hours'
   }
 
   private items(form: AppointmentOutcomeForm, hasErrors: boolean): { text: string; value: string }[] {

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -94,13 +94,8 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  protected backPath(): string {
-    return this.pathWithFormId(
-      paths.appointments.chooseSupervisor({
-        projectCode: this.appointment.projectCode,
-        appointmentId: this.appointment.id.toString(),
-      }),
-    )
+  protected backPage(): AppointmentFormPage {
+    return 'choose-supervisor'
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -8,15 +8,16 @@ import Offender from '../../models/offender'
 import paths from '../../paths'
 import SessionUtils from '../../utils/sessionUtils'
 import { pathWithQuery } from '../../utils/utils'
+import { AppointmentFormPage } from './pathMap'
 
 export default abstract class BaseAppointmentUpdatePage {
   form?: AppointmentOutcomeForm
 
+  protected abstract page: AppointmentFormPage
+
   protected abstract nextPath(projectCode: string, appointmentId: string | AppointmentDto): string
 
   protected abstract backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>): string
-
-  abstract updatePath(appointment: AppointmentDto): string
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 
@@ -40,6 +41,16 @@ export default abstract class BaseAppointmentUpdatePage {
   updateForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm {
     this.form = this.getForm(form, ...args)
     return this.form
+  }
+
+  updatePath(appointment: AppointmentDto) {
+    return this.pathWithFormId(
+      paths.appointments.update({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: this.page,
+      }),
+    )
   }
 
   protected commonViewData(

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -17,7 +17,7 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract nextPath(projectCode: string, appointmentId: string | AppointmentDto): string
 
-  protected abstract backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>): string
+  protected abstract backPage(): AppointmentFormPage | undefined
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 
@@ -27,8 +27,8 @@ export default abstract class BaseAppointmentUpdatePage {
     this.formId = query.form?.toString()
   }
 
-  exitForm(appointment: AppointmentDto, project: ProjectDto, originalSearch: Record<string, string>): string {
-    if (project.projectType.group === 'GROUP') {
+  exitForm(appointment: AppointmentDto, project?: ProjectDto, originalSearch?: Record<string, string>): string {
+    if (project?.projectType.group === 'GROUP') {
       return SessionUtils.getSessionPath(appointment, originalSearch)
     }
     return pathWithQuery(paths.projects.show({ projectCode: appointment.projectCode }), originalSearch)
@@ -53,13 +53,33 @@ export default abstract class BaseAppointmentUpdatePage {
     )
   }
 
+  protected backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>, project?: ProjectDto) {
+    const backPage = this.backPage()
+
+    if (!backPage) {
+      return this.exitForm(appointment, project, originalSearch)
+    }
+
+    return pathWithQuery(
+      this.pathWithFormId(
+        paths.appointments.update({
+          projectCode: appointment.projectCode,
+          appointmentId: appointment.id.toString(),
+          page: backPage,
+        }),
+      ),
+      originalSearch,
+    )
+  }
+
   protected commonViewData(
     appointment: AppointmentDto,
     originalSearch?: Record<string, string>,
+    project?: ProjectDto,
   ): AppointmentUpdatePageViewData {
     return {
       offender: new Offender(appointment.offender),
-      backLink: this.backPath(appointment, originalSearch),
+      backLink: this.backPath(appointment, originalSearch, project),
       updatePath: this.updatePath(appointment),
       form: this.formId,
     }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -15,7 +15,7 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract page: AppointmentFormPage
 
-  protected abstract nextPath(projectCode: string, appointmentId: string | AppointmentDto): string
+  protected abstract nextPage(): AppointmentFormPage | undefined
 
   protected abstract backPage(): AppointmentFormPage | undefined
 
@@ -35,7 +35,19 @@ export default abstract class BaseAppointmentUpdatePage {
   }
 
   next(projectCode: string, appointmentId: string) {
-    return this.pathWithFormId(this.nextPath(projectCode, appointmentId))
+    const nextPage = this.nextPage()
+
+    if (!nextPage) {
+      throw new Error('No next page configured')
+    }
+
+    return this.pathWithFormId(
+      paths.appointments.update({
+        projectCode,
+        appointmentId,
+        page: nextPage,
+      }),
+    )
   }
 
   updateForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -34,7 +34,7 @@ describe('CheckAppointmentDetailsPage', () => {
     beforeEach(() => {
       page = new CheckAppointmentDetailsPage({}, projectFactory.build())
       appointment = appointmentFactory.build({ sensitive: false })
-      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue(updatePath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
 
     it('should return an object containing project details', () => {
@@ -207,9 +207,10 @@ describe('CheckAppointmentDetailsPage', () => {
         project: projectFactory.build(),
         originalSearch: {},
       })
-      expect(paths.appointments.appointmentDetails).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'appointment-details',
       })
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -217,7 +217,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
     it('should return an object containing the next path', () => {
       const nextPath = '/appointments/choose-supervisor'
-      jest.spyOn(paths.appointments, 'chooseSupervisor').mockReturnValue(nextPath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
       const result = page.viewData({
         appointment,
@@ -225,9 +225,10 @@ describe('CheckAppointmentDetailsPage', () => {
         originalSearch: {},
       })
 
-      expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'choose-supervisor',
       })
       expect(result.nextPath).toBe(pathWithQuery)
     })
@@ -563,16 +564,20 @@ describe('CheckAppointmentDetailsPage', () => {
   })
 
   describe('next', () => {
-    it('should return attendance outcome link with given appointmentId', () => {
+    it('should return supervisor link with given appointmentId', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const path = '/path'
       const page = new CheckAppointmentDetailsPage({}, projectFactory.build())
 
-      jest.spyOn(paths.appointments, 'chooseSupervisor').mockReturnValue(path)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode,
+        appointmentId,
+        page: 'choose-supervisor',
+      })
     })
   })
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -14,6 +14,7 @@ import HtmlUtils from '../../utils/htmlUtils'
 import LocationUtils from '../../utils/locationUtils'
 import { yesNoDisplayValue } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   projectItems: Array<GovUkSummaryListItem>
@@ -39,6 +40,8 @@ interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
 }
 
 export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'appointment-details'
+
   validationErrors: ValidationErrors<Body> = {}
 
   constructor(
@@ -219,14 +222,5 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
 
   protected nextPath(projectCode: string, appointmentId: string): string {
     return this.pathWithFormId(paths.appointments.chooseSupervisor({ projectCode, appointmentId }))
-  }
-
-  updatePath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.appointmentDetails({
-        appointmentId: appointment.id.toString(),
-        projectCode: appointment.projectCode,
-      }),
-    )
   }
 }

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -6,7 +6,6 @@ import {
   GovUkSummaryListItem,
   ValidationErrors,
 } from '../../@types/user-defined'
-import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import GovUKComponentUtils from '../../utils/govUkComponentUtils'
@@ -84,7 +83,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       sharedItems: this.buildSharedDetails(appointment),
       contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
       showMissingOutcomeMessage: this.isMissingOutcome(appointment),
-      nextPath: this.nextPath(appointment.projectCode, appointment.id.toString()),
+      nextPath: this.next(appointment.projectCode, appointment.id.toString()),
     }
   }
 
@@ -220,7 +219,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return undefined
   }
 
-  protected nextPath(projectCode: string, appointmentId: string): string {
-    return this.pathWithFormId(paths.appointments.chooseSupervisor({ projectCode, appointmentId }))
+  protected nextPage(): AppointmentFormPage {
+    return 'choose-supervisor'
   }
 }

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -75,7 +75,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     contactOutcome?: ContactOutcomeDto
   }): ViewData {
     return {
-      ...this.commonViewData(appointment, originalSearch),
+      ...this.commonViewData(appointment, originalSearch, project),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
       showContinueButton: !appointment.contactOutcomeCode,
@@ -216,8 +216,8 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return GovUKComponentUtils.buildSummaryListItems(items, true)
   }
 
-  protected backPath(appointment: AppointmentDto, originalSearch: Record<string, string>): string {
-    return this.exitForm(appointment, this.project, originalSearch)
+  protected backPage(): AppointmentFormPage | undefined {
+    return undefined
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -156,10 +156,10 @@ describe('ChooseSupervisorPage', () => {
       const query = { supervisor: 'Jane' }
       const page = new ChooseSupervisorPage(query, appointmentFactory.build())
 
-      jest.spyOn(paths.appointments, 'attendanceOutcome').mockReturnValue(path)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.attendanceOutcome).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'attendance-outcome' })
     })
   })
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -34,14 +34,15 @@ describe('ChooseSupervisorPage', () => {
       supervisors = supervisorSummaryFactory.buildList(2)
       form = appointmentOutcomeFormFactory.build()
       teams = { providers: providerTeamSummaryFactory.buildList(3) }
-      jest.spyOn(paths.appointments, 'chooseSupervisor').mockReturnValue(updatePath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
 
     it('should return an object containing an update link for the form', async () => {
       const result = page.viewData(appointment, teams, supervisors, form)
-      expect(paths.appointments.chooseSupervisor).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'choose-supervisor',
       })
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -7,7 +7,6 @@ import {
   ValidationErrors,
 } from '../../@types/user-defined'
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
-import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
@@ -89,7 +88,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     return 'appointment-details'
   }
 
-  protected nextPath(projectCode: string, appointmentId: string): string {
-    return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
+  protected nextPage(): AppointmentFormPage {
+    return 'attendance-outcome'
   }
 }

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -85,13 +85,8 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  protected backPath(): string {
-    return this.pathWithFormId(
-      paths.appointments.appointmentDetails({
-        projectCode: this.appointment.projectCode,
-        appointmentId: this.appointment.id.toString(),
-      }),
-    )
+  protected backPage(): AppointmentFormPage {
+    return 'appointment-details'
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -9,6 +9,7 @@ import {
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import paths from '../../paths'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   teamItems: GovUkSelectOption[]
@@ -26,6 +27,8 @@ interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
 }
 
 export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'choose-supervisor'
+
   validationErrors: ValidationErrors<Body> = {}
 
   constructor(
@@ -93,14 +96,5 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
 
   protected nextPath(projectCode: string, appointmentId: string): string {
     return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
-  }
-
-  updatePath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.chooseSupervisor({
-        appointmentId: appointment.id.toString(),
-        projectCode: appointment.projectCode,
-      }),
-    )
   }
 }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -50,29 +50,31 @@ describe('ConfirmPage', () => {
 
     describe('back link', () => {
       it('should return an object containing a back link to the compliance page if attended', async () => {
-        jest.spyOn(paths.appointments, 'logCompliance')
+        jest.spyOn(paths.appointments, 'update')
         const formWithoutEnforcement = appointmentOutcomeFormFactory.build({
           contactOutcome: contactOutcomeFactory.build({ attended: true }),
         })
 
         const result = page.viewData(appointment, formWithoutEnforcement)
-        expect(paths.appointments.logCompliance).toHaveBeenCalledWith({
+        expect(paths.appointments.update).toHaveBeenCalledWith({
           projectCode: appointment.projectCode,
           appointmentId: appointment.id.toString(),
+          page: 'log-compliance',
         })
         expect(result.backLink).toBe(pathWithQuery)
       })
 
       it('should return an object containing a back link to the attendance outcome page if did not attend', async () => {
-        jest.spyOn(paths.appointments, 'attendanceOutcome')
+        jest.spyOn(paths.appointments, 'update')
         const formWithoutEnforcement = appointmentOutcomeFormFactory.build({
           contactOutcome: contactOutcomeFactory.build({ attended: false }),
         })
 
         const result = page.viewData(appointment, formWithoutEnforcement)
-        expect(paths.appointments.attendanceOutcome).toHaveBeenCalledWith({
+        expect(paths.appointments.update).toHaveBeenCalledWith({
           projectCode: appointment.projectCode,
           appointmentId: appointment.id.toString(),
+          page: 'attendance-outcome',
         })
         expect(result.backLink).toBe(pathWithQuery)
       })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -79,12 +79,13 @@ describe('ConfirmPage', () => {
     })
 
     it('should return an object containing an update link for the form', async () => {
-      jest.spyOn(paths.appointments, 'confirm')
+      jest.spyOn(paths.appointments, 'update')
 
       const result = page.viewData(appointment, form)
-      expect(paths.appointments.confirm).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'confirm-details',
       })
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -539,7 +539,7 @@ describe('ConfirmPage', () => {
   describe('nextPath', () => {
     it('should throw not implemented error', () => {
       const page = new ConfirmPage({})
-      expect(() => page.next('', '')).toThrow(new Error('Method not implemented'))
+      expect(() => page.next('', '')).toThrow(new Error('No next page configured'))
     })
   })
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -13,6 +13,7 @@ import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import NotesUtils from '../../utils/notesUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   alertPractitionerItems: GovUkRadioOption[]
@@ -26,6 +27,8 @@ interface Query extends AppointmentUpdateQuery {
 }
 
 export default class ConfirmPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'confirm-details'
+
   constructor(private readonly query: Query) {
     super(query)
   }
@@ -65,15 +68,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       return this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId }))
     }
     return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
-  }
-
-  updatePath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.confirm({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-      }),
-    )
   }
 
   private getStartAndEndTime(form: AppointmentOutcomeForm) {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -56,8 +56,8 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.alertPractitioner)
   }
 
-  protected nextPath(_projectCode: string, _appointmentId: string): string {
-    throw new Error('Method not implemented')
+  protected nextPage(): AppointmentFormPage | undefined {
+    return undefined
   }
 
   protected backPage(): AppointmentFormPage {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -100,9 +100,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   }
 
   private formItems(form: AppointmentOutcomeForm, appointment: AppointmentDto): GovUkSummaryListItem[] {
-    const appointmentId = appointment.id.toString()
-    const { projectCode } = appointment
-
     const items = [
       {
         key: {
@@ -114,7 +111,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.pathWithFormId(paths.appointments.chooseSupervisor({ projectCode, appointmentId })),
+              href: this.changePath(appointment, 'choose-supervisor'),
               text: 'Change',
               visuallyHiddenText: 'supervising officer',
             },
@@ -131,18 +128,14 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
+              href: this.changePath(appointment, 'attendance-outcome'),
               text: 'Change',
               visuallyHiddenText: 'attendance outcome',
             },
           ],
         },
       },
-      ...NotesUtils.checkYourAnswersRows(
-        form,
-        this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId })),
-        appointment,
-      ),
+      ...NotesUtils.checkYourAnswersRows(form, this.changePath(appointment, 'attendance-outcome'), appointment),
       {
         key: {
           text: 'Start and end time',
@@ -154,7 +147,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           items: form.contactOutcome.attended
             ? [
                 {
-                  href: this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId })),
+                  href: this.changePath(appointment, 'log-hours'),
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
                 },
@@ -177,7 +170,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
             actions: {
               items: [
                 {
-                  href: this.pathWithFormId(paths.appointments.logHours({ projectCode, appointmentId })),
+                  href: this.changePath(appointment, 'log-hours'),
                   text: 'Change',
                   visuallyHiddenText: 'penalty hours',
                 },
@@ -194,7 +187,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
             actions: {
               items: [
                 {
-                  href: this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId })),
+                  href: this.changePath(appointment, 'log-compliance'),
                   text: 'Change',
                   visuallyHiddenText: 'compliance',
                 },
@@ -206,6 +199,16 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     }
 
     return items
+  }
+
+  private changePath(appointment: AppointmentDto, page: AppointmentFormPage) {
+    return this.pathWithFormId(
+      paths.appointments.update({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page,
+      }),
+    )
   }
 
   getComplianceAnswers(form: AppointmentOutcomeForm): string {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -60,14 +60,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     throw new Error('Method not implemented')
   }
 
-  protected backPath(appointment: AppointmentDto): string {
-    const appointmentId = appointment.id.toString()
-    const { projectCode } = appointment
-
+  protected backPage(): AppointmentFormPage {
     if (this.form && this.form.contactOutcome?.attended) {
-      return this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId }))
+      return 'log-compliance'
     }
-    return this.pathWithFormId(paths.appointments.attendanceOutcome({ projectCode, appointmentId }))
+    return 'attendance-outcome'
   }
 
   private getStartAndEndTime(form: AppointmentOutcomeForm) {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -57,12 +57,13 @@ describe('LogCompliancePage', () => {
 
     it('should return an object containing an update link for the form', async () => {
       const updatePath = '/update'
-      jest.spyOn(paths.appointments, 'logCompliance').mockReturnValue(updatePath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
 
       const result = page.viewData(appointment, form)
-      expect(paths.appointments.logCompliance).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         appointmentId: appointment.id.toString(),
         projectCode: appointment.projectCode,
+        page: 'log-compliance',
       })
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -244,10 +244,10 @@ describe('LogCompliancePage', () => {
       const nextPath = '/path'
       page = new LogCompliancePage({})
 
-      jest.spyOn(paths.appointments, 'confirm').mockReturnValue(nextPath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.confirm).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
 
     it('should return confirm page link with given appointmentId', () => {
@@ -259,10 +259,10 @@ describe('LogCompliancePage', () => {
       page = new LogCompliancePage({})
       page.updateForm(existingForm)
 
-      jest.spyOn(paths.appointments, 'confirm').mockReturnValue(nextPath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.confirm).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
   })
 

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -49,10 +49,15 @@ describe('LogCompliancePage', () => {
 
     it('should return an object containing a back link to the session page', async () => {
       const backLink = '/appointment/1'
-      jest.spyOn(paths.appointments, 'logHours').mockReturnValue(backLink)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(backLink)
 
       const result = page.viewData(appointment, form)
       expect(result.backLink).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'log-hours',
+      })
     })
 
     it('should return an object containing an update link for the form', async () => {

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -10,6 +10,7 @@ import {
 import paths from '../../paths'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   hiVisItems: GovUkRadioOption[]
@@ -33,6 +34,8 @@ export interface LogComplianceQuery extends AppointmentUpdateQuery {
 }
 
 export default class LogCompliancePage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'log-compliance'
+
   hasError: boolean
 
   validationErrors: ValidationErrors<Body> = {}
@@ -101,15 +104,6 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
 
   protected nextPath(projectCode: string, appointmentId: string): string {
     return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
-  }
-
-  updatePath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.logCompliance({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-      }),
-    )
   }
 
   private getItems(checkedValue?: string) {

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -93,13 +93,8 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     this.hasError = Object.keys(this.validationErrors).length > 0
   }
 
-  protected backPath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.logHours({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-      }),
-    )
+  protected backPage(): AppointmentFormPage {
+    return 'log-hours'
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -7,7 +7,6 @@ import {
   ValidationErrors,
   YesOrNo,
 } from '../../@types/user-defined'
-import paths from '../../paths'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
@@ -97,8 +96,8 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     return 'log-hours'
   }
 
-  protected nextPath(projectCode: string, appointmentId: string): string {
-    return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
+  protected nextPage(): AppointmentFormPage {
+    return 'confirm-details'
   }
 
   private getItems(checkedValue?: string) {

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -401,11 +401,12 @@ describe('LogHoursPage', () => {
     })
 
     it('should return the update path for the page', () => {
-      jest.spyOn(paths.appointments, 'logHours')
+      jest.spyOn(paths.appointments, 'update')
       const result = page.viewData(appointment, form)
-      expect(paths.appointments.logHours).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'log-hours',
       })
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -236,7 +236,7 @@ describe('LogHoursPage', () => {
       page = new LogHoursPage()
       appointment = appointmentFactory.build()
       form = appointmentOutcomeFormFactory.build({ contactOutcome: contactOutcomeFactory.build({ attended: true }) })
-      jest.spyOn(paths.appointments, 'logHours').mockReturnValue(updatePath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
 
     it('should return an object containing start time and end time', () => {
@@ -390,12 +390,13 @@ describe('LogHoursPage', () => {
     })
 
     it('should return an object containing a back link to the attendance outcome page', async () => {
-      jest.spyOn(paths.appointments, 'attendanceOutcome')
+      jest.spyOn(paths.appointments, 'update')
       const result = page.viewData(appointment, form)
 
-      expect(paths.appointments.attendanceOutcome).toHaveBeenCalledWith({
+      expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: 'attendance-outcome',
       })
       expect(result.backLink).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -423,10 +423,10 @@ describe('LogHoursPage', () => {
       page = new LogHoursPage({})
       page.updateForm(form)
 
-      jest.spyOn(paths.appointments, 'logCompliance').mockReturnValue(nextPath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.logCompliance).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-compliance' })
     })
 
     it('if contact outcome not attended - should return confirm details link with given appointmentId', () => {
@@ -440,10 +440,10 @@ describe('LogHoursPage', () => {
         }),
       )
 
-      jest.spyOn(paths.appointments, 'confirm').mockReturnValue(nextPath)
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
       expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
-      expect(paths.appointments.confirm).toHaveBeenCalledWith({ projectCode, appointmentId })
+      expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
   })
 

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -172,13 +172,8 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     return viewData
   }
 
-  protected backPath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.attendanceOutcome({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-      }),
-    )
+  protected backPage(): AppointmentFormPage {
+    return 'attendance-outcome'
   }
 
   protected nextPath(projectCode: string, appointmentId: string): string {

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -6,7 +6,6 @@ import {
   ValidationErrors,
 } from '../../@types/user-defined'
 import Offender from '../../models/offender'
-import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
@@ -176,11 +175,11 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     return 'attendance-outcome'
   }
 
-  protected nextPath(projectCode: string, appointmentId: string): string {
+  protected nextPage(): AppointmentFormPage {
     if (this.form.contactOutcome && this.form.contactOutcome.attended) {
-      return this.pathWithFormId(paths.appointments.logCompliance({ projectCode, appointmentId }))
+      return 'log-compliance'
     }
 
-    return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
+    return 'confirm-details'
   }
 }

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -9,6 +9,7 @@ import Offender from '../../models/offender'
 import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   offender: Offender
@@ -34,6 +35,8 @@ export interface LogHoursQuery extends AppointmentUpdateQuery {
 }
 
 export default class LogHoursPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'log-hours'
+
   hasErrors: boolean
 
   validationErrors: ValidationErrors<LogHoursBody> = {}
@@ -184,14 +187,5 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     }
 
     return this.pathWithFormId(paths.appointments.confirm({ projectCode, appointmentId }))
-  }
-
-  updatePath(appointment: AppointmentDto): string {
-    return this.pathWithFormId(
-      paths.appointments.logHours({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-      }),
-    )
   }
 }

--- a/server/pages/appointments/pathMap.ts
+++ b/server/pages/appointments/pathMap.ts
@@ -1,0 +1,7 @@
+export type AppointmentFormPage =
+  | 'choose-supervisor'
+  | 'attendance-outcome'
+  | 'log-hours'
+  | 'log-compliance'
+  | 'confirm-details'
+  | 'appointment-details'

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -33,7 +33,7 @@ const paths = {
   },
   appointments: {
     create: courseCompletionsShowPath.path('create-new-appointment'),
-    update: appointmentPath.path('update'),
+    update: appointmentPath.path(':page'),
     appointmentDetails: appointmentPath.path('appointment-details'),
     chooseSupervisor: appointmentPath.path('choose-supervisor'),
     attendanceOutcome: appointmentPath.path('attendance-outcome'),

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -34,12 +34,6 @@ const paths = {
   appointments: {
     create: courseCompletionsShowPath.path('create-new-appointment'),
     update: appointmentPath.path(':page'),
-    appointmentDetails: appointmentPath.path('appointment-details'),
-    chooseSupervisor: appointmentPath.path('choose-supervisor'),
-    attendanceOutcome: appointmentPath.path('attendance-outcome'),
-    logHours: appointmentPath.path('log-hours'),
-    logCompliance: appointmentPath.path('log-compliance'),
-    confirm: appointmentPath.path('confirm-details'),
     travelTime: {
       index: appointmentsPath.path('attended'),
       filter: appointmentsPath.path('attended').path('filter'),

--- a/server/routes/appointment.ts
+++ b/server/routes/appointment.ts
@@ -34,48 +34,6 @@ export default function appointmentRoutes(controllers: Controllers, router: Rout
     return handler(req, res, next)
   })
 
-  get(paths.appointments.appointmentDetails.pattern, updateControllers['appointment-details'].show(), {
-    auditEvent: Page.VIEW_APPOINTMENT,
-  })
-  post(paths.appointments.appointmentDetails.pattern, updateControllers['appointment-details'].submit(), {
-    auditEvent: Page.EDIT_APPOINTMENT_DETAILS_PAGE,
-  })
-
-  get(paths.appointments.chooseSupervisor.pattern, updateControllers['choose-supervisor'].show(), {
-    auditEvent: Page.VIEW_CHOOSE_SUPERVISOR_PAGE,
-  })
-  post(paths.appointments.chooseSupervisor.pattern, updateControllers['choose-supervisor'].submit(), {
-    auditEvent: Page.EDIT_CHOOSE_SUPERVISOR_PAGE,
-  })
-
-  get(paths.appointments.attendanceOutcome.pattern, updateControllers['attendance-outcome'].show(), {
-    auditEvent: Page.VIEW_APPOINTMENT_ATTENDANCE_OUTCOME_PAGE,
-  })
-  post(paths.appointments.attendanceOutcome.pattern, updateControllers['attendance-outcome'].submit(), {
-    auditEvent: Page.EDIT_APPOINTMENT_ATTENDANCE_OUTCOME_PAGE,
-  })
-
-  get(paths.appointments.logHours.pattern, updateControllers['log-hours'].show(), {
-    auditEvent: Page.VIEW_APPOINTMENT_LOG_HOURS_PAGE,
-  })
-  post(paths.appointments.logHours.pattern, updateControllers['log-hours'].submit(), {
-    auditEvent: Page.EDIT_APPOINTMENT_LOG_HOURS_PAGE,
-  })
-
-  get(paths.appointments.logCompliance.pattern, updateControllers['log-compliance'].show(), {
-    auditEvent: Page.VIEW_APPOINTMENT_LOG_COMPLIANCE_PAGE,
-  })
-  post(paths.appointments.logCompliance.pattern, updateControllers['log-compliance'].submit(), {
-    auditEvent: Page.EDIT_APPOINTMENT_LOG_COMPLIANCE_PAGE,
-  })
-
-  get(paths.appointments.confirm.pattern, updateControllers['confirm-details'].show(), {
-    auditEvent: Page.VIEW_APPOINTMENT_CONFIRM_PAGE,
-  })
-  post(paths.appointments.confirm.pattern, updateControllers['confirm-details'].submit(), {
-    auditEvent: Page.EDIT_APPOINTMENT,
-  })
-
   get(paths.appointments.travelTime.index.pattern, adjustTravelTimeController.index(), {
     auditEvent: Page.SEARCH_TRAVEL_TIME_TASKS,
   })

--- a/server/routes/appointment.ts
+++ b/server/routes/appointment.ts
@@ -3,11 +3,36 @@ import paths from '../paths'
 import type { Controllers } from '../controllers'
 import { Page } from '../services/auditService'
 import { actions } from './utils'
+import { AppointmentFormPage } from '../pages/appointments/pathMap'
 
 export default function appointmentRoutes(controllers: Controllers, router: Router): Router {
   const { appointments: { updateControllers, adjustTravelTimeController } = {} } = controllers
 
   const { get, post } = actions(router)
+
+  get(paths.appointments.update.pattern, async (req, res, next) => {
+    const page = req.params.page as AppointmentFormPage
+    const controller = updateControllers[page]
+
+    if (!controller) {
+      return next()
+    }
+
+    const handler = controller.show()
+    return handler(req, res, next)
+  })
+
+  post(paths.appointments.update.pattern, async (req, res, next) => {
+    const page = req.params.page as AppointmentFormPage
+    const controller = updateControllers[page]
+
+    if (!controller) {
+      return next()
+    }
+
+    const handler = controller.submit()
+    return handler(req, res, next)
+  })
 
   get(paths.appointments.appointmentDetails.pattern, updateControllers['appointment-details'].show(), {
     auditEvent: Page.VIEW_APPOINTMENT,

--- a/server/routes/appointment.ts
+++ b/server/routes/appointment.ts
@@ -5,57 +5,49 @@ import { Page } from '../services/auditService'
 import { actions } from './utils'
 
 export default function appointmentRoutes(controllers: Controllers, router: Router): Router {
-  const {
-    appointments: {
-      attendanceOutcomeController,
-      logComplianceController,
-      logHoursController,
-      appointmentDetailsController,
-      chooseSupervisorController,
-      confirmController,
-      adjustTravelTimeController,
-    } = {},
-  } = controllers
+  const { appointments: { updateControllers, adjustTravelTimeController } = {} } = controllers
 
   const { get, post } = actions(router)
 
-  get(paths.appointments.appointmentDetails.pattern, appointmentDetailsController.show(), {
+  get(paths.appointments.appointmentDetails.pattern, updateControllers['appointment-details'].show(), {
     auditEvent: Page.VIEW_APPOINTMENT,
   })
-  post(paths.appointments.appointmentDetails.pattern, appointmentDetailsController.submit(), {
+  post(paths.appointments.appointmentDetails.pattern, updateControllers['appointment-details'].submit(), {
     auditEvent: Page.EDIT_APPOINTMENT_DETAILS_PAGE,
   })
 
-  get(paths.appointments.chooseSupervisor.pattern, chooseSupervisorController.show(), {
+  get(paths.appointments.chooseSupervisor.pattern, updateControllers['choose-supervisor'].show(), {
     auditEvent: Page.VIEW_CHOOSE_SUPERVISOR_PAGE,
   })
-  post(paths.appointments.chooseSupervisor.pattern, chooseSupervisorController.submit(), {
+  post(paths.appointments.chooseSupervisor.pattern, updateControllers['choose-supervisor'].submit(), {
     auditEvent: Page.EDIT_CHOOSE_SUPERVISOR_PAGE,
   })
 
-  get(paths.appointments.attendanceOutcome.pattern, attendanceOutcomeController.show(), {
+  get(paths.appointments.attendanceOutcome.pattern, updateControllers['attendance-outcome'].show(), {
     auditEvent: Page.VIEW_APPOINTMENT_ATTENDANCE_OUTCOME_PAGE,
   })
-  post(paths.appointments.attendanceOutcome.pattern, attendanceOutcomeController.submit(), {
+  post(paths.appointments.attendanceOutcome.pattern, updateControllers['attendance-outcome'].submit(), {
     auditEvent: Page.EDIT_APPOINTMENT_ATTENDANCE_OUTCOME_PAGE,
   })
 
-  get(paths.appointments.logHours.pattern, logHoursController.show(), {
+  get(paths.appointments.logHours.pattern, updateControllers['log-hours'].show(), {
     auditEvent: Page.VIEW_APPOINTMENT_LOG_HOURS_PAGE,
   })
-  post(paths.appointments.logHours.pattern, logHoursController.submit(), {
+  post(paths.appointments.logHours.pattern, updateControllers['log-hours'].submit(), {
     auditEvent: Page.EDIT_APPOINTMENT_LOG_HOURS_PAGE,
   })
 
-  get(paths.appointments.logCompliance.pattern, logComplianceController.show(), {
+  get(paths.appointments.logCompliance.pattern, updateControllers['log-compliance'].show(), {
     auditEvent: Page.VIEW_APPOINTMENT_LOG_COMPLIANCE_PAGE,
   })
-  post(paths.appointments.logCompliance.pattern, logComplianceController.submit(), {
+  post(paths.appointments.logCompliance.pattern, updateControllers['log-compliance'].submit(), {
     auditEvent: Page.EDIT_APPOINTMENT_LOG_COMPLIANCE_PAGE,
   })
 
-  get(paths.appointments.confirm.pattern, confirmController.show(), { auditEvent: Page.VIEW_APPOINTMENT_CONFIRM_PAGE })
-  post(paths.appointments.confirm.pattern, confirmController.submit(), {
+  get(paths.appointments.confirm.pattern, updateControllers['confirm-details'].show(), {
+    auditEvent: Page.VIEW_APPOINTMENT_CONFIRM_PAGE,
+  })
+  post(paths.appointments.confirm.pattern, updateControllers['confirm-details'].submit(), {
     auditEvent: Page.EDIT_APPOINTMENT,
   })
 

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -88,7 +88,7 @@ describe('SessionUtils', () => {
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
       jest.spyOn(DateTimeFormats, 'minutesToHoursAndMinutes').mockReturnValue('1:00')
-      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+      jest.spyOn(paths.appointments, 'update').mockReturnValue('/appointment-details')
 
       const appointments = [appointmentSummaryFactory.build({ contactOutcome: null })]
       const session = sessionFactory.build({ appointmentSummaries: appointments })
@@ -175,7 +175,7 @@ describe('SessionUtils', () => {
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
       jest.spyOn(DateTimeFormats, 'minutesToHoursAndMinutes').mockReturnValue('1:00')
-      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+      jest.spyOn(paths.appointments, 'update').mockReturnValue('/appointment-details')
 
       const appointments = [appointmentSummaryFactory.build({ contactOutcome: null })]
       const session = sessionFactory.build({ appointmentSummaries: appointments })
@@ -195,7 +195,7 @@ describe('SessionUtils', () => {
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
       jest.spyOn(DateTimeFormats, 'minutesToHoursAndMinutes').mockReturnValue('1:00')
-      jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+      jest.spyOn(paths.appointments, 'update').mockReturnValue('/appointment-details')
 
       const appointments = [appointmentSummaryFactory.build({ contactOutcome: contactOutcomeFactory.build() })]
       const session = sessionFactory.build({ appointmentSummaries: appointments })
@@ -257,7 +257,7 @@ describe('SessionUtils', () => {
         const offender = new Offender(offenderDto)
         jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
         jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
-        jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+        jest.spyOn(paths.appointments, 'update').mockReturnValue('/appointment-details')
 
         const result = SessionUtils.getAppointmentActionCell({
           appointmentId,
@@ -271,9 +271,10 @@ describe('SessionUtils', () => {
         expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
           `Update ${mockHiddenText}`,
           pathWithQuery(
-            paths.appointments.appointmentDetails({
+            paths.appointments.update({
               projectCode,
               appointmentId: appointmentId.toString(),
+              page: 'appointment-details',
             }),
             search,
           ),
@@ -301,7 +302,7 @@ describe('SessionUtils', () => {
         const offender = new Offender(offenderDto)
         jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
         jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)
-        jest.spyOn(paths.appointments, 'appointmentDetails').mockReturnValue('/appointment-details')
+        jest.spyOn(paths.appointments, 'update').mockReturnValue('/appointment-details')
 
         const result = SessionUtils.getAppointmentActionCell({
           appointmentId,
@@ -316,9 +317,10 @@ describe('SessionUtils', () => {
         expect(HtmlUtils.getAnchor).toHaveBeenCalledWith(
           `View ${mockHiddenText}`,
           pathWithQuery(
-            paths.appointments.appointmentDetails({
+            paths.appointments.update({
               projectCode,
               appointmentId: appointmentId.toString(),
+              page: 'appointment-details',
             }),
             search,
           ),

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -352,6 +352,14 @@ describe('SessionUtils', () => {
       expect(path).toBe(`/sessions/${appointment.projectCode}/${appointment.date}`)
     })
 
+    it('returns expected path when query parameter is not provided', () => {
+      const session = sessionSummaryFactory.build()
+      const path = SessionUtils.getSessionPath(session)
+
+      expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: session.projectCode, date: session.date })
+      expect(path).toBe(`/sessions/${session.projectCode}/${session.date}`)
+    })
+
     it('returns path with original search params', () => {
       const search = { provider: 'provider', team: 'team' }
       const session = sessionSummaryFactory.build()

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -57,7 +57,7 @@ export default class SessionUtils {
     })
   }
 
-  static getSessionPath(session: SessionSummaryDto | AppointmentDto, query: Record<string, string>) {
+  static getSessionPath(session: SessionSummaryDto | AppointmentDto, query?: Record<string, string>) {
     const { date, projectCode } = session
     return pathWithQuery(paths.sessions.show({ projectCode, date }), query)
   }

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -80,7 +80,11 @@ export default class SessionUtils {
     const linkHtml = HtmlUtils.getAnchor(
       actionContent,
       pathWithQuery(
-        paths.appointments.appointmentDetails({ appointmentId: appointmentId.toString(), projectCode }),
+        paths.appointments.update({
+          appointmentId: appointmentId.toString(),
+          projectCode,
+          page: 'appointment-details',
+        }),
         originalSearch,
       ),
     )


### PR DESCRIPTION
## Context

This PR consolidates the appointment update journey into a single dynamic route (`/appointments/:projectCode/:appointmentId/:page`) and updates the appointment form page models to use that unified route across the appointment form flow.

This is to enable the introduction of an alternative route pattern with different parameters for a bulk update appointment journey, using this more consolidated logic.

It also brings the implementation inline with the course completions form routing logic.

## Changes in this PR

- Replaced per-page appointment routes with a single :page route and a controller form map keyed by AppointmentFormPage.
- Refactored appointment update pages to use central path implementation with delegated page, nextPage() and backPage() values.

**Note:** 
This update removes the audit log at page view level. I am going to look at implementing this along with CRN(s) at the controller level, or if not will introduce the ability to build the audit event using the request parameters in a future PR.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
