### PR TITLE
CPB-1026 handle appointment or session in appointment page routes

### DIFF
--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -140,6 +140,12 @@ export interface AppointmentParams {
   projectCode: string
 }
 
+export interface AppointmentOrSessionParams {
+  appointmentId?: string
+  date?: string
+  projectCode: string
+}
+
 export type AppointmentOrSession = AppointmentDto | SessionDto
 
 export interface GovUkSelectOption {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,7 +1,9 @@
 import type { Response, RequestHandler } from 'express'
 import {
+  AppointmentDto,
   AttendanceDataDto,
   ContactOutcomeDto,
+  SessionDto,
   SupervisorSummaryDto,
   ProjectTypeDto,
   ProviderTeamSummaryDto,
@@ -10,7 +12,7 @@ import ReferenceDataService from '../../services/referenceDataService'
 
 export type AppointmentUpdatePageViewData = {
   backLink: string
-  offender: Offender
+  offender?: Offender
   updatePath: string
   form?: string
 }
@@ -137,6 +139,8 @@ export interface AppointmentParams {
   appointmentId: string
   projectCode: string
 }
+
+export type AppointmentOrSession = AppointmentDto | SessionDto
 
 export interface GovUkSelectOption {
   text: string

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -64,7 +64,7 @@ export default class AppointmentDetailsController {
 
       const page = new CheckAppointmentDetailsPage(_req.body)
 
-      return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
+      return res.redirect(page.next(appointmentParams))
     }
   }
 }

--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -10,6 +10,7 @@ import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/attendanceOutcomePage')
 
@@ -31,10 +32,16 @@ describe('attendanceOutcomeController', () => {
   const appointmentService = createMock<AppointmentService>()
   const referenceDataService = createMock<ReferenceDataService>()
   const formService = createMock<AppointmentFormService>()
+  const sessionService = createMock<SessionService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    attendanceOutcomeController = new AttendanceOutcomeController(appointmentService, referenceDataService, formService)
+    attendanceOutcomeController = new AttendanceOutcomeController(
+      appointmentService,
+      referenceDataService,
+      formService,
+      sessionService,
+    )
   })
 
   describe('show', () => {

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -4,26 +4,32 @@ import ReferenceDataService from '../../services/referenceDataService'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
+import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import SessionService from '../../services/sessionService'
 
 export default class AttendanceOutcomeController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly referenceDataService: ReferenceDataService,
     private readonly formService: AppointmentFormService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointment = await this.appointmentService.getAppointment({
-        ...(_req.params as unknown as AppointmentParams),
-        username: res.locals.user.username,
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
       const page = new AttendanceOutcomePage({
         query: _req.query,
-        appointmentOrSession: appointment,
+        appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
 
@@ -35,17 +41,19 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = { ..._req.params } as unknown as AppointmentParams
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
-      const appointment = await this.appointmentService.getAppointment({
-        ...appointmentParams,
-        username: res.locals.user.username,
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
       const page = new AttendanceOutcomePage({
         query: _req.body,
-        appointmentOrSession: appointment,
+        appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
       const form = await this.formService.getForm(page.formId, res.locals.user.username)
@@ -62,7 +70,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const toSave = page.updateForm(form, outcomes.contactOutcomes)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams))
+      return res.redirect(page.next(appointmentOrSessionParams))
     }
   }
 }

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -23,7 +23,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
       const page = new AttendanceOutcomePage({
         query: _req.query,
-        appointment,
+        appointmentOrSession: appointment,
         contactOutcomes: outcomes.contactOutcomes,
       })
 
@@ -45,7 +45,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
       const page = new AttendanceOutcomePage({
         query: _req.body,
-        appointment,
+        appointmentOrSession: appointment,
         contactOutcomes: outcomes.contactOutcomes,
       })
       const form = await this.formService.getForm(page.formId, res.locals.user.username)

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -62,7 +62,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const toSave = page.updateForm(form, outcomes.contactOutcomes)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
+      return res.redirect(page.next(appointmentParams))
     }
   }
 }

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -12,6 +12,7 @@ import providerSummaryFactory from '../../testutils/factories/providerSummaryFac
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import ChooseSupervisorController from './chooseSupervisorController'
 import ProjectService from '../../services/projectService'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/chooseSupervisorPage.ts')
 jest.mock('../../utils/errorUtils')
@@ -34,6 +35,7 @@ describe('ChooseSupervisorController', () => {
   const providerDataService = createMock<ProviderService>()
   const formService = createMock<AppointmentFormService>()
   const projectService = createMock<ProjectService>()
+  const sessionService = createMock<SessionService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -42,6 +44,7 @@ describe('ChooseSupervisorController', () => {
       formService,
       providerDataService,
       projectService,
+      sessionService,
     )
   })
 

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -4,8 +4,10 @@ import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
+import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import SessionService from '../../services/sessionService'
 
 export default class ChooseSupervisorController implements IFormPageController {
   constructor(
@@ -13,19 +15,22 @@ export default class ChooseSupervisorController implements IFormPageController {
     private readonly appointmentFormService: AppointmentFormService,
     private readonly providerService: ProviderService,
     private readonly projectService: ProjectService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = _req.params as unknown as AppointmentParams
+      const appointmentOrSessionParams = _req.params as unknown as AppointmentOrSessionParams
       const project = await this.projectService.getProject({
         username: res.locals.user.username,
-        projectCode: appointmentParams.projectCode,
+        projectCode: appointmentOrSessionParams.projectCode,
       })
 
-      const appointment = await this.appointmentService.getAppointment({
-        ...appointmentParams,
-        username: res.locals.user.username,
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
@@ -45,8 +50,8 @@ export default class ChooseSupervisorController implements IFormPageController {
         : []
 
       res.render('appointments/update/chooseSupervisor', {
-        ...page.viewData(appointment, teams, supervisors, form),
-        chooseSupervisorPath: page.updatePath(appointment),
+        ...page.viewData(appointmentOrSession, teams, supervisors, form),
+        chooseSupervisorPath: page.updatePath(appointmentOrSession),
         form: page.formId,
         team,
       })
@@ -55,16 +60,18 @@ export default class ChooseSupervisorController implements IFormPageController {
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = { ..._req.params } as unknown as AppointmentParams
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
       const project = await this.projectService.getProject({
         username: res.locals.user.username,
-        projectCode: appointmentParams.projectCode,
+        projectCode: appointmentOrSessionParams.projectCode,
       })
 
-      const appointment = await this.appointmentService.getAppointment({
-        ...appointmentParams,
-        username: res.locals.user.username,
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
@@ -86,10 +93,10 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       if (page.hasErrors) {
         return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointment, teams, supervisors, form),
+          ...page.viewData(appointmentOrSession, teams, supervisors, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
-          chooseSupervisorPath: page.updatePath(appointment),
+          chooseSupervisorPath: page.updatePath(appointmentOrSession),
           form: page.formId,
         })
       }
@@ -97,7 +104,7 @@ export default class ChooseSupervisorController implements IFormPageController {
       const toSave = page.updateForm(form, teams, supervisors)
       await this.appointmentFormService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams))
+      return res.redirect(page.next(appointmentOrSessionParams))
     }
   }
 }

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -97,7 +97,7 @@ export default class ChooseSupervisorController implements IFormPageController {
       const toSave = page.updateForm(form, teams, supervisors)
       await this.appointmentFormService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
+      return res.redirect(page.next(appointmentParams))
     }
   }
 }

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -10,6 +10,7 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import ProjectService from '../../services/projectService'
 import * as ErrorUtils from '../../utils/errorUtils'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/confirmPage')
 
@@ -33,10 +34,16 @@ describe('ConfirmController', () => {
   const appointmentService = createMock<AppointmentService>()
   const appointmentFormService = createMock<AppointmentFormService>()
   const projectService = createMock<ProjectService>()
+  const sessionService = createMock<SessionService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    confirmController = new ConfirmController(appointmentService, appointmentFormService, projectService)
+    confirmController = new ConfirmController(
+      appointmentService,
+      appointmentFormService,
+      projectService,
+      sessionService,
+    )
   })
 
   describe('show', () => {

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -3,23 +3,29 @@ import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared'
-import { AppointmentOutcomeForm, AppointmentParams, IFormPageController } from '../../@types/user-defined'
+import { AppointmentOrSessionParams, AppointmentOutcomeForm, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 import NotesUtils from '../../utils/notesUtils'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import SessionService from '../../services/sessionService'
 
 export default class ConfirmController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly appointmentFormService: AppointmentFormService,
     private readonly projectService: ProjectService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointment = await this.appointmentService.getAppointment({
-        ...(_req.params as unknown as AppointmentParams),
-        username: res.locals.user.username,
+      const appointmentOrSessionParams = _req.params as unknown as AppointmentOrSessionParams
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const page = new ConfirmPage(_req.query)
@@ -27,21 +33,26 @@ export default class ConfirmController implements IFormPageController {
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
 
-      res.render('appointments/update/confirm', { ...page.viewData(appointment, form), errorList, preventDoubleClick })
+      res.render('appointments/update/confirm', {
+        ...page.viewData(appointmentOrSession, form),
+        errorList,
+        preventDoubleClick,
+      })
     }
   }
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = _req.params as unknown as AppointmentParams
+      const { projectCode, appointmentId } = _req.params
       const appointment = await this.appointmentService.getAppointment({
-        ...appointmentParams,
+        projectCode,
+        appointmentId,
         username: res.locals.user.username,
       })
 
       const project = await this.projectService.getProject({
         username: res.locals.user.username,
-        projectCode: appointmentParams.projectCode,
+        projectCode,
       })
 
       const page = new ConfirmPage(_req.body)

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -17,14 +17,20 @@ const controllers = (services: Services) => {
     services.appointmentService,
     services.referenceDataService,
     services.appointmentFormService,
+    services.sessionService,
   )
 
   const logComplianceController = new LogComplianceController(
     services.appointmentService,
     services.appointmentFormService,
+    services.sessionService,
   )
 
-  const logHoursController = new LogHoursController(services.appointmentService, services.appointmentFormService)
+  const logHoursController = new LogHoursController(
+    services.appointmentService,
+    services.appointmentFormService,
+    services.sessionService,
+  )
 
   const appointmentDetailsController = new AppointmentDetailsController(
     services.appointmentService,
@@ -38,12 +44,14 @@ const controllers = (services: Services) => {
     services.appointmentFormService,
     services.providerService,
     services.projectService,
+    services.sessionService,
   )
 
   const confirmController = new ConfirmController(
     services.appointmentService,
     services.appointmentFormService,
     services.projectService,
+    services.sessionService,
   )
 
   const adjustTravelTimeController = new AdjustTravelTimeController(

--- a/server/controllers/appointments/logComplianceController.test.ts
+++ b/server/controllers/appointments/logComplianceController.test.ts
@@ -8,6 +8,7 @@ import LogComplianceController from './logComplianceController'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../models/offender')
 jest.mock('../../pages/appointments/logCompliancePage')
@@ -22,6 +23,7 @@ describe('logComplianceController', () => {
   let logComplianceController: LogComplianceController
   const appointmentService = createMock<AppointmentService>()
   const formService = createMock<AppointmentFormService>()
+  const sessionService = createMock<SessionService>()
 
   const logCompliancePageMock: jest.Mock = LogCompliancePage as unknown as jest.Mock<LogCompliancePage>
   const pageViewData = {
@@ -30,7 +32,7 @@ describe('logComplianceController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    logComplianceController = new LogComplianceController(appointmentService, formService)
+    logComplianceController = new LogComplianceController(appointmentService, formService, sessionService)
   })
 
   describe('show', () => {

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -3,31 +3,37 @@ import AppointmentService from '../../services/appointmentService'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
+import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import SessionService from '../../services/sessionService'
 
 export default class LogComplianceController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly formService: AppointmentFormService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointment = await this.appointmentService.getAppointment({
-        ...(_req.params as unknown as AppointmentParams),
-        username: res.locals.user.username,
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const page = new LogCompliancePage(_req.query)
       const form = await this.formService.getForm(page.formId, res.locals.user.username)
 
-      res.render('appointments/update/logCompliance', page.viewData(appointment, form))
+      res.render('appointments/update/logCompliance', page.viewData(appointmentOrSession, form))
     }
   }
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = { ..._req.params } as unknown as AppointmentParams
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
       const page = new LogCompliancePage(_req.body)
       const form = await this.formService.getForm(page.formId, res.locals.user.username)
@@ -35,13 +41,15 @@ export default class LogComplianceController implements IFormPageController {
       page.validate()
 
       if (page.hasError) {
-        const appointment = await this.appointmentService.getAppointment({
-          ...appointmentParams,
-          username: res.locals.user.username,
+        const appointmentOrSession = await getAppointmentOrSession({
+          appointmentOrSessionParams,
+          res,
+          appointmentService: this.appointmentService,
+          sessionService: this.sessionService,
         })
 
         return res.render('appointments/update/logCompliance', {
-          ...page.viewData(appointment, form),
+          ...page.viewData(appointmentOrSession, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
@@ -50,7 +58,7 @@ export default class LogComplianceController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams))
+      return res.redirect(page.next(appointmentOrSessionParams))
     }
   }
 }

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -50,7 +50,7 @@ export default class LogComplianceController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
+      return res.redirect(page.next(appointmentParams))
     }
   }
 }

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -9,6 +9,7 @@ import { generateErrorSummary } from '../../utils/errorUtils'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/logHoursPage')
 jest.mock('../../utils/errorUtils')
@@ -29,10 +30,11 @@ describe('logHoursController', () => {
   let logHoursController: LogHoursController
   const appointmentService = createMock<AppointmentService>()
   const formService = createMock<AppointmentFormService>()
+  const sessionService = createMock<SessionService>()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    logHoursController = new LogHoursController(appointmentService, formService)
+    logHoursController = new LogHoursController(appointmentService, formService, sessionService)
   })
 
   describe('show', () => {

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -53,7 +53,7 @@ export default class LogHoursController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams.projectCode, appointmentParams.appointmentId))
+      return res.redirect(page.next(appointmentParams))
     }
   }
 }

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -3,19 +3,25 @@ import AppointmentService from '../../services/appointmentService'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
 import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentParams, IFormPageController } from '../../@types/user-defined'
+import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import SessionService from '../../services/sessionService'
 
 export default class LogHoursController implements IFormPageController {
   constructor(
     private readonly appointmentService: AppointmentService,
     private readonly formService: AppointmentFormService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointment = await this.appointmentService.getAppointment({
-        ...(_req.params as unknown as AppointmentParams),
-        username: res.locals.user.username,
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+      const appointment = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const page = new LogHoursPage(_req.query)
@@ -30,21 +36,23 @@ export default class LogHoursController implements IFormPageController {
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const appointmentParams = { ..._req.params } as unknown as AppointmentParams
+      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
       const page = new LogHoursPage(_req.body)
       page.validate()
 
       const form = await this.formService.getForm(page.formId, res.locals.user.username)
 
-      const appointment = await this.appointmentService.getAppointment({
-        ...appointmentParams,
-        username: res.locals.user.username,
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       if (page.hasErrors) {
         return res.render('appointments/update/logHours', {
-          ...page.viewData(appointment, form),
+          ...page.viewData(appointmentOrSession, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
@@ -53,7 +61,7 @@ export default class LogHoursController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentParams))
+      return res.redirect(page.next(appointmentOrSessionParams))
     }
   }
 }

--- a/server/controllers/shared/getAppointmentOrSession.test.ts
+++ b/server/controllers/shared/getAppointmentOrSession.test.ts
@@ -1,0 +1,101 @@
+import type { Response } from 'express'
+import AppointmentService from '../../services/appointmentService'
+import SessionService from '../../services/sessionService'
+import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
+import getAppointmentOrSession from './getAppointmentOrSession'
+
+describe('getAppointmentOrSession', () => {
+  it('calls appointment service with request params and username and returns appointment', async () => {
+    const appointment = appointmentFactory.build()
+    const appointmentService = { getAppointment: jest.fn(() => appointment) } as unknown as AppointmentService
+    const sessionService = { getSession: jest.fn() } as unknown as SessionService
+
+    const appointmentOrSessionParams = {
+      appointmentId: '123',
+      projectCode: 'XRC',
+    }
+
+    const res = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    const result = await getAppointmentOrSession({
+      appointmentOrSessionParams,
+      res,
+      appointmentService,
+      sessionService,
+    })
+
+    expect(result).toEqual(appointment)
+    expect(appointmentService.getAppointment).toHaveBeenCalledWith({
+      appointmentId: '123',
+      projectCode: 'XRC',
+      username: 'username',
+    })
+  })
+
+  it('calls session service with project code, date and username and returns session', async () => {
+    const session = sessionFactory.build()
+    const appointmentService = { getAppointment: jest.fn() } as unknown as AppointmentService
+    const sessionService = { getSession: jest.fn(() => session) } as unknown as SessionService
+
+    const appointmentOrSessionParams = {
+      projectCode: 'XRC',
+      date: '2026-06-10',
+    }
+
+    const res = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    const result = await getAppointmentOrSession({
+      appointmentOrSessionParams,
+      res,
+      appointmentService,
+      sessionService,
+    })
+
+    expect(result).toEqual(session)
+    expect(sessionService.getSession).toHaveBeenCalledWith({
+      username: 'username',
+      projectCode: 'XRC',
+      date: '2026-06-10',
+    })
+    expect(appointmentService.getAppointment).not.toHaveBeenCalled()
+  })
+
+  it('throws if neither date nor appointmentId are provided', async () => {
+    const appointmentService = { getAppointment: jest.fn() } as unknown as AppointmentService
+    const sessionService = { getSession: jest.fn() } as unknown as SessionService
+
+    const appointmentOrSessionParams = {
+      projectCode: 'XRC',
+    }
+
+    const res = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    await expect(
+      getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService,
+        sessionService,
+      }),
+    ).rejects.toThrow('Either appointmentId or date must be provided')
+  })
+})

--- a/server/controllers/shared/getAppointmentOrSession.ts
+++ b/server/controllers/shared/getAppointmentOrSession.ts
@@ -1,0 +1,42 @@
+import type { Response } from 'express'
+import AppointmentService from '../../services/appointmentService'
+import SessionService from '../../services/sessionService'
+import { AppointmentOrSession, AppointmentOrSessionParams } from '../../@types/user-defined'
+
+type AppointmentFormDetailsParams = {
+  appointmentOrSessionParams: AppointmentOrSessionParams
+  res: Response
+  appointmentService: AppointmentService
+  sessionService: SessionService
+}
+
+export default async ({
+  appointmentOrSessionParams,
+  res,
+  appointmentService,
+  sessionService,
+}: AppointmentFormDetailsParams): Promise<AppointmentOrSession> => {
+  const { projectCode, date, appointmentId } = appointmentOrSessionParams
+  const { username } = res.locals.user
+
+  if (!appointmentId && !date) {
+    throw new Error('Either appointmentId or date must be provided')
+  }
+
+  if (appointmentId) {
+    const appointment = await appointmentService.getAppointment({
+      projectCode,
+      appointmentId,
+      username,
+    })
+    return appointment
+  }
+
+  const session = await sessionService.getSession({
+    username,
+    projectCode,
+    date,
+  })
+
+  return session
+}

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -490,7 +490,7 @@ describe('AttendanceOutcomePage', () => {
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-        expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+        expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
         expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-hours' })
       })
     })
@@ -510,7 +510,7 @@ describe('AttendanceOutcomePage', () => {
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-        expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+        expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
         expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
       })
     })

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -2,11 +2,13 @@ import { faker } from '@faker-js/faker'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import { contactOutcomeFactory, contactOutcomesFactory } from '../../testutils/factories/contactOutcomeFactory'
 import AttendanceOutcomePage, { AttendanceOutcomeBody } from './attendanceOutcomePage'
 import * as Utils from '../../utils/utils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import NotesUtils from '../../utils/notesUtils'
 
 jest.mock('../../models/offender')
 
@@ -17,12 +19,17 @@ describe('AttendanceOutcomePage', () => {
   const pathWithQuery = '/path?'
 
   beforeEach(() => {
+    jest.resetAllMocks()
     jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
   })
 
   describe('validationErrors', () => {
     it('returns error when attendance outcome is empty', () => {
-      const page = new AttendanceOutcomePage({ query: {} as AttendanceOutcomeBody, appointment, contactOutcomes })
+      const page = new AttendanceOutcomePage({
+        query: {} as AttendanceOutcomeBody,
+        appointmentOrSession: appointment,
+        contactOutcomes,
+      })
 
       expect(page.validationErrors()).toEqual({
         attendanceOutcome: { text: 'Select an attendance outcome' },
@@ -38,7 +45,7 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInTheFuture,
+          appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
@@ -53,7 +60,7 @@ describe('AttendanceOutcomePage', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInTheFuture,
+          appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
@@ -68,11 +75,29 @@ describe('AttendanceOutcomePage', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInTheFuture,
+          appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
         expect(page.validationErrors()).toEqual({})
+      })
+
+      it('returns error if appointmentOrSession is a session and contact outcome is attended', () => {
+        const sessionInTheFuture = sessionFactory.build({
+          date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
+        })
+        const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
+        const page = new AttendanceOutcomePage({
+          query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
+          appointmentOrSession: sessionInTheFuture,
+          contactOutcomes: [...contactOutcomes, attendedContactOutcome],
+        })
+
+        expect(page.validationErrors()).toEqual({
+          attendanceOutcome: {
+            text: 'The outcome entered must be: acceptable absence',
+          },
+        })
       })
     })
 
@@ -85,7 +110,7 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentToday,
+          appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
@@ -96,7 +121,7 @@ describe('AttendanceOutcomePage', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentToday,
+          appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
@@ -107,7 +132,7 @@ describe('AttendanceOutcomePage', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentToday,
+          appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
@@ -122,7 +147,7 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInThePast,
+          appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
@@ -133,7 +158,7 @@ describe('AttendanceOutcomePage', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInThePast,
+          appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
@@ -144,7 +169,7 @@ describe('AttendanceOutcomePage', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-          appointment: appointmentInThePast,
+          appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
@@ -156,7 +181,7 @@ describe('AttendanceOutcomePage', () => {
       it('should not have any errors if no notes value', () => {
         const page = new AttendanceOutcomePage({
           query: {} as AttendanceOutcomeBody,
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
         page.validationErrors()
@@ -168,7 +193,7 @@ describe('AttendanceOutcomePage', () => {
         const notes = faker.string.alpha(count)
         const page = new AttendanceOutcomePage({
           query: { notes } as AttendanceOutcomeBody,
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
         page.validationErrors()
@@ -180,7 +205,7 @@ describe('AttendanceOutcomePage', () => {
         const notes = faker.string.alpha(4001)
         const page = new AttendanceOutcomePage({
           query: { notes } as AttendanceOutcomeBody,
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
         page.validationErrors()
@@ -193,7 +218,7 @@ describe('AttendanceOutcomePage', () => {
   })
 
   describe('viewData', () => {
-    it('should render the attendance outcome page', async () => {
+    it('returns view data for an appointment', async () => {
       const formWithOutcomes = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[0].code }),
         notes: 'Test notes',
@@ -201,7 +226,7 @@ describe('AttendanceOutcomePage', () => {
       })
       const page = new AttendanceOutcomePage({
         query: {} as AttendanceOutcomeBody,
-        appointment,
+        appointmentOrSession: appointment,
         contactOutcomes,
       })
       const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
@@ -238,6 +263,12 @@ describe('AttendanceOutcomePage', () => {
       ]
 
       jest.spyOn(paths.appointments, 'update')
+      const notesItems = {
+        notes: 'Test notes',
+        showIsSensitiveQuestion: true,
+        isSensitiveItems: expectedSensitiveItems,
+      }
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const result = page.viewData(formWithOutcomes)
 
@@ -252,6 +283,8 @@ describe('AttendanceOutcomePage', () => {
         page: 'choose-supervisor',
       })
 
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment)
+
       expect(result).toEqual({
         offender,
         items: expectedItems,
@@ -263,6 +296,80 @@ describe('AttendanceOutcomePage', () => {
       })
     })
 
+    it('returns view data for a session', () => {
+      const session = sessionFactory.build()
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
+      })
+      const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
+
+      const page = new AttendanceOutcomePage({
+        query: {} as AttendanceOutcomeBody,
+        appointmentOrSession: session,
+        contactOutcomes,
+      })
+
+      const result = page.viewData(form)
+
+      const expectedItems = [
+        {
+          text: contactOutcomes[0].name,
+          value: contactOutcomes[0].code,
+          checked: false,
+        },
+        {
+          text: contactOutcomes[1].name,
+          value: contactOutcomes[1].code,
+          checked: true,
+        },
+        {
+          text: contactOutcomes[2].name,
+          value: contactOutcomes[2].code,
+          checked: false,
+        },
+      ]
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'attendance-outcome',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'choose-supervisor',
+      })
+
+      expect(result).toEqual({
+        backLink: pathWithQuery,
+        updatePath: pathWithQuery,
+        form: undefined,
+        ...notesItems,
+        items: expectedItems,
+      })
+    })
+
+    it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build()
+      const form = appointmentOutcomeFormFactory.build()
+      const notesItems = { notes: 'some note', showIsSensitiveQuestion: false }
+      const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
+
+      const page = new AttendanceOutcomePage({
+        query: {} as AttendanceOutcomeBody,
+        appointmentOrSession: session,
+        contactOutcomes,
+      })
+
+      const viewData = page.viewData(form)
+
+      expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined)
+      expect(viewData).toEqual(expect.objectContaining(notesItems))
+    })
+
     describe('items', () => {
       it('should map contact outcome value as selected if no errors', () => {
         const form = appointmentOutcomeFormFactory.build({
@@ -270,7 +377,7 @@ describe('AttendanceOutcomePage', () => {
         })
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: contactOutcomes[1].code },
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
 
@@ -298,13 +405,17 @@ describe('AttendanceOutcomePage', () => {
       })
 
       it('should return query values if there are errors', () => {
+        const notesItems = { notes: 'Test', showIsSensitiveQuestion: true }
+        jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
+        const query = { notes: notesItems.notes }
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: null, notes: 'Test' },
-          appointment,
+          query,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
 
-        const result = page.viewData(appointmentOutcomeFormFactory.build(), true)
+        const form = appointmentOutcomeFormFactory.build()
+        const result = page.viewData(form, true)
 
         const expectedItems = [
           {
@@ -325,13 +436,14 @@ describe('AttendanceOutcomePage', () => {
         ]
 
         expect(result.items).toEqual(expectedItems)
-        expect(result.notes).toEqual('Test')
+        expect(result.notes).toEqual(notesItems.notes)
+        expect(NotesUtils.questionItems).toHaveBeenCalledWith(query, form, appointment)
       })
 
       it('should return items if page has Errors and contact outcome is undefined', () => {
         const page = new AttendanceOutcomePage({
           query: {},
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes,
         })
         page.validationErrors()
@@ -372,7 +484,7 @@ describe('AttendanceOutcomePage', () => {
 
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: attendedOutcome.code },
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] }).contactOutcomes,
         })
 
@@ -392,7 +504,7 @@ describe('AttendanceOutcomePage', () => {
 
         const page = new AttendanceOutcomePage({
           query: { attendanceOutcome: notAttendedOutcome.code },
-          appointment,
+          appointmentOrSession: appointment,
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }).contactOutcomes,
         })
 
@@ -411,7 +523,7 @@ describe('AttendanceOutcomePage', () => {
       const form = appointmentOutcomeFormFactory.build({ notes: appointmentNotes })
       const page = new AttendanceOutcomePage({
         query: { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes, isSensitive: 'yes' },
-        appointment,
+        appointmentOrSession: appointment,
         contactOutcomes,
       })
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -1,4 +1,5 @@
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -33,22 +34,22 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
   private query: AttendanceOutcomeQuery
 
-  private appointment: AppointmentDto
+  private appointmentOrSession: AppointmentOrSession
 
   private contactOutcomes: ContactOutcomeDto[]
 
   constructor({
     query,
-    appointment,
+    appointmentOrSession,
     contactOutcomes,
   }: {
     query: AttendanceOutcomeQuery
-    appointment: AppointmentDto
+    appointmentOrSession: AppointmentOrSession
     contactOutcomes: ContactOutcomeDto[]
   }) {
     super(query)
     this.query = query
-    this.appointment = appointment
+    this.appointmentOrSession = appointmentOrSession
     this.contactOutcomes = contactOutcomes
   }
 
@@ -71,7 +72,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
     if (
       this.outcomeIsAttendedOrEnforceable(this.query.attendanceOutcome) &&
-      DateTimeFormats.dateIsInFuture(this.appointment.date)
+      DateTimeFormats.dateIsInFuture(this.appointmentOrSession.date)
     ) {
       validationErrors.attendanceOutcome = {
         text: 'The outcome entered must be: acceptable absence',
@@ -86,9 +87,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
+    const appointment = this.isSingleAppointment(this.appointmentOrSession)
+      ? (this.appointmentOrSession as AppointmentDto)
+      : undefined
     return {
-      ...this.commonViewData({ appointmentOrSession: this.appointment }),
-      ...NotesUtils.questionItems(this.query, form, this.appointment),
+      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession }),
+      ...NotesUtils.questionItems(this.query, form, appointment),
       items: this.items(form, hasErrors),
     }
   }

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -87,7 +87,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
     return {
-      ...this.commonViewData({ appointment: this.appointment }),
+      ...this.commonViewData({ appointmentOrSession: this.appointment }),
       ...NotesUtils.questionItems(this.query, form, this.appointment),
       items: this.items(form, hasErrors),
     }

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -1,0 +1,57 @@
+/* eslint max-classes-per-file: "off" -- need multiple classes to test different implementations of this abstract class */
+
+import { AppointmentOutcomeForm } from '../../@types/user-defined'
+import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
+import { AppointmentFormPage } from './pathMap'
+
+describe('BaseAppointmentUpdatePage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('next()', () => {
+    it('throws an error when nextPage returns undefined', () => {
+      const page = new PageWithoutNextPage({})
+
+      expect(() => page.next({ projectCode: 'P123', appointmentId: '1' })).toThrow('No next page configured')
+    })
+
+    it('throws an error when only projectCode is provided', () => {
+      const page = new PageWithNextPage({})
+
+      expect(() => page.next({ projectCode: 'P123' })).toThrow('Path must have an appointment ID or session date')
+    })
+  })
+})
+
+class PageWithNextPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'attendance-outcome'
+
+  protected nextPage(): AppointmentFormPage {
+    return 'confirm-details'
+  }
+
+  protected backPage(): AppointmentFormPage {
+    return 'choose-supervisor'
+  }
+
+  protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
+    return form
+  }
+}
+
+class PageWithoutNextPage extends BaseAppointmentUpdatePage {
+  protected page: AppointmentFormPage = 'attendance-outcome'
+
+  protected nextPage(): undefined {
+    return undefined
+  }
+
+  protected backPage(): AppointmentFormPage {
+    return 'choose-supervisor'
+  }
+
+  protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
+    return form
+  }
+}

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -1,5 +1,6 @@
-import { AppointmentDto, ProjectDto } from '../../@types/shared'
+import { ProjectDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -27,11 +28,15 @@ export default abstract class BaseAppointmentUpdatePage {
     this.formId = query.form?.toString()
   }
 
-  exitForm(appointment: AppointmentDto, project?: ProjectDto, originalSearch?: Record<string, string>): string {
+  exitForm(
+    appointmentOrSession: AppointmentOrSession,
+    project?: ProjectDto,
+    originalSearch?: Record<string, string>,
+  ): string {
     if (project?.projectType.group === 'GROUP') {
-      return SessionUtils.getSessionPath(appointment, originalSearch)
+      return SessionUtils.getSessionPath(appointmentOrSession, originalSearch)
     }
-    return pathWithQuery(paths.projects.show({ projectCode: appointment.projectCode }), originalSearch)
+    return pathWithQuery(paths.projects.show({ projectCode: appointmentOrSession.projectCode }), originalSearch)
   }
 
   next(projectCode: string, appointmentId: string) {
@@ -55,53 +60,80 @@ export default abstract class BaseAppointmentUpdatePage {
     return this.form
   }
 
-  updatePath(appointment: AppointmentDto) {
-    return this.pathWithFormId(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: this.page,
-      }),
-    )
+  updatePath(appointmentOrSession: AppointmentOrSession) {
+    return this.buildPath(appointmentOrSession, this.page)
   }
 
-  protected backPath(appointment: AppointmentDto, originalSearch?: Record<string, string>, project?: ProjectDto) {
+  protected isSingleAppointment = (appointmentOrSession: AppointmentOrSession) =>
+    'deliusEventNumber' in appointmentOrSession
+
+  protected backPath(
+    appointmentOrSession: AppointmentOrSession,
+    originalSearch?: Record<string, string>,
+    project?: ProjectDto,
+  ) {
     const backPage = this.backPage()
 
     if (!backPage) {
-      return this.exitForm(appointment, project, originalSearch)
+      return this.exitForm(appointmentOrSession, project, originalSearch)
     }
 
-    return pathWithQuery(
-      this.pathWithFormId(
-        paths.appointments.update({
-          projectCode: appointment.projectCode,
-          appointmentId: appointment.id.toString(),
-          page: backPage,
-        }),
-      ),
-      originalSearch,
-    )
+    return this.buildPath(appointmentOrSession, backPage, originalSearch)
   }
 
   protected commonViewData({
-    appointment,
+    appointmentOrSession,
     originalSearch,
     project,
   }: {
-    appointment: AppointmentDto
+    appointmentOrSession: AppointmentOrSession
     originalSearch?: Record<string, string>
     project?: ProjectDto
   }): AppointmentUpdatePageViewData {
-    return {
-      offender: new Offender(appointment.offender),
-      backLink: this.backPath(appointment, originalSearch, project),
-      updatePath: this.updatePath(appointment),
+    const viewData: AppointmentUpdatePageViewData = {
+      backLink: this.backPath(appointmentOrSession, originalSearch, project),
+      updatePath: this.updatePath(appointmentOrSession),
       form: this.formId,
     }
+
+    if ('offender' in appointmentOrSession) {
+      viewData.offender = new Offender(appointmentOrSession.offender)
+    }
+
+    return viewData
   }
 
   protected pathWithFormId(path: string): string {
     return pathWithQuery(path, { form: this.formId })
+  }
+
+  private buildPath(
+    appointmentOrSession: AppointmentOrSession,
+    page: AppointmentFormPage,
+    originalSearch?: Record<string, string>,
+  ): string {
+    if (this.isSingleAppointment(appointmentOrSession)) {
+      return pathWithQuery(
+        this.pathWithFormId(
+          paths.appointments.update({
+            projectCode: appointmentOrSession.projectCode,
+            appointmentId: appointmentOrSession.id.toString(),
+            page,
+          }),
+        ),
+        originalSearch,
+      )
+    }
+
+    return pathWithQuery(
+      this.pathWithFormId(
+        paths.sessions.update({
+          projectCode: appointmentOrSession.projectCode,
+          date: appointmentOrSession.date,
+          page,
+        }),
+      ),
+      originalSearch,
+    )
   }
 }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -39,20 +39,34 @@ export default abstract class BaseAppointmentUpdatePage {
     return pathWithQuery(paths.projects.show({ projectCode: appointmentOrSession.projectCode }), originalSearch)
   }
 
-  next(projectCode: string, appointmentId: string) {
+  next({ appointmentId, date, projectCode }: { projectCode: string; appointmentId?: string; date?: string }) {
     const nextPage = this.nextPage()
 
     if (!nextPage) {
       throw new Error('No next page configured')
     }
 
-    return this.pathWithFormId(
-      paths.appointments.update({
-        projectCode,
-        appointmentId,
-        page: nextPage,
-      }),
-    )
+    if (appointmentId) {
+      return this.pathWithFormId(
+        paths.appointments.update({
+          projectCode,
+          appointmentId,
+          page: nextPage,
+        }),
+      )
+    }
+
+    if (date) {
+      return this.pathWithFormId(
+        paths.sessions.update({
+          projectCode,
+          date,
+          page: nextPage,
+        }),
+      )
+    }
+
+    throw new Error('Path must have an appointment ID or session date')
   }
 
   updateForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -572,7 +572,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode,
         appointmentId,

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -71,7 +71,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     contactOutcome?: ContactOutcomeDto
   }): ViewData {
     return {
-      ...this.commonViewData({ appointment, originalSearch, project }),
+      ...this.commonViewData({ appointmentOrSession: appointment, originalSearch, project }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
       showContinueButton: !appointment.contactOutcomeCode,

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -80,7 +80,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       sharedItems: this.buildSharedDetails(appointment),
       contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
       showMissingOutcomeMessage: this.isMissingOutcome(appointment),
-      nextPath: this.next(appointment.projectCode, appointment.id.toString()),
+      nextPath: this.next({ projectCode: appointment.projectCode, appointmentId: appointment.id.toString() }),
     }
   }
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -195,7 +195,7 @@ describe('ChooseSupervisorPage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'attendance-outcome' })
     })
   })

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -2,6 +2,7 @@ import { AppointmentDto, ProviderTeamSummariesDto, SupervisorSummaryDto } from '
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
 import * as Utils from '../../utils/utils'
@@ -115,6 +116,43 @@ describe('ChooseSupervisorPage', () => {
       )
 
       expect(result.supervisorItems).toBe(supervisorItems)
+    })
+
+    it('should return expected viewData when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build()
+      const teamItems = [
+        { text: 'Choose team', value: '' },
+        { text: 'Team 1', value: 'T1' },
+      ]
+      const supervisorItems = [
+        { text: 'Choose supervisor', value: '' },
+        { text: 'Supervisor 1', value: 'S1' },
+      ]
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValueOnce(teamItems).mockReturnValueOnce(supervisorItems)
+
+      page = new ChooseSupervisorPage({ team: 'T1' })
+
+      const result = page.viewData(session, teams, supervisors, form)
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'choose-supervisor',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'appointment-details',
+      })
+
+      expect(result).toEqual({
+        backLink: pathWithQuery,
+        updatePath: pathWithQuery,
+        teamItems,
+        supervisorItems,
+      })
     })
   })
 

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -1,5 +1,6 @@
-import { AppointmentDto, ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/shared'
+import { ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -53,7 +54,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
   }
 
   viewData(
-    appointment: AppointmentDto,
+    appointmentOrSession: AppointmentOrSession,
     teams: ProviderTeamSummariesDto,
     supervisors: SupervisorSummaryDto[],
     form: AppointmentOutcomeForm,
@@ -62,7 +63,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData({ appointmentOrSession: appointment }),
+      ...this.commonViewData({ appointmentOrSession }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -62,7 +62,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData({ appointment }),
+      ...this.commonViewData({ appointmentOrSession: appointment }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -2,6 +2,7 @@ import { AppointmentDto } from '../../@types/shared'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import ConfirmPage from './confirmPage'
 import * as Utils from '../../utils/utils'
 import { AppointmentOutcomeForm, YesOrNo } from '../../@types/user-defined'
@@ -92,6 +93,34 @@ describe('ConfirmPage', () => {
       expect(result.updatePath).toBe(pathWithQuery)
     })
 
+    it('should return expected commonViewData when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.viewData(session, submitted)
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'confirm-details',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'attendance-outcome',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(result.offender).toBeUndefined()
+    })
+
     describe('alertPractitionerItems', () => {
       it('should return an object containing alert practitioner question items if contact outcome will alert', () => {
         form = appointmentOutcomeFormFactory.build({
@@ -110,6 +139,19 @@ describe('ConfirmPage', () => {
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
         const result = page.viewData(appointment, form)
+        expect(result.alertPractitionerItems).toEqual(items)
+      })
+
+      it('should pass undefined alert value when appointmentOrSession is a session', () => {
+        const session = sessionFactory.build()
+        const items = [{ text: 'Yes', value: 'yes' }]
+        jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
+
+        const determineCheckedValueSpy = jest.spyOn(GovUkRadioGroup, 'determineCheckedValue')
+
+        const result = page.viewData(session, form)
+
+        expect(determineCheckedValueSpy).toHaveBeenCalledWith(undefined)
         expect(result.alertPractitionerItems).toEqual(items)
       })
     })
@@ -507,6 +549,117 @@ describe('ConfirmPage', () => {
             ],
           },
         })
+      })
+
+      it('should return submittedItems with session change links when appointmentOrSession is a session', () => {
+        const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+        const hours = '0'
+        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
+        jest.spyOn(paths.sessions, 'update')
+        jest.spyOn(paths.appointments, 'update')
+
+        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+        const submitted = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          notes: 'some notes',
+          isSensitive: undefined,
+        })
+
+        const result = page.viewData(session, submitted)
+
+        expect(result.submittedItems).toEqual([
+          {
+            key: {
+              text: 'Supervising officer',
+            },
+            value: {
+              text: submitted.supervisor.fullName,
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery,
+                  text: 'Change',
+                  visuallyHiddenText: 'supervising officer',
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: 'Attendance',
+            },
+            value: {
+              text: submitted.contactOutcome.name,
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery,
+                  text: 'Change',
+                  visuallyHiddenText: 'attendance outcome',
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              text: 'some notes',
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery,
+                  text: 'Change',
+                  visuallyHiddenText: 'notes',
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: 'Sensitive',
+            },
+            value: {
+              text: 'Not entered',
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery,
+                  text: 'Change',
+                  visuallyHiddenText: 'sensitivity',
+                },
+              ],
+            },
+          },
+          {
+            key: {
+              text: 'Start and end time',
+            },
+            value: {
+              html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
+            },
+            actions: {
+              items: [],
+            },
+          },
+        ])
+
+        expect(paths.sessions.update).toHaveBeenCalledWith({
+          projectCode: session.projectCode,
+          date: session.date,
+          page: 'choose-supervisor',
+        })
+        expect(paths.sessions.update).toHaveBeenCalledWith({
+          projectCode: session.projectCode,
+          date: session.date,
+          page: 'attendance-outcome',
+        })
+        expect(paths.appointments.update).not.toHaveBeenCalled()
       })
     })
   })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -694,7 +694,7 @@ describe('ConfirmPage', () => {
   describe('nextPath', () => {
     it('should throw not implemented error', () => {
       const page = new ConfirmPage({})
-      expect(() => page.next('', '')).toThrow(new Error('No next page configured'))
+      expect(() => page.next({ projectCode: '', appointmentId: '' })).toThrow(new Error('No next page configured'))
     })
   })
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -42,7 +42,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     this.form = form
 
     return {
-      ...this.commonViewData({ appointment }),
+      ...this.commonViewData({ appointmentOrSession: appointment }),
       submittedItems: this.formItems(form, appointment),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,5 +1,5 @@
-import { AppointmentDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -37,16 +37,17 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return form
   }
 
-  viewData(appointment: AppointmentDto, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
+    const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
     this.form = form
 
     return {
-      ...this.commonViewData({ appointmentOrSession: appointment }),
-      submittedItems: this.formItems(form, appointment),
+      ...this.commonViewData({ appointmentOrSession }),
+      submittedItems: this.formItems(form, appointmentOrSession),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({
-        checkedValue: GovUkRadioGroup.determineCheckedValue(appointment.alertActive),
+        checkedValue: GovUkRadioGroup.determineCheckedValue(alertValue),
       }),
       alertDiaryText: `Would you ${showWillAlertPractitionerMessage ? 'also' : ''} like this to be sent to the alert diary?`,
     }
@@ -99,7 +100,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return `${penaltyTimeInHumanReadableFormat}<br>Total hours credited: ${DateTimeFormats.hoursAndMinutesToHumanReadable(Number(creditedHours), Number(creditedMinutes))}`
   }
 
-  private formItems(form: AppointmentOutcomeForm, appointment: AppointmentDto): GovUkSummaryListItem[] {
+  private formItems(form: AppointmentOutcomeForm, appointment: AppointmentOrSession): GovUkSummaryListItem[] {
     const items = [
       {
         key: {
@@ -135,7 +136,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           ],
         },
       },
-      ...NotesUtils.checkYourAnswersRows(form, this.changePath(appointment, 'attendance-outcome'), appointment),
+      ...NotesUtils.checkYourAnswersRows(
+        form,
+        this.changePath(appointment, 'attendance-outcome'),
+        this.isSingleAppointment(appointment) ? appointment : undefined,
+      ),
       {
         key: {
           text: 'Start and end time',
@@ -201,11 +206,21 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return items
   }
 
-  private changePath(appointment: AppointmentDto, page: AppointmentFormPage) {
+  private changePath(appointmentOrSession: AppointmentOrSession, page: AppointmentFormPage) {
+    if ('deliusEventNumber' in appointmentOrSession) {
+      return this.pathWithFormId(
+        paths.appointments.update({
+          projectCode: appointmentOrSession.projectCode,
+          appointmentId: appointmentOrSession.id.toString(),
+          page,
+        }),
+      )
+    }
+
     return this.pathWithFormId(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
+      paths.sessions.update({
+        projectCode: appointmentOrSession.projectCode,
+        date: appointmentOrSession.date,
         page,
       }),
     )

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -272,7 +272,7 @@ describe('LogCompliancePage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
 
@@ -287,7 +287,7 @@ describe('LogCompliancePage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
   })

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -4,6 +4,7 @@ import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import LogCompliancePage, { LogComplianceQuery } from './logCompliancePage'
 import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -71,6 +72,31 @@ describe('LogCompliancePage', () => {
         page: 'log-compliance',
       })
       expect(result.updatePath).toBe(pathWithQuery)
+    })
+
+    it('should return expected commonViewData when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.viewData(session, form)
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'log-compliance',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'log-hours',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(result.offender).toBeUndefined()
     })
 
     describe('items', () => {

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -1,5 +1,6 @@
-import { AppointmentDto, AttendanceDataDto } from '../../@types/shared'
+import { AttendanceDataDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -57,10 +58,10 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  viewData(appointment: AppointmentDto, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
     const formValues = this.getFormDisplayValues(form)
     return {
-      ...this.commonViewData({ appointmentOrSession: appointment }),
+      ...this.commonViewData({ appointmentOrSession }),
       hiVisItems: GovUkRadioGroup.yesNoItems({
         checkedValue: formValues.hiVis,
       }),

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -60,7 +60,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   viewData(appointment: AppointmentDto, form: AppointmentOutcomeForm): ViewData {
     const formValues = this.getFormDisplayValues(form)
     return {
-      ...this.commonViewData({ appointment }),
+      ...this.commonViewData({ appointmentOrSession: appointment }),
       hiVisItems: GovUkRadioGroup.yesNoItems({
         checkedValue: formValues.hiVis,
       }),

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -2,6 +2,7 @@ import { AppointmentDto } from '../../@types/shared'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 import LogHoursPage, { LogHoursQuery } from './logHoursPage'
 import * as Utils from '../../utils/utils'
@@ -410,6 +411,31 @@ describe('LogHoursPage', () => {
         page: 'log-hours',
       })
       expect(result.updatePath).toBe(pathWithQuery)
+    })
+
+    it('should return expected commonViewData when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.viewData(session, form)
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'log-hours',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'attendance-outcome',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(result.offender).toBeUndefined()
     })
   })
 

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -451,7 +451,7 @@ describe('LogHoursPage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-compliance' })
     })
 
@@ -468,7 +468,7 @@ describe('LogHoursPage', () => {
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next(projectCode, appointmentId)).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
   })

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -5,13 +5,11 @@ import {
   AppointmentUpdateQuery,
   ValidationErrors,
 } from '../../@types/user-defined'
-import Offender from '../../models/offender'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
-  offender: Offender
   startTime: string
   endTime: string
   penaltyTimeHours?: string
@@ -139,7 +137,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     const isOutcomeAcceptableAbsenceStoodDown = form.contactOutcome?.code === 'AASD'
 
     const viewData = {
-      ...this.commonViewData({ appointment }),
+      ...this.commonViewData({ appointmentOrSession: appointment }),
       startTime: DateTimeFormats.stripTime(form.startTime),
       endTime: DateTimeFormats.stripTime(form.endTime),
       showPenaltyHours: isAttended,

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -1,5 +1,5 @@
-import { AppointmentDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -132,12 +132,12 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  viewData(appointment: AppointmentDto, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
     const isAttended = Boolean(form.contactOutcome?.attended)
     const isOutcomeAcceptableAbsenceStoodDown = form.contactOutcome?.code === 'AASD'
 
     const viewData = {
-      ...this.commonViewData({ appointmentOrSession: appointment }),
+      ...this.commonViewData({ appointmentOrSession }),
       startTime: DateTimeFormats.stripTime(form.startTime),
       endTime: DateTimeFormats.stripTime(form.endTime),
       showPenaltyHours: isAttended,

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -9,6 +9,7 @@ const appointmentPath = appointmentsPath.path(':projectCode').path(':appointment
 const projectsIndividualPlacementsPath = projectsPath.path('individual-placements')
 
 const travelTimeTaskPath = appointmentPath.path('travel-time/:taskId')
+const singleSessionPath = sessionsPath.path(':projectCode').path(':date')
 const paths = {
   error: path('/error'),
   data: {
@@ -22,7 +23,8 @@ const paths = {
   sessions: {
     index: sessionsPath,
     search: sessionsPath.path('search'),
-    show: sessionsPath.path(':projectCode').path(':date'),
+    show: singleSessionPath,
+    update: singleSessionPath.path('update/:page'),
   },
   courseCompletions: {
     index: courseCompletionsPath,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,7 +14,7 @@ export default function routes(controllers: Controllers): Router {
 
   const { get } = actions(router)
 
-  const { dashboardController, sessionsController, projectsController, dataController, staticController } = controllers
+  const { dashboardController, projectsController, dataController, staticController } = controllers
 
   get('/', dashboardController.index(), { auditEvent: Page.VIEW_INDEX_PAGE })
   get(paths.data.teams.pattern, dataController.teams())
@@ -28,7 +28,7 @@ export default function routes(controllers: Controllers): Router {
   staticRoutes(staticController, router)
 
   appointmentRoutes(controllers, router)
-  sessionRoutes(sessionsController, router)
+  sessionRoutes(controllers, router)
   projectRoutes(projectsController, router)
   courseCompletionRoutes(controllers, router)
 

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -1,15 +1,43 @@
 import { Router } from 'express'
-import SessionsController from '../controllers/sessionsController'
 import paths from '../paths'
 import { actions } from './utils'
 import { Page } from '../services/auditService'
+import { Controllers } from '../controllers'
+import { AppointmentFormPage } from '../pages/appointments/pathMap'
 
-export default function sessionRoutes(sessionsController: SessionsController, router: Router): Router {
-  const { get } = actions(router)
+export default function sessionRoutes(controllers: Controllers, router: Router): Router {
+  const { get, post } = actions(router)
+  const { sessionsController, appointments } = controllers
 
   get('/sessions', sessionsController.index(), { auditEvent: Page.VIEW_SESSIONS_SEARCH_PAGE })
   get('/sessions/search', sessionsController.search(), { auditEvent: Page.VIEW_SESSIONS })
   get(paths.sessions.show.pattern, sessionsController.show())
+
+  get(paths.sessions.update.pattern, async (req, res, next) => {
+    const page = req.params.page as AppointmentFormPage
+    const controller = appointments.updateControllers[page]
+
+    // There is no route for appointment details when handling multiples
+    if (!controller || page === 'appointment-details') {
+      return next()
+    }
+
+    const handler = controller.show()
+    return handler(req, res, next)
+  })
+
+  post(paths.sessions.update.pattern, async (req, res, next) => {
+    const page = req.params.page as AppointmentFormPage
+    const controller = appointments.updateControllers[page]
+
+    // There is no route for appointment details when handling multiples
+    if (!controller || page === 'appointment-details') {
+      return next()
+    }
+
+    const handler = controller.submit()
+    return handler(req, res, next)
+  })
 
   return router
 }


### PR DESCRIPTION
## Context

In preparation for processing bulk updates of multiple appointments on a group session, this change extends the existing appointment “update” page journey so it can be routed and rendered for either a single appointment, or a group session.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- Introduce the concept of `appointmentOrSession` via abstracted shared method which fetches the appropriate model given the current route params.
- Update routing implementation to return the appropriate next/update/back routes for the view template based on whether the model in question is an appointment or session.

Still to be implemented:
- Introduction of a form page to select the appointments to be updated, and link to start the form
- Handling of submit of bulk appointments (currently the final submit step still only handles single appointments)

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ