### PR TITLE
CPB-874 Show previous attempts on course completion page

### DIFF
--- a/integration_tests/pages/courseCompletions/completionDetailsComponent.ts
+++ b/integration_tests/pages/courseCompletions/completionDetailsComponent.ts
@@ -1,0 +1,31 @@
+import { EteCourseCompletionEventDto } from '../../../server/@types/shared'
+import CourseCompletionUtils from '../../../server/utils/courseCompletionUtils'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import SummaryListComponent from '../components/summaryListComponent'
+
+export default class CompletionDetailsComponent {
+  private readonly details: SummaryListComponent
+
+  constructor(private readonly title: string = 'Completion details') {
+    this.details = new SummaryListComponent(this.title)
+  }
+
+  shouldShowCompletionDetails(courseCompletion: EteCourseCompletionEventDto) {
+    const completionDate = DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime)
+    const timeSpent = DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes)
+    const status = CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status)
+
+    this.details
+      .getValueWithLabel(`Attempt ${courseCompletion.attempts}`)
+      .should('contain.text', completionDate)
+      .should('contain.text', timeSpent)
+      .should('contain.text', status)
+  }
+
+  shouldShowAttemptPlaceholder({ attempt }: { attempt: number }) {
+    this.details
+      .getValueWithLabel(`Attempt ${attempt}`)
+      .should('contain.text', 'Details in Community Campus')
+      .should('contain.text', 'Fail')
+  }
+}

--- a/integration_tests/pages/courseCompletions/courseCompletionPage.ts
+++ b/integration_tests/pages/courseCompletions/courseCompletionPage.ts
@@ -48,7 +48,6 @@ export default class CourseCompletionPage extends Page {
     const expectedPlus20 = dateTimeUtils.totalMinutesToHoursAndMinutesParts(
       this.courseCompletion.expectedTimeMinutes * 1.2,
     )
-    const total = dateTimeUtils.totalMinutesToHoursAndMinutesParts(this.courseCompletion.totalTimeMinutes)
 
     const courseMap: { [index: string]: string } = {
       'Course name': this.courseCompletion.courseName,
@@ -61,20 +60,24 @@ export default class CourseCompletionPage extends Page {
       ),
     }
 
-    const completionMap: { [index: string]: string } = {
-      'Completion status': CourseCompletionUtils.formattedCourseCompletionLabel(this.courseCompletion.status),
-      'Completion date': dateTimeUtils.isoDateToUIDate(this.courseCompletion.completionDateTime),
-      'Total time spent': dateTimeUtils.hoursAndMinutesToHumanReadable(+total.hours, +total.minutes),
-      'Course attempts': `${this.courseCompletion.attempts} out of 3`,
-    }
-
-    const maps = [learnerMap, courseMap, completionMap]
+    const maps = [learnerMap, courseMap]
 
     maps.forEach((map, i) => {
       Object.entries(map).forEach(([label, value]) => {
         summaryLists[i].getValueWithLabel(label).should('contain.text', value)
       })
     })
+
+    const completionDate = dateTimeUtils.isoDateToUIDate(this.courseCompletion.completionDateTime)
+    const timeSpent = dateTimeUtils.totalMinutesToHumanReadableHoursAndMinutes(this.courseCompletion.totalTimeMinutes)
+    const status = CourseCompletionUtils.formattedCourseCompletionLabel(this.courseCompletion.status)
+
+    this.completionDetails
+      .getValueWithLabel(`Attempt ${this.courseCompletion.attempts}`)
+      .should('contain.text', 'Pass')
+      .should('contain.text', completionDate)
+      .should('contain.text', timeSpent)
+      .should('contain.text', status)
   }
 
   clickProcess() {

--- a/integration_tests/pages/courseCompletions/courseCompletionPage.ts
+++ b/integration_tests/pages/courseCompletions/courseCompletionPage.ts
@@ -5,20 +5,20 @@ import Page from '../page'
 import dateTimeUtils from '../../../server/utils/dateTimeUtils'
 import { CourseCompletionPageInput } from '../../../server/pages/courseCompletionIndexPage'
 import { pathWithQuery } from '../../../server/utils/utils'
-import CourseCompletionUtils from '../../../server/utils/courseCompletionUtils'
+import CompletionDetailsComponent from './completionDetailsComponent'
 
 export default class CourseCompletionPage extends Page {
   private learnerDetails: SummaryListComponent
 
   private courseDetails: SummaryListComponent
 
-  private completionDetails: SummaryListComponent
+  completionDetails: CompletionDetailsComponent
 
   constructor(private readonly courseCompletion: EteCourseCompletionEventDto) {
     super(`${courseCompletion.firstName} ${courseCompletion.lastName}`)
     this.learnerDetails = new SummaryListComponent('Learner details')
     this.courseDetails = new SummaryListComponent('Course details')
-    this.completionDetails = new SummaryListComponent('Completion details')
+    this.completionDetails = new CompletionDetailsComponent()
   }
 
   static visit(
@@ -32,7 +32,7 @@ export default class CourseCompletionPage extends Page {
   }
 
   shouldShowCourseCompletionDetails() {
-    const summaryLists = [this.learnerDetails, this.courseDetails, this.completionDetails]
+    const summaryLists = [this.learnerDetails, this.courseDetails]
 
     const learnerMap: { [index: string]: string } = {
       'First name': this.courseCompletion.firstName,
@@ -68,16 +68,7 @@ export default class CourseCompletionPage extends Page {
       })
     })
 
-    const completionDate = dateTimeUtils.isoDateToUIDate(this.courseCompletion.completionDateTime)
-    const timeSpent = dateTimeUtils.totalMinutesToHumanReadableHoursAndMinutes(this.courseCompletion.totalTimeMinutes)
-    const status = CourseCompletionUtils.formattedCourseCompletionLabel(this.courseCompletion.status)
-
-    this.completionDetails
-      .getValueWithLabel(`Attempt ${this.courseCompletion.attempts}`)
-      .should('contain.text', 'Pass')
-      .should('contain.text', completionDate)
-      .should('contain.text', timeSpent)
-      .should('contain.text', status)
+    this.completionDetails.shouldShowCompletionDetails(this.courseCompletion)
   }
 
   clickProcess() {

--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -97,6 +97,9 @@ context('Person Page', () => {
   it('navigates back to search results', () => {
     const pdu = communityCampusPduFactory.build({ id: form.originalSearch.pdu })
     const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
     cy.task('stubFindCourseCompletion', { courseCompletion })
     //  Given I am on the page
     const page = PersonPage.visit(courseCompletion, offender)
@@ -109,6 +112,14 @@ context('Person Page', () => {
     Page.verifyOnPage(CrnPage, courseCompletion)
 
     //  And I click back again
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
     page.clickBack()
 
     // Then I should see the course completion details page
@@ -118,9 +129,6 @@ context('Person Page', () => {
     cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
     cy.task('stubGetProviders', {
       providers: { providers: providerSummaryFactory.buildList(2) },
-    })
-    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletion],
     })
 
     cy.task('stubGetCourseCompletions', {
@@ -153,8 +161,19 @@ context('Person Page', () => {
   // Scenario: Navigating back with recommended CRN
   it('navigates back to course completion details if recommended CRN is unchanged', () => {
     const recommendation = courseCompletionRecommendationFactory.build({ crn: form.crn })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
     cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection: recommendation })
     cy.task('stubSaveCourseCompletionForm', form)
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
 
     //  Given I am on the page
     const page = PersonPage.visit(courseCompletion, offender)

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -117,9 +117,20 @@ context('Crn Page', () => {
   it('navigates back', () => {
     //  Given I am on the form page
     const page = CrnPage.visit(courseCompletion, '12')
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
 
     cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
     cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
 
     //  When I click back
     page.clickBack()
@@ -138,8 +149,19 @@ context('Crn Page', () => {
     cy.task('stubFindCourseCompletion', { courseCompletion })
     // Given I am on the page
     const page = CrnPage.visit(courseCompletion, '12', { pdu: pdu.id, provider: provider.code })
+    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletion],
+    })
 
     // When I click back
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
     page.clickBack()
 
     // Then I should see the course completion details page
@@ -149,9 +171,6 @@ context('Crn Page', () => {
     cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
     cy.task('stubGetProviders', {
       providers: { providers: providerSummaryFactory.buildList(2) },
-    })
-    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletion],
     })
 
     cy.task('stubGetCourseCompletions', {

--- a/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
@@ -44,6 +44,7 @@ context('Unable to credit time', () => {
   const offender = offenderFullFactory.build()
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender })
   const form = courseCompletionFormFactory.build({ crn: offender.crn })
+  const courseCompletionsResponse = pagedModelCourseCompletionEventFactory.build({ content: [courseCompletion] })
 
   beforeEach(() => {
     cy.task('reset')
@@ -53,6 +54,14 @@ context('Unable to credit time', () => {
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubSaveCourseCompletionForm', courseCompletionFormFactory.build())
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionsResponse,
+    })
   })
 
   // Scenario: Submitting the form

--- a/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
+++ b/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
@@ -310,6 +310,14 @@ context('Search course completions', () => {
     // And I click the view link for a course completion
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubSaveCourseCompletionForm', courseCompletionFormFactory.build())
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
     page.clickCourseCompletion()
 
     // Then I am on the course completion details page

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -31,6 +31,9 @@ context('Project page', () => {
   const form = courseCompletionFormFactory.build()
   const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
   const courseCompletion = courseCompletionFactory.build()
+  const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
+    content: [courseCompletion],
+  })
 
   beforeEach(() => {
     cy.task('reset')
@@ -41,6 +44,14 @@ context('Project page', () => {
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponse,
+    })
   })
 
   // Scenario: Processing a course completion
@@ -104,9 +115,6 @@ context('Project page', () => {
     cy.task('stubGetCommunityCampusPdus', { pdus: communityCampusPdusFactory.build() })
     cy.task('stubGetProviders', {
       providers: { providers: providerSummaryFactory.buildList(2) },
-    })
-    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletion],
     })
 
     cy.task('stubGetCourseCompletions', {

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -5,6 +5,18 @@
 //    Given I am on the course completion page
 //    When I click process
 //    Then I should see the first page of the form
+//  Scenario: Showing completion details for pass on third attempt
+//    Given the course completion is a pass on the third attempt
+//    When I visit the course completion page
+//    Then I should see data for three attempts
+//  Scenario: Showing completion details for pass on second attempt
+//    Given the course completion is a pass on the second attempt
+//    When I visit the course completion page
+//    Then I should see data for two attempts
+//  Scenario: Showing completion details for fail on third attempt
+//    Given the course completion is a fail on the third attempt
+//    When I visit the course completion page
+//    Then I should see data for three attempts
 //  Scenario: Skips CRN page if recommendation
 //    Given I am on the course completion page
 //    When I click process
@@ -65,6 +77,86 @@ context('Project page', () => {
 
     // Then I should see the first page of the form
     Page.verifyOnPage(CrnPage)
+  })
+
+  it('shows completion details for a pass on third attempt', () => {
+    // Given the course completion is a pass on the third attempt
+    const courseCompletionPass = courseCompletionFactory.build({ status: 'Passed', attempts: 3 })
+    const courseCompletionResponseWithPass = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletionPass],
+    })
+
+    cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionPass })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletionPass.id, recommendedSelection })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletionPass.pdu.providerCode,
+        pduId: courseCompletionPass.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponseWithPass,
+    })
+
+    // When I visit the course completion page
+    const page = CourseCompletionPage.visit(courseCompletionPass)
+
+    // Then I should see data for three attempts
+    page.completionDetails.shouldShowCompletionDetails(courseCompletionPass)
+    page.completionDetails.shouldShowAttemptPlaceholder({ attempt: 2 })
+    page.completionDetails.shouldShowAttemptPlaceholder({ attempt: 1 })
+  })
+
+  it('shows completion details for a pass on second attempt', () => {
+    // Given the course completion is a pass on the second attempt
+    const courseCompletionPass = courseCompletionFactory.build({ status: 'Passed', attempts: 2 })
+    const courseCompletionResponseWithPass = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletionPass],
+    })
+
+    cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionPass })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletionPass.id, recommendedSelection })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletionPass.pdu.providerCode,
+        pduId: courseCompletionPass.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponseWithPass,
+    })
+
+    // When I visit the course completion page
+    const page = CourseCompletionPage.visit(courseCompletionPass)
+
+    // Then I should see data for two attempts
+    page.completionDetails.shouldShowCompletionDetails(courseCompletionPass)
+    page.completionDetails.shouldShowAttemptPlaceholder({ attempt: 1 })
+  })
+
+  it('shows completion details for a fail', () => {
+    // Given the course completion is a fail on the third attempt
+    const courseCompletionFail = courseCompletionFactory.build({ status: 'Failed', attempts: 3 })
+    const courseCompletionResponseWithFail = pagedModelCourseCompletionEventFactory.build({
+      content: [courseCompletionFail],
+    })
+
+    cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionFail })
+    cy.task('stubGetRecommendedSelection', { id: courseCompletionFail.id, recommendedSelection })
+    cy.task('stubGetCourseCompletions', {
+      request: {
+        providerCode: courseCompletionFail.pdu.providerCode,
+        pduId: courseCompletionFail.pdu.id,
+        username: 'some-name',
+      },
+      courseCompletions: courseCompletionResponseWithFail,
+    })
+
+    // When I visit the course completion page
+    const page = CourseCompletionPage.visit(courseCompletionFail)
+
+    // Then I should see data for three attempts
+    page.completionDetails.shouldShowCompletionDetails(courseCompletionFail)
+    page.completionDetails.shouldShowAttemptPlaceholder({ attempt: 2 })
+    page.completionDetails.shouldShowAttemptPlaceholder({ attempt: 1 })
   })
 
   // Scenario: Skips CRN page if recommendation

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -111,6 +111,7 @@ export interface GetCourseCompletionsRequest extends BaseRequest, PagedRequest {
   dateTo?: string
   resolutionStatus?: CourseCompletionResolutionStatus
   showCourseFailures?: CourseCompletionShowCourseFailures
+  externalReference?: string
 }
 
 export interface GetCourseCompletionsParams extends BaseRequest, PagedRequest, GetCourseCompletionsRequest {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -157,7 +157,7 @@ export interface LinkItem {
 
 export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow' | 'green' | 'teal'
 
-export type GovUKValue = { text: string } | { html: string }
+export type GovUKValue = { text?: string; html?: string }
 
 export type GovUKActionItem = { href: string; text: string; visuallyHiddenText: string }
 

--- a/server/controllers/courseCompletions/index.test.ts
+++ b/server/controllers/courseCompletions/index.test.ts
@@ -18,6 +18,8 @@ import courseCompletionFormFactory from '../../testutils/factories/courseComplet
 import AuditService from '../../services/auditService'
 import courseCompletionRecommendationFactory from '../../testutils/factories/courseCompletionRecommendationFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import CourseCompletionUtils from '../../utils/courseCompletionUtils'
+import { GovUkSummaryListItem } from '../../@types/user-defined'
 
 jest.mock('../../pages/courseCompletionIndexPage')
 jest.mock('../../utils/paginationUtils')
@@ -75,6 +77,8 @@ describe('CourseCompletionsController', () => {
 
   const mockTime = '5 hours and 30 minutes'
 
+  const mockCompletionDetailsRow = [{ key: { title: 'Attempt 1' } } as unknown as GovUkSummaryListItem]
+
   const form = courseCompletionFormFactory.build()
 
   beforeEach(() => {
@@ -107,6 +111,7 @@ describe('CourseCompletionsController', () => {
     })
     getProvidersAndPdusMock.mockResolvedValue(providersAndPdus)
 
+    jest.spyOn(CourseCompletionUtils, 'completionDetailsRows').mockReturnValue(mockCompletionDetailsRow)
     jest.spyOn(DateTimeFormats, 'hoursAndMinutesToHumanReadable').mockReturnValue(mockTime)
   })
 
@@ -257,6 +262,7 @@ describe('CourseCompletionsController', () => {
           expectedPlus20: mockTime,
           totalTimeSpent: mockTime,
         },
+        completionDetailsRows: mockCompletionDetailsRow,
         backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
         processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'crn' }), {
           ...req.query,
@@ -293,6 +299,7 @@ describe('CourseCompletionsController', () => {
           expectedPlus20: mockTime,
           totalTimeSpent: mockTime,
         },
+        completionDetailsRows: mockCompletionDetailsRow,
         backLink: pathWithQuery(paths.courseCompletions.search({}), req.query as Record<string, string>),
         processLink: pathWithQuery(paths.courseCompletions.process({ id: courseCompletion.id, page: 'person' }), {
           ...req.query,

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -71,6 +71,27 @@ export default class CourseCompletionsController {
       )
       const total = DateTimeFormats.totalMinutesToHoursAndMinutesParts(courseCompletion.totalTimeMinutes)
 
+      const { sortBy, sortDirection } = getPaginationRequestParams<CourseCompletionSortField>(
+        req,
+        paths.courseCompletions.search({}),
+        {
+          provider: courseCompletion.provider,
+          pdu: courseCompletion.pdu,
+        },
+        courseCompletionSortFields,
+      )
+
+      const courseCompletions = await this.courseCompletionService.searchCourseCompletions({
+        username: res.locals.user.username,
+        providerCode: courseCompletion.pdu.providerCode,
+        pduId: courseCompletion.pdu.id,
+        sortBy,
+        sortDirection,
+        resolutionStatus: 'Unresolved',
+        showCourseFailures: 'Yes',
+        externalReference: courseCompletion.externalReference,
+      })
+
       res.render('courseCompletions/show', {
         courseCompletion: {
           ...courseCompletion,
@@ -81,7 +102,10 @@ export default class CourseCompletionsController {
           ),
           totalTimeSpent: DateTimeFormats.hoursAndMinutesToHumanReadable(+total.hours, +total.minutes),
         },
-        completionDetailsRows: CourseCompletionUtils.completionDetailsRows({ courseCompletion }),
+        completionDetailsRows: CourseCompletionUtils.completionDetailsRows({
+          courseCompletion,
+          allCourseCompletions: courseCompletions.content,
+        }),
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
         processLink: pathWithQuery(
           paths.courseCompletions.process({ id: courseCompletion.id, page: firstProcessPage }),

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -11,6 +11,7 @@ import { pathWithQuery } from '../../utils/utils'
 import CourseCompletionFormService from '../../services/forms/courseCompletionFormService'
 import AuditService, { Page } from '../../services/auditService'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import CourseCompletionUtils from '../../utils/courseCompletionUtils'
 
 const courseCompletionSortFields = ['firstName', 'lastName', 'courseName', 'completionDateTime', 'status'] as const
 
@@ -80,6 +81,7 @@ export default class CourseCompletionsController {
           ),
           totalTimeSpent: DateTimeFormats.hoursAndMinutesToHumanReadable(+total.hours, +total.minutes),
         },
+        completionDetailsRows: CourseCompletionUtils.completionDetailsRows({ courseCompletion }),
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
         processLink: pathWithQuery(
           paths.courseCompletions.process({ id: courseCompletion.id, page: firstProcessPage }),

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -101,7 +101,10 @@ describe('CourseCompletionUtils', () => {
   describe('completionDetails', () => {
     it.each([['Failed' as const], ['Passed' as const]])('returns row with completion details for %s', status => {
       const courseCompletion = courseCompletionFactory.build({ status })
-      const [row] = CourseCompletionUtils.completionDetailsRows({ courseCompletion })
+      const [row] = CourseCompletionUtils.completionDetailsRows({
+        courseCompletion,
+        allCourseCompletions: [courseCompletion],
+      })
 
       expect((row.key as { text: string }).text).toEqual(`Attempt ${courseCompletion.attempts}`)
       expect((row.value as { html: string }).html).toContain(
@@ -113,6 +116,263 @@ describe('CourseCompletionUtils', () => {
       expect((row.value as { html: string }).html).toContain(
         CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status),
       )
+    })
+
+    describe('Passes', () => {
+      describe('when all attempts are present', () => {
+        it('returns row with attempts in order when there is one attempt', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionPass],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+        })
+
+        it('returns row with attempts in order when there are two attempts', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 2,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+          const courseCompletionFailure = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-08').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionFailure, courseCompletionPass],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[1].value.html).toContain('8 January 2020')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+        })
+
+        it('returns row with attempts in order when there are three attempts', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 3,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+          const courseCompletionFirstFailure = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-07').toISOString(),
+          })
+          const courseCompletionSecondFailure = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 2,
+            completionDateTime: new Date('2020-01-08').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionSecondFailure, courseCompletionPass, courseCompletionFirstFailure],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 3')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[1].value.html).toContain('8 January 2020')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[2].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[2].value.html).toContain('7 January 2020')
+          expect(courseCompletionRows[2].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+        })
+      })
+
+      describe('when all attempts are not present', () => {
+        it('returns row with two placeholder attempts when the pass is the third attempt', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 3,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionPass],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 3')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[1].value.html).toContain('Details in Community Campus')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[2].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[2].value.html).toContain('Details in Community Campus')
+          expect(courseCompletionRows[2].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+        })
+
+        it('returns row with one placeholder attempt when the pass is the second attempt', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 2,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionPass],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[1].value.html).toContain('Details in Community Campus')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[2]).toBeUndefined()
+        })
+
+        it('returns row with no placeholder attempts when the pass is the first attempt', () => {
+          const courseCompletionPass = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionPass,
+            allCourseCompletions: [courseCompletionPass],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Passed'),
+          )
+
+          expect(courseCompletionRows[1]).toBeUndefined()
+        })
+      })
+    })
+
+    describe('Failures', () => {
+      describe('when all attempts are present', () => {
+        it('returns row with attempts in order', () => {
+          const courseCompletionLastFail = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 3,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+          const courseCompletionFirstFailure = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-07').toISOString(),
+          })
+          const courseCompletionSecondFailure = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 2,
+            completionDateTime: new Date('2020-01-08').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionLastFail,
+            allCourseCompletions: [
+              courseCompletionSecondFailure,
+              courseCompletionLastFail,
+              courseCompletionFirstFailure,
+            ],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 3')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[1].value.html).toContain('8 January 2020')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[2].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[2].value.html).toContain('7 January 2020')
+          expect(courseCompletionRows[2].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+        })
+      })
+
+      describe('when all attempts are not present', () => {
+        it('returns row with two placeholder attempts', () => {
+          const courseCompletionLastFail = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 3,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionLastFail,
+            allCourseCompletions: [courseCompletionLastFail],
+          })
+
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 3')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+          expect(courseCompletionRows[0].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 2')
+          expect(courseCompletionRows[1].value.html).toContain('Details in Community Campus')
+          expect(courseCompletionRows[1].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+
+          expect(courseCompletionRows[2].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[2].value.html).toContain('Details in Community Campus')
+          expect(courseCompletionRows[2].value.html).toContain(
+            CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
+          )
+        })
+      })
     })
   })
 })

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -6,7 +6,7 @@ import DateTimeFormats from './dateTimeUtils'
 
 describe('CourseCompletionUtils', () => {
   beforeEach(() => {
-    jest.resetAllMocks()
+    jest.restoreAllMocks()
   })
   describe('formattedLearnerDetails', () => {
     it('returns formatted learner details', () => {
@@ -87,6 +87,7 @@ describe('CourseCompletionUtils', () => {
       })
     })
   })
+
   describe('formattedCourseCompletionLabel', () => {
     it('formats the course completion label appropriately', () => {
       const failedCourseCompletion = courseCompletionFactory.build({ status: 'Failed' })
@@ -94,6 +95,24 @@ describe('CourseCompletionUtils', () => {
 
       const passedCourseCompletion = courseCompletionFactory.build({ status: 'Passed' })
       expect(CourseCompletionUtils.formattedCourseCompletionLabel(passedCourseCompletion.status)).toEqual('Pass')
+    })
+  })
+
+  describe('completionDetails', () => {
+    it.each([['Failed' as const], ['Passed' as const]])('returns row with completion details for %s', status => {
+      const courseCompletion = courseCompletionFactory.build({ status })
+      const [row] = CourseCompletionUtils.completionDetailsRows({ courseCompletion })
+
+      expect((row.key as { text: string }).text).toEqual(`Attempt ${courseCompletion.attempts}`)
+      expect((row.value as { html: string }).html).toContain(
+        DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes),
+      )
+      expect((row.value as { html: string }).html).toContain(
+        DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime),
+      )
+      expect((row.value as { html: string }).html).toContain(
+        CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status),
+      )
     })
   })
 })

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -1,6 +1,9 @@
 import { EteCourseCompletionEventDto, OffenderDto } from '../@types/shared'
+import { GovUkSummaryListItem } from '../@types/user-defined'
 import Offender, { OffenderDetails } from '../models/offender'
 import DateTimeFormats from './dateTimeUtils'
+import GovUKComponentUtils from './govUkComponentUtils'
+import HtmlUtils from './htmlUtils'
 
 export interface LearnerDetails {
   firstName: string
@@ -71,5 +74,38 @@ export default class CourseCompletionUtils {
 
   static formattedCourseCompletionLabel(label: string): string {
     return label === 'Passed' ? 'Pass' : 'Fail'
+  }
+
+  static completionDetailsRows({
+    courseCompletion,
+  }: {
+    courseCompletion: EteCourseCompletionEventDto
+  }): GovUkSummaryListItem[] {
+    const completionDate = DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime)
+    const timeSpent = DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes)
+    const status = CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status)
+    const statusColour = courseCompletion.status === 'Passed' ? 'green' : 'red'
+
+    const contentHtml = `
+      <div class="govuk-!-padding-left-0 govuk-grid-column-one-third">
+        ${completionDate}
+      </div>
+      <div class="govuk-!-padding-left-0 govuk-grid-column-one-third">
+        Time spent: ${timeSpent}
+      </div>
+      <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+        ${HtmlUtils.getStatusTag(status, statusColour)}
+      </div>
+    `
+
+    const row = [
+      GovUKComponentUtils.buildSummaryListItem({
+        label: `Attempt ${courseCompletion.attempts}`,
+        content: contentHtml,
+        contentIsHtml: true,
+      }),
+    ]
+
+    return row
   }
 }

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -78,34 +78,79 @@ export default class CourseCompletionUtils {
 
   static completionDetailsRows({
     courseCompletion,
+    allCourseCompletions,
   }: {
     courseCompletion: EteCourseCompletionEventDto
+    allCourseCompletions: EteCourseCompletionEventDto[]
   }): GovUkSummaryListItem[] {
+    const MAX_ATTEMPTS = 3
+
+    const sortedCourseCompletions = [...allCourseCompletions].sort((a, b) =>
+      b.completionDateTime.localeCompare(a.completionDateTime),
+    )
+
+    const maxAttemptNumber = courseCompletion.status === 'Passed' ? courseCompletion.attempts : MAX_ATTEMPTS
+
+    const rows: GovUkSummaryListItem[] = []
+
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      const rowLength = rows.length
+      const currentCourseCompletion = sortedCourseCompletions[i]
+      const shouldSkipBuildingRow =
+        courseCompletion.status === 'Passed' && !currentCourseCompletion && courseCompletion.attempts === rowLength
+
+      if (!shouldSkipBuildingRow) {
+        const attemptNumber = maxAttemptNumber - rowLength
+
+        const item = currentCourseCompletion
+          ? this.buildCourseCompletionRow(currentCourseCompletion)
+          : this.buildCourseCompletionRow(undefined, attemptNumber)
+
+        rows.push(item)
+      }
+    }
+
+    return rows
+  }
+
+  private static buildCourseCompletionRow(courseCompletion?: EteCourseCompletionEventDto, attempt?: number) {
+    if (!courseCompletion) {
+      const contentHtml = `
+        <div class="govuk-!-padding-left-0 govuk-grid-column-two-thirds">
+          Details in Community Campus
+        </div>
+        <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+          ${HtmlUtils.getStatusTag('Fail', 'red')}
+        </div>
+      `
+      return GovUKComponentUtils.buildSummaryListItem({
+        label: `Attempt ${attempt}`,
+        content: contentHtml,
+        contentIsHtml: true,
+      })
+    }
+
     const completionDate = DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime)
     const timeSpent = DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes)
     const status = CourseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status)
     const statusColour = courseCompletion.status === 'Passed' ? 'green' : 'red'
 
     const contentHtml = `
-      <div class="govuk-!-padding-left-0 govuk-grid-column-one-third">
+      <div class="govuk-!-padding-left-0 govuk-grid-column-one-quarter">
         ${completionDate}
       </div>
-      <div class="govuk-!-padding-left-0 govuk-grid-column-one-third">
+      <div class="govuk-!-padding-left-0 govuk-grid-column-one-half">
         Time spent: ${timeSpent}
       </div>
-      <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+      <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
         ${HtmlUtils.getStatusTag(status, statusColour)}
       </div>
     `
 
-    const row = [
-      GovUKComponentUtils.buildSummaryListItem({
-        label: `Attempt ${courseCompletion.attempts}`,
-        content: contentHtml,
-        contentIsHtml: true,
-      }),
-    ]
-
-    return row
+    return GovUKComponentUtils.buildSummaryListItem({
+      label: `Attempt ${courseCompletion.attempts}`,
+      content: contentHtml,
+      contentIsHtml: true,
+    })
   }
 }

--- a/server/views/courseCompletions/show.njk
+++ b/server/views/courseCompletions/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -145,6 +146,17 @@
     }
   ]
 }) }}
+
+{% if courseCompletion.status == "Failed" %}
+  {{ govukWarningText({
+    text: "This course has been failed three times.",
+    iconFallbackText: "Warning",
+    classes: "govuk-!-margin-bottom-3"
+  }) }}
+
+  <p class="govuk-body govuk-!-margin-bottom-4">Reset the course in Community Campus so {{ courseCompletion.firstName }} {{
+  courseCompletion.lastName }} can try again. You can still credit any agreed time if a course has been failed.</p>
+{% endif %}
 
 {{ govukSummaryList({
   card: {

--- a/server/views/courseCompletions/show.njk
+++ b/server/views/courseCompletions/show.njk
@@ -152,40 +152,7 @@
       text: 'Completion details'
     }
   },
-  rows: [
-    {
-      key: {
-        text: 'Completion status'
-      },
-      value: {
-        html: courseCompletionUtils.formattedCourseCompletionLabel(courseCompletion.status)
-      }
-    },
-    {
-      key: {
-        text: 'Completion date'
-      },
-      value: {
-        html: dateTimeUtils.isoDateToUIDate(courseCompletion.completionDateTime)
-      }
-    },
-    {
-      key: {
-        text: 'Total time spent'
-      },
-      value: {
-        html: courseCompletion.totalTimeSpent
-      }
-    },
-    {
-      key: {
-        text: 'Course attempts'
-      },
-      value: {
-        html: (courseCompletion.attempts ~ ' out of 3')
-      }
-    }
-  ]
+  rows: completionDetailsRows
 }) }}
 
 {% endblock %}


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-874?atlOrigin=eyJpIjoiMWJhZTI4MmEwZjM3NDc3MmIwMGIwMTMxODYxODZjOGYiLCJwIjoiaiJ9)

## Context
Show the current pass/fail and any previous attempts up until the most recent
attempt. If we don't have the previous attempt in the API response, show a
placeholder for a fail.

Note: The completion details section will be added to the outcome page in a separate PR.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Update existing completion details section to match the latest design
* Show previous attempts

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
#### Failures
Only third attempt failure is returned
<img width="1198" height="267" alt="Screenshot 2026-06-09 at 09 34 59" src="https://github.com/user-attachments/assets/356e3c16-db2f-4f9c-98b6-a72bee8b8cd4" />

Only second and third attempt failures are returned
<img width="1207" height="275" alt="Screenshot 2026-06-09 at 09 34 42" src="https://github.com/user-attachments/assets/81173adb-f40b-48d6-b73e-d81b26ba3bf9" />

All failures returned
<img width="1205" height="268" alt="Screenshot 2026-06-09 at 09 34 29" src="https://github.com/user-attachments/assets/abc6dbed-21ac-4200-bef0-db4286e87366" />

Failure warning text
<img width="1244" height="393" alt="image" src="https://github.com/user-attachments/assets/f92d08d8-11a3-4b8e-80fe-bf2368a1b1c6" />

#### Passes
Pass and previous failures returned
<img width="1208" height="281" alt="Screenshot 2026-06-09 at 09 34 09" src="https://github.com/user-attachments/assets/b28acfa3-2b1f-4c44-b635-bf836985030c" />

Pass on first attempt
<img width="1203" height="172" alt="Screenshot 2026-06-09 at 14 27 56" src="https://github.com/user-attachments/assets/ed442daf-c906-4fa0-a747-3c0be7b0600c" />

Pass on second attempt and one fail returned
<img width="1215" height="263" alt="image" src="https://github.com/user-attachments/assets/897d2f1d-19d9-4060-a87d-89090de7959c" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
