### PR TITLE
CPB-1026: Tidy ups

### DIFF
--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -95,6 +95,7 @@ context('Session details', () => {
     const firstAppointment = appointmentFactory.build({
       id: 1001,
       projectCode: project.projectCode,
+      providerCode: project.providerCode,
       pickUpData: { time, pickupLocation: pickupLocationFactory.build() },
       contactOutcomeCode: undefined,
       attendanceData: undefined,
@@ -441,6 +442,7 @@ context('Session details', () => {
       const appointmentWithoutContactOutcome = appointmentFactory.build({
         contactOutcomeCode: undefined,
         projectCode: this.project.projectCode,
+        providerCode: this.project.providerCode,
         attendanceData: undefined,
         minutesCredited: undefined,
         enforcementData: undefined,
@@ -486,6 +488,7 @@ context('Session details', () => {
       const appointmentInThePast = appointmentFactory.build({
         contactOutcomeCode: undefined,
         projectCode: this.project.projectCode,
+        providerCode: this.project.providerCode,
         date: DateTimeFormats.getTodaysDatePlusDays(-1).formattedDate,
       })
       cy.task('stubFindAppointment', { appointment: appointmentInThePast })

--- a/integration_tests/tests/appointments/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/appointments/chooseSupervisor.cy.ts
@@ -40,6 +40,7 @@ context('Choose supervisor', () => {
     const firstAppointment = appointmentFactory.build({
       id: 1001,
       projectCode: project.projectCode,
+      providerCode: project.providerCode,
       pickUpData: { time, location: locationFactory.build() },
     })
     cy.wrap(firstAppointment).as('appointment')
@@ -59,7 +60,7 @@ context('Choose supervisor', () => {
     const supervisors = supervisorSummaryFactory.buildList(2)
     cy.wrap(supervisors).as('supervisors')
 
-    const provider = providerSummaryFactory.build({ code: firstAppointment.providerCode })
+    const provider = providerSummaryFactory.build({ code: project.providerCode })
     cy.wrap(provider).as('provider')
 
     cy.task('stubGetProviders', { providers: { providers: [provider] } })
@@ -81,7 +82,11 @@ context('Choose supervisor', () => {
   describe('Supervisor input', function describe() {
     // Scenario: Supervisor for an appointment has no previously saved value
     it('should not have a selected supervisor if no supervisor on attendance data', function test() {
-      const appointment = appointmentFactory.build({ attendanceData: undefined, projectCode: this.project.projectCode })
+      const appointment = appointmentFactory.build({
+        attendanceData: undefined,
+        projectCode: this.project.projectCode,
+        providerCode: this.project.providerCode,
+      })
       const supervisors = supervisorSummaryFactory.buildList(2)
 
       const teams = providerTeamSummaryFactory.buildList(2)
@@ -103,7 +108,10 @@ context('Choose supervisor', () => {
 
     // Scenario: Supervisor for an appointment has a previously saved value
     it('should show any existing value for supervisor in the form', function test() {
-      const appointment = appointmentFactory.build({ projectCode: this.project.projectCode })
+      const appointment = appointmentFactory.build({
+        projectCode: this.project.projectCode,
+        providerCode: this.project.providerCode,
+      })
       const supervisors = [
         supervisorSummaryFactory.build(),
         supervisorSummaryFactory.build({ code: appointment.supervisorOfficerCode }),

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -295,8 +295,11 @@ context('Confirm appointment details page', () => {
   describe('navigating back to a page from the summary page', function describe() {
     const contactOutcomes = contactOutcomesFactory.build()
 
-    it('navigates back to the appointment details page', function test() {
-      const project = projectFactory.build({ projectCode: this.appointment.projectCode })
+    it('navigates back to supervisor page', function test() {
+      const project = projectFactory.build({
+        projectCode: this.appointment.projectCode,
+        providerCode: this.appointment.providerCode,
+      })
       const form = appointmentOutcomeFormFactory.build()
 
       // Given I am on the confirm page of an in progress update
@@ -314,7 +317,7 @@ context('Confirm appointment details page', () => {
       ]
       cy.task('stubGetSupervisors', {
         teamCode: this.appointment.supervisingTeamCode,
-        providerCode: this.appointment.providerCode,
+        providerCode: project.providerCode,
         supervisors,
       })
       cy.task('stubFindProject', { project })

--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -193,7 +193,10 @@ context('Attendance outcome', () => {
   //  Scenario: Returning to choose supervisor page
   it('navigates back to the previous page', function test() {
     const supervisors = supervisorSummaryFactory.buildList(2)
-    const project = projectFactory.build({ projectCode: this.appointment.projectCode })
+    const project = projectFactory.build({
+      projectCode: this.appointment.projectCode,
+      providerCode: this.appointment.providerCode,
+    })
 
     // Given I am on the attendance outcome page for an appointment
     const page = AttendanceOutcomePage.visit(this.appointment)

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -36,7 +36,7 @@ export default class AppointmentDetailsController {
         ? await this.referenceDataService.getContactOutcome(res.locals.user.username, appointment.contactOutcomeCode)
         : undefined
 
-      const page = new CheckAppointmentDetailsPage(_req.query, project)
+      const page = new CheckAppointmentDetailsPage(_req.query)
 
       let form: AppointmentOutcomeForm
       if (page.formId) {

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -50,6 +50,7 @@ describe('ChooseSupervisorController', () => {
       chooseSupervisorPageMock.mockImplementationOnce(() => {
         return {
           viewData: () => pageViewData,
+          updatePath: () => '/path',
         }
       })
       const appointment = appointmentFactory.build()
@@ -72,16 +73,18 @@ describe('ChooseSupervisorController', () => {
 
     it('should fetch the in progress form if it exists', async () => {
       const formId = '123'
+      const supervisorPath = '/path'
       const viewData = {
         someProp: '',
         team,
         form: formId,
-        chooseSupervisorPath: `/appointments/${projectCode}/${appointmentId}/choose-supervisor`,
+        chooseSupervisorPath: supervisorPath,
       }
 
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
         formId,
         viewData: () => viewData,
+        updatePath: () => supervisorPath,
       }))
 
       formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
@@ -104,6 +107,7 @@ describe('ChooseSupervisorController', () => {
         validate: () => {},
         hasErrors: true,
         validationErrors: errors,
+        updatePath: () => '/path',
       }))
 
       const errorSummary = {

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -11,6 +11,7 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import ChooseSupervisorController from './chooseSupervisorController'
+import ProjectService from '../../services/projectService'
 
 jest.mock('../../pages/appointments/chooseSupervisorPage.ts')
 jest.mock('../../utils/errorUtils')
@@ -32,10 +33,16 @@ describe('ChooseSupervisorController', () => {
   const appointmentService = createMock<AppointmentService>()
   const providerDataService = createMock<ProviderService>()
   const formService = createMock<AppointmentFormService>()
+  const projectService = createMock<ProjectService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    appointmentsController = new ChooseSupervisorController(appointmentService, formService, providerDataService)
+    appointmentsController = new ChooseSupervisorController(
+      appointmentService,
+      formService,
+      providerDataService,
+      projectService,
+    )
   })
 
   describe('show', () => {

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -6,23 +6,30 @@ import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
 import paths from '../../paths'
+import ProjectService from '../../services/projectService'
 
 export default class ChooseSupervisorController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,
     private readonly providerService: ProviderService,
+    private readonly projectService: ProjectService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
       const appointmentParams = _req.params as unknown as AppointmentParams
+      const project = await this.projectService.getProject({
+        username: res.locals.user.username,
+        projectCode: appointmentParams.projectCode,
+      })
+
       const appointment = await this.appointmentService.getAppointment({
         ...appointmentParams,
         username: res.locals.user.username,
       })
 
-      const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
+      const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
 
       const page = new ChooseSupervisorPage(_req.query)
 
@@ -32,7 +39,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       const supervisors = team
         ? await this.providerService.getSupervisors({
-            providerCode: appointment.providerCode,
+            providerCode: project.providerCode,
             teamCode: team,
             username: res.locals.user.username,
           })
@@ -51,18 +58,23 @@ export default class ChooseSupervisorController implements IFormPageController {
     return async (_req: Request, res: Response) => {
       const appointmentParams = { ..._req.params } as unknown as AppointmentParams
 
+      const project = await this.projectService.getProject({
+        username: res.locals.user.username,
+        projectCode: appointmentParams.projectCode,
+      })
+
       const appointment = await this.appointmentService.getAppointment({
         ...appointmentParams,
         username: res.locals.user.username,
       })
 
-      const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
+      const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
 
       const team = _req.body.team?.toString()
 
       const supervisors = team
         ? await this.providerService.getSupervisors({
-            providerCode: appointment.providerCode,
+            providerCode: project.providerCode,
             teamCode: team,
             username: res.locals.user.username,
           })

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -5,7 +5,6 @@ import ProviderService from '../../services/providerService'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
-import paths from '../../paths'
 import ProjectService from '../../services/projectService'
 
 export default class ChooseSupervisorController implements IFormPageController {
@@ -47,7 +46,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       res.render('appointments/update/chooseSupervisor', {
         ...page.viewData(appointment, teams, supervisors, form),
-        chooseSupervisorPath: paths.appointments.update({ ...appointmentParams, page: 'choose-supervisor' }),
+        chooseSupervisorPath: page.updatePath(appointment),
         form: page.formId,
         team,
       })
@@ -90,7 +89,7 @@ export default class ChooseSupervisorController implements IFormPageController {
           ...page.viewData(appointment, teams, supervisors, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
-          chooseSupervisorPath: paths.appointments.update({ ...appointmentParams, page: 'choose-supervisor' }),
+          chooseSupervisorPath: page.updatePath(appointment),
           form: page.formId,
         })
       }

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -24,7 +24,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       const teams = await this.providerService.getTeams(appointment.providerCode, res.locals.user.username)
 
-      const page = new ChooseSupervisorPage(_req.query, appointment)
+      const page = new ChooseSupervisorPage(_req.query)
 
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
 
@@ -68,7 +68,7 @@ export default class ChooseSupervisorController implements IFormPageController {
           })
         : []
 
-      const page = new ChooseSupervisorPage(_req.body, appointment)
+      const page = new ChooseSupervisorPage(_req.body)
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
 
       page.validate()

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -37,6 +37,7 @@ const controllers = (services: Services) => {
     services.appointmentService,
     services.appointmentFormService,
     services.providerService,
+    services.projectService,
   )
 
   const confirmController = new ConfirmController(

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -87,7 +87,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
     return {
-      ...this.commonViewData(this.appointment),
+      ...this.commonViewData({ appointment: this.appointment }),
       ...NotesUtils.questionItems(this.query, form, this.appointment),
       items: this.items(form, hasErrors),
     }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -84,11 +84,15 @@ export default abstract class BaseAppointmentUpdatePage {
     )
   }
 
-  protected commonViewData(
-    appointment: AppointmentDto,
-    originalSearch?: Record<string, string>,
-    project?: ProjectDto,
-  ): AppointmentUpdatePageViewData {
+  protected commonViewData({
+    appointment,
+    originalSearch,
+    project,
+  }: {
+    appointment: AppointmentDto
+    originalSearch?: Record<string, string>
+    project?: ProjectDto
+  }): AppointmentUpdatePageViewData {
     return {
       offender: new Offender(appointment.offender),
       backLink: this.backPath(appointment, originalSearch, project),

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -32,7 +32,7 @@ describe('CheckAppointmentDetailsPage', () => {
     const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
 
     beforeEach(() => {
-      page = new CheckAppointmentDetailsPage({}, projectFactory.build())
+      page = new CheckAppointmentDetailsPage({})
       appointment = appointmentFactory.build({ sensitive: false })
       jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
@@ -193,7 +193,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const backLink = '/project/1'
       jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
-      page = new CheckAppointmentDetailsPage({}, project)
+      page = new CheckAppointmentDetailsPage({})
       const search = { provider: 'provider' }
       const result = page.viewData({ appointment, project, originalSearch: search })
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
@@ -568,7 +568,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const path = '/path'
-      const page = new CheckAppointmentDetailsPage({}, projectFactory.build())
+      const page = new CheckAppointmentDetailsPage({})
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -586,7 +586,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const form = appointmentOutcomeFormFactory.build()
       const supervisors = supervisorSummaryFactory.buildList(2)
       const [selectedSupervisor] = supervisors
-      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code }, projectFactory.build())
+      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code })
 
       const result = page.updateForm(form, supervisors)
       expect(result).toEqual({ ...form, supervisor: selectedSupervisor })
@@ -595,7 +595,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
   describe('setFormId', () => {
     it('should update the formId', () => {
-      const page = new CheckAppointmentDetailsPage({}, projectFactory.build())
+      const page = new CheckAppointmentDetailsPage({})
       page.setFormId('1')
 
       expect(page.formId).toEqual('1')

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -43,10 +43,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
 
   validationErrors: ValidationErrors<Body> = {}
 
-  constructor(
-    private readonly query: AppointmentDetailsQuery,
-    private readonly project?: ProjectDto,
-  ) {
+  constructor(private readonly query: AppointmentDetailsQuery) {
     super(query)
   }
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -74,7 +74,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     contactOutcome?: ContactOutcomeDto
   }): ViewData {
     return {
-      ...this.commonViewData(appointment, originalSearch, project),
+      ...this.commonViewData({ appointment, originalSearch, project }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
       showContinueButton: !appointment.contactOutcomeCode,

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -7,7 +7,6 @@ import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
 import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
-import projectFactory from '../../testutils/factories/projectFactory'
 import ChooseSupervisorPage from './chooseSupervisorPage'
 import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 
@@ -30,7 +29,7 @@ describe('ChooseSupervisorPage', () => {
 
     beforeEach(() => {
       appointment = appointmentFactory.build()
-      page = new ChooseSupervisorPage({}, appointment)
+      page = new ChooseSupervisorPage({})
       supervisors = supervisorSummaryFactory.buildList(2)
       form = appointmentOutcomeFormFactory.build()
       teams = { providers: providerTeamSummaryFactory.buildList(3) }
@@ -55,7 +54,7 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234' }, appointment)
+      page = new ChooseSupervisorPage({ team: '1234' })
 
       const result = page.viewData(appointment, teams, supervisors, form)
 
@@ -79,7 +78,7 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234' }, appointment)
+      page = new ChooseSupervisorPage({ team: '1234' })
 
       const result = page.viewData(appointmentFactory.build(), teams, supervisors, form)
 
@@ -102,7 +101,7 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234', supervisor }, appointmentFactory.build())
+      page = new ChooseSupervisorPage({ team: '1234', supervisor })
       page.validate()
 
       const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build())
@@ -122,7 +121,7 @@ describe('ChooseSupervisorPage', () => {
   describe('validate', () => {
     it('has no errors if team has value and supervisor has value', () => {
       const query = { team: 'X123', supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query, appointmentFactory.build())
+      const page = new ChooseSupervisorPage(query)
       page.validate()
 
       expect(page.hasErrors).toBe(false)
@@ -131,7 +130,7 @@ describe('ChooseSupervisorPage', () => {
 
     it.each(['', undefined])('has errors if team is empty', (team: string | undefined) => {
       const query = { team, supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query, appointmentFactory.build())
+      const page = new ChooseSupervisorPage(query)
       page.validate()
 
       expect(page.hasErrors).toBe(true)
@@ -140,7 +139,7 @@ describe('ChooseSupervisorPage', () => {
 
     it.each(['', undefined])('has errors if supervisor is empty', (supervisor: string | undefined) => {
       const query = { team: 'X123', supervisor }
-      const page = new ChooseSupervisorPage(query, appointmentFactory.build())
+      const page = new ChooseSupervisorPage(query)
       page.validate()
 
       expect(page.hasErrors).toBe(true)
@@ -154,7 +153,7 @@ describe('ChooseSupervisorPage', () => {
       const projectCode = '2'
       const path = '/path'
       const query = { supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query, appointmentFactory.build())
+      const page = new ChooseSupervisorPage(query)
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -168,7 +167,7 @@ describe('ChooseSupervisorPage', () => {
       const form = appointmentOutcomeFormFactory.build()
       const supervisors = supervisorSummaryFactory.buildList(2)
       const [selectedSupervisor] = supervisors
-      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code }, projectFactory.build())
+      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code })
 
       const result = page.updateForm(form, supervisors)
       expect(result).toEqual({ ...form, supervisor: selectedSupervisor })

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -65,7 +65,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData(appointment),
+      ...this.commonViewData({ appointment }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -30,10 +30,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
 
   validationErrors: ValidationErrors<Body> = {}
 
-  constructor(
-    private readonly query: AppointmentDetailsQuery,
-    private readonly appointment: AppointmentDto,
-  ) {
+  constructor(private readonly query: AppointmentDetailsQuery) {
     super(query)
   }
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -42,7 +42,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     this.form = form
 
     return {
-      ...this.commonViewData(appointment),
+      ...this.commonViewData({ appointment }),
       submittedItems: this.formItems(form, appointment),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -60,7 +60,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   viewData(appointment: AppointmentDto, form: AppointmentOutcomeForm): ViewData {
     const formValues = this.getFormDisplayValues(form)
     return {
-      ...this.commonViewData(appointment),
+      ...this.commonViewData({ appointment }),
       hiVisItems: GovUkRadioGroup.yesNoItems({
         checkedValue: formValues.hiVis,
       }),

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -139,7 +139,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     const isOutcomeAcceptableAbsenceStoodDown = form.contactOutcome?.code === 'AASD'
 
     const viewData = {
-      ...this.commonViewData(appointment),
+      ...this.commonViewData({ appointment }),
       startTime: DateTimeFormats.stripTime(form.startTime),
       endTime: DateTimeFormats.stripTime(form.endTime),
       showPenaltyHours: isAttended,

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -346,6 +346,14 @@ describe('SessionUtils', () => {
       expect(path).toBe(`/sessions/${session.projectCode}/${session.date}`)
     })
 
+    it('returns expected path given a SessionDto', () => {
+      const session = sessionFactory.build()
+      const path = SessionUtils.getSessionPath(session, {})
+
+      expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: session.projectCode, date: session.date })
+      expect(path).toBe(`/sessions/${session.projectCode}/${session.date}`)
+    })
+
     it('returns expected path given an AppointmentDto', () => {
       const appointment = appointmentFactory.build()
       const path = SessionUtils.getSessionPath(appointment, {})

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -57,8 +57,11 @@ export default class SessionUtils {
     })
   }
 
-  static getSessionPath(session: SessionSummaryDto | AppointmentDto, query?: Record<string, string>) {
-    const { date, projectCode } = session
+  static getSessionPath(
+    appointmentOrSession: SessionSummaryDto | SessionDto | AppointmentDto,
+    query?: Record<string, string>,
+  ) {
+    const { date, projectCode } = appointmentOrSession
     return pathWithQuery(paths.sessions.show({ projectCode, date }), query)
   }
 


### PR DESCRIPTION
## Context

This change contains a few tidy-ups and refactors to pave the wave for bringing in the ability to save updates for multiple appointments at once (bulk updates)

## Changes in this PR

- Broadened `SessionUtils.getSessionPath()` to accept a `SessionDto`
- Refactored BaseAppointmentUpdatePage.commonViewData to take a named-parameter object, to make it easier to manage undefined parameters
- Updated choose-supervisor flow to derive provider context via ProjectService, to remove dependency on a single appointment during a bulk journey

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
