### PR TITLE
CPB-1026: Update header for bulk update pages

### DIFF
--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -11,8 +11,8 @@ import {
 import ReferenceDataService from '../../services/referenceDataService'
 
 export type AppointmentUpdatePageViewData = {
+  heading: { title: string; caption: string }
   backLink: string
-  offender?: Offender
   updatePath: string
   form?: string
 }

--- a/server/controllers/appointments/adjustTravelTimeController.test.ts
+++ b/server/controllers/appointments/adjustTravelTimeController.test.ts
@@ -4,7 +4,6 @@ import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import UpdateTravelTimePage from '../../pages/appointments/updateTravelTimePage'
 import AdjustTravelTimeController from './adjustTravelTimeController'
 import AppointmentService from '../../services/appointmentService'
-import Offender from '../../models/offender'
 import ProviderService from '../../services/providerService'
 import SearchTravelTimePage from '../../pages/appointments/searchTravelTimePage'
 import OffenderService from '../../services/offenderService'
@@ -133,7 +132,7 @@ describe('AdjustTravelTimeController', () => {
 
   describe('update', () => {
     const viewData = {
-      offender: { crn: '1234', name: 'Sam Smith', isLimited: false } as Offender,
+      heading: { caption: '1234', title: 'Sam Smith' },
       backLink: '/back',
       updatePath: '/update',
       completeTaskPath: '/complete',
@@ -208,7 +207,7 @@ describe('AdjustTravelTimeController', () => {
 
   describe('submitUpdate', () => {
     const viewData = {
-      offender: { crn: '1234', name: 'Sam Smith', isLimited: false } as Offender,
+      heading: { caption: '1234', title: 'Sam Smith' },
       backLink: '/back',
       updatePath: '/update',
       completeTaskPath: '/complete',

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -301,14 +301,12 @@ describe('AttendanceOutcomePage', () => {
 
     it('returns view data for a session', () => {
       const session = sessionFactory.build()
-      const formattedDate = '10 June 2026'
       const form = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
       })
       const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
 
       jest.spyOn(paths.sessions, 'update')
-      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const page = new AttendanceOutcomePage({
@@ -348,19 +346,14 @@ describe('AttendanceOutcomePage', () => {
         page: 'choose-supervisor',
       })
 
-      expect(result).toEqual({
-        backLink: pathWithQuery,
-        updatePath: pathWithQuery,
-        form: undefined,
-        heading: {
-          title: `${session.projectName}(${formattedDate})`,
-          caption: 'Bulk update',
-        },
-        ...notesItems,
-        items: expectedItems,
-      })
-
-      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
+      expect(result).toEqual(
+        expect.objectContaining({
+          backLink: pathWithQuery,
+          updatePath: pathWithQuery,
+          ...notesItems,
+          items: expectedItems,
+        }),
+      )
     })
 
     it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -286,7 +286,10 @@ describe('AttendanceOutcomePage', () => {
       expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment)
 
       expect(result).toEqual({
-        offender,
+        heading: {
+          title: offender.name,
+          caption: offender.crn,
+        },
         items: expectedItems,
         updatePath: pathWithQuery,
         backLink: pathWithQuery,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -301,12 +301,14 @@ describe('AttendanceOutcomePage', () => {
 
     it('returns view data for a session', () => {
       const session = sessionFactory.build()
+      const formattedDate = '10 June 2026'
       const form = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
       })
       const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
 
       jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const page = new AttendanceOutcomePage({
@@ -350,9 +352,15 @@ describe('AttendanceOutcomePage', () => {
         backLink: pathWithQuery,
         updatePath: pathWithQuery,
         form: undefined,
+        heading: {
+          title: `${session.projectName}(${formattedDate})`,
+          caption: 'Bulk update',
+        },
         ...notesItems,
         items: expectedItems,
       })
+
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
     })
 
     it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -1,8 +1,15 @@
 /* eslint max-classes-per-file: "off" -- need multiple classes to test different implementations of this abstract class */
 
-import { AppointmentOutcomeForm } from '../../@types/user-defined'
+import { ProjectDto } from '../../@types/shared'
+import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
+import Offender from '../../models/offender'
+import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
+
+jest.mock('../../models/offender')
 
 describe('BaseAppointmentUpdatePage', () => {
   beforeEach(() => {
@@ -22,10 +29,57 @@ describe('BaseAppointmentUpdatePage', () => {
       expect(() => page.next({ projectCode: 'P123' })).toThrow('Path must have an appointment ID or session date')
     })
   })
+
+  describe('viewData: heading', () => {
+    it('returns heading containing offender details when appointment is provided', () => {
+      const page = new PageWithNextPage({})
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      const offender = {
+        name: 'Sam Smith',
+        crn: 'CRN123',
+        isLimited: false,
+      }
+
+      offenderMock.mockImplementation(() => offender)
+
+      const result = page.getCommonViewDataForTest({
+        appointmentOrSession: appointmentFactory.build(),
+      })
+
+      expect(result.heading).toEqual({
+        title: offender.name,
+        caption: offender.crn,
+      })
+    })
+
+    it('returns heading containing project name and formatted date when session is provided', () => {
+      const page = new PageWithNextPage({})
+      const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
+      const formattedDate = '10 June 2026'
+
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
+
+      const result = page.getCommonViewDataForTest({ appointmentOrSession: session })
+
+      expect(result.heading).toEqual({
+        title: `${session.projectName} (${formattedDate})`,
+        caption: 'Bulk update',
+      })
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
+    })
+  })
 })
 
 class PageWithNextPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'attendance-outcome'
+
+  public getCommonViewDataForTest(args: {
+    appointmentOrSession: AppointmentOrSession
+    originalSearch?: Record<string, string>
+    project?: ProjectDto
+  }): AppointmentUpdatePageViewData {
+    return this.commonViewData(args)
+  }
 
   protected nextPage(): AppointmentFormPage {
     return 'confirm-details'

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -108,13 +108,20 @@ export default abstract class BaseAppointmentUpdatePage {
       backLink: this.backPath(appointmentOrSession, originalSearch, project),
       updatePath: this.updatePath(appointmentOrSession),
       form: this.formId,
-    }
-
-    if ('offender' in appointmentOrSession) {
-      viewData.offender = new Offender(appointmentOrSession.offender)
+      heading: this.buildHeading(appointmentOrSession),
     }
 
     return viewData
+  }
+
+  private buildHeading(appointmentOrSession: AppointmentOrSession) {
+    if ('offender' in appointmentOrSession) {
+      const offender = new Offender(appointmentOrSession.offender)
+      return {
+        title: offender.name,
+        caption: offender.crn,
+      }
+    }
   }
 
   protected pathWithFormId(path: string): string {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -7,6 +7,7 @@ import {
 } from '../../@types/user-defined'
 import Offender from '../../models/offender'
 import paths from '../../paths'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 import SessionUtils from '../../utils/sessionUtils'
 import { pathWithQuery } from '../../utils/utils'
 import { AppointmentFormPage } from './pathMap'
@@ -121,6 +122,10 @@ export default abstract class BaseAppointmentUpdatePage {
         title: offender.name,
         caption: offender.crn,
       }
+    }
+    return {
+      title: `${appointmentOrSession.projectName}(${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)})`,
+      caption: 'Bulk update',
     }
   }
 

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -124,7 +124,7 @@ export default abstract class BaseAppointmentUpdatePage {
       }
     }
     return {
-      title: `${appointmentOrSession.projectName}(${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)})`,
+      title: `${appointmentOrSession.projectName} (${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)})`,
       caption: 'Bulk update',
     }
   }

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -1,5 +1,4 @@
 import { AppointmentDto } from '../../@types/shared'
-import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
@@ -16,8 +15,6 @@ import enforcementDataFactory from '../../testutils/factories/enforcementDataFac
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import HtmlUtils from '../../utils/htmlUtils'
 
-jest.mock('../../models/offender')
-
 describe('CheckAppointmentDetailsPage', () => {
   const pathWithQuery = '/path?'
   beforeEach(() => {
@@ -29,7 +26,6 @@ describe('CheckAppointmentDetailsPage', () => {
     let page: CheckAppointmentDetailsPage
     let appointment: AppointmentDto
     const updatePath = '/update'
-    const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
 
     beforeEach(() => {
       page = new CheckAppointmentDetailsPage({})
@@ -153,29 +149,6 @@ describe('CheckAppointmentDetailsPage', () => {
       })
       expect(AppointmentUtils.getStatusColour).toHaveBeenCalledWith(contactOutcome)
       expect(HtmlUtils.getStatusTagClass).toHaveBeenCalledWith(statusColour)
-    })
-
-    it('should return an object containing heading details', () => {
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-      }
-
-      offenderMock.mockImplementation(() => {
-        return offender
-      })
-
-      const result = page.viewData({
-        appointment,
-        project: projectFactory.build(),
-        originalSearch: {},
-      })
-
-      expect(result.heading).toEqual({
-        title: offender.name,
-        caption: offender.crn,
-      })
     })
 
     it('should return an object containing a back link to the session page', async () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -155,7 +155,7 @@ describe('CheckAppointmentDetailsPage', () => {
       expect(HtmlUtils.getStatusTagClass).toHaveBeenCalledWith(statusColour)
     })
 
-    it('should return an object containing offender', () => {
+    it('should return an object containing heading details', () => {
       const offender = {
         name: 'Sam Smith',
         crn: 'CRN123',
@@ -172,7 +172,10 @@ describe('CheckAppointmentDetailsPage', () => {
         originalSearch: {},
       })
 
-      expect(result.offender).toBe(offender)
+      expect(result.heading).toEqual({
+        title: offender.name,
+        caption: offender.crn,
+      })
     })
 
     it('should return an object containing a back link to the session page', async () => {

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -6,6 +6,7 @@ import sessionFactory from '../../testutils/factories/sessionFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
 import * as Utils from '../../utils/utils'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import ChooseSupervisorPage from './chooseSupervisorPage'
@@ -120,6 +121,7 @@ describe('ChooseSupervisorPage', () => {
 
     it('should return expected viewData when appointmentOrSession is a session', () => {
       const session = sessionFactory.build()
+      const formattedDate = '10 June 2026'
       const teamItems = [
         { text: 'Choose team', value: '' },
         { text: 'Team 1', value: 'T1' },
@@ -130,6 +132,7 @@ describe('ChooseSupervisorPage', () => {
       ]
 
       jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValueOnce(teamItems).mockReturnValueOnce(supervisorItems)
 
       page = new ChooseSupervisorPage({ team: 'T1' })
@@ -150,9 +153,15 @@ describe('ChooseSupervisorPage', () => {
       expect(result).toEqual({
         backLink: pathWithQuery,
         updatePath: pathWithQuery,
+        heading: {
+          title: `${session.projectName}(${formattedDate})`,
+          caption: 'Bulk update',
+        },
         teamItems,
         supervisorItems,
       })
+
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
     })
   })
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -6,7 +6,6 @@ import sessionFactory from '../../testutils/factories/sessionFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
 import * as Utils from '../../utils/utils'
-import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import ChooseSupervisorPage from './chooseSupervisorPage'
@@ -121,7 +120,6 @@ describe('ChooseSupervisorPage', () => {
 
     it('should return expected viewData when appointmentOrSession is a session', () => {
       const session = sessionFactory.build()
-      const formattedDate = '10 June 2026'
       const teamItems = [
         { text: 'Choose team', value: '' },
         { text: 'Team 1', value: 'T1' },
@@ -132,7 +130,6 @@ describe('ChooseSupervisorPage', () => {
       ]
 
       jest.spyOn(paths.sessions, 'update')
-      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValueOnce(teamItems).mockReturnValueOnce(supervisorItems)
 
       page = new ChooseSupervisorPage({ team: 'T1' })
@@ -150,18 +147,14 @@ describe('ChooseSupervisorPage', () => {
         page: 'appointment-details',
       })
 
-      expect(result).toEqual({
-        backLink: pathWithQuery,
-        updatePath: pathWithQuery,
-        heading: {
-          title: `${session.projectName}(${formattedDate})`,
-          caption: 'Bulk update',
-        },
-        teamItems,
-        supervisorItems,
-      })
-
-      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
+      expect(result).toEqual(
+        expect.objectContaining({
+          backLink: pathWithQuery,
+          updatePath: pathWithQuery,
+          teamItems,
+          supervisorItems,
+        }),
+      )
     })
   })
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -33,7 +33,7 @@ describe('ConfirmPage', () => {
       jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
     })
 
-    it('should return an object containing offender', () => {
+    it('should return an object containing heading details', () => {
       const offender = {
         name: 'Sam Smith',
         crn: 'CRN123',
@@ -46,7 +46,10 @@ describe('ConfirmPage', () => {
 
       const result = page.viewData(appointment, form)
 
-      expect(result.offender).toBe(offender)
+      expect(result.heading).toEqual({
+        title: offender.name,
+        caption: offender.crn,
+      })
     })
 
     describe('back link', () => {
@@ -118,7 +121,7 @@ describe('ConfirmPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.offender).toBeUndefined()
+      expect(result.heading).toBeUndefined()
     })
 
     describe('alertPractitionerItems', () => {

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -121,7 +121,10 @@ describe('ConfirmPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toBeUndefined()
+      expect(result.heading).toEqual({
+        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
+        caption: 'Bulk update',
+      })
     })
 
     describe('alertPractitionerItems', () => {

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -1,5 +1,4 @@
 import { AppointmentDto } from '../../@types/shared'
-import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
@@ -12,8 +11,6 @@ import DateTimeFormats from '../../utils/dateTimeUtils'
 import projectFactory from '../../testutils/factories/projectFactory'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 
-jest.mock('../../models/offender')
-
 describe('ConfirmPage', () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -23,7 +20,6 @@ describe('ConfirmPage', () => {
     let page: ConfirmPage
     let appointment: AppointmentDto
     let form: AppointmentOutcomeForm
-    const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
     const pathWithQuery = '/path?'
 
     beforeEach(() => {
@@ -31,25 +27,6 @@ describe('ConfirmPage', () => {
       appointment = appointmentFactory.build({ sensitive: false })
       form = appointmentOutcomeFormFactory.build()
       jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
-    })
-
-    it('should return an object containing heading details', () => {
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-      }
-
-      offenderMock.mockImplementation(() => {
-        return offender
-      })
-
-      const result = page.viewData(appointment, form)
-
-      expect(result.heading).toEqual({
-        title: offender.name,
-        caption: offender.crn,
-      })
     })
 
     describe('back link', () => {
@@ -121,10 +98,6 @@ describe('ConfirmPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toEqual({
-        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
-        caption: 'Bulk update',
-      })
     })
 
     describe('alertPractitionerItems', () => {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -7,6 +7,7 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import LogCompliancePage, { LogComplianceQuery } from './logCompliancePage'
 import * as Utils from '../../utils/utils'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 
@@ -99,7 +100,10 @@ describe('LogCompliancePage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toBeUndefined()
+      expect(result.heading).toEqual({
+        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
+        caption: 'Bulk update',
+      })
     })
 
     describe('items', () => {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -32,7 +32,7 @@ describe('LogCompliancePage', () => {
       form = appointmentOutcomeFormFactory.build()
     })
 
-    it('should return an object containing offender', () => {
+    it('should return an object containing heading details', () => {
       const offender = {
         name: 'Sam Smith',
         crn: 'CRN123',
@@ -45,7 +45,10 @@ describe('LogCompliancePage', () => {
 
       const result = page.viewData(appointment, form)
 
-      expect(result.offender).toBe(offender)
+      expect(result.heading).toEqual({
+        title: offender.name,
+        caption: offender.crn,
+      })
     })
 
     it('should return an object containing a back link to the session page', async () => {
@@ -96,7 +99,7 @@ describe('LogCompliancePage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.offender).toBeUndefined()
+      expect(result.heading).toBeUndefined()
     })
 
     describe('items', () => {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -1,17 +1,13 @@
 import { AppointmentDto } from '../../@types/shared'
 import { AppointmentOutcomeForm, GovUkRadioOption } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
-import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import LogCompliancePage, { LogComplianceQuery } from './logCompliancePage'
 import * as Utils from '../../utils/utils'
-import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
-
-jest.mock('../../models/offender')
 
 describe('LogCompliancePage', () => {
   let page: LogCompliancePage
@@ -24,32 +20,12 @@ describe('LogCompliancePage', () => {
   })
 
   describe('viewData', () => {
-    const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
     let form: AppointmentOutcomeForm
 
     beforeEach(() => {
       page = new LogCompliancePage({})
       appointment = appointmentFactory.build()
       form = appointmentOutcomeFormFactory.build()
-    })
-
-    it('should return an object containing heading details', () => {
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-      }
-
-      offenderMock.mockImplementation(() => {
-        return offender
-      })
-
-      const result = page.viewData(appointment, form)
-
-      expect(result.heading).toEqual({
-        title: offender.name,
-        caption: offender.crn,
-      })
     })
 
     it('should return an object containing a back link to the session page', async () => {
@@ -100,10 +76,6 @@ describe('LogCompliancePage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toEqual({
-        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
-        caption: 'Bulk update',
-      })
     })
 
     describe('items', () => {

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -1,17 +1,13 @@
 import { AppointmentDto } from '../../@types/shared'
-import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 import LogHoursPage, { LogHoursQuery } from './logHoursPage'
 import * as Utils from '../../utils/utils'
-import DateTimeFormats from '../../utils/dateTimeUtils'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
-
-jest.mock('../../models/offender')
 
 describe('LogHoursPage', () => {
   let page: LogHoursPage
@@ -232,7 +228,6 @@ describe('LogHoursPage', () => {
     let appointment: AppointmentDto
     let form: AppointmentOutcomeForm
     const updatePath = '/update'
-    const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
 
     beforeEach(() => {
       page = new LogHoursPage()
@@ -375,25 +370,6 @@ describe('LogHoursPage', () => {
       })
     })
 
-    it('should return an object containing heading details', () => {
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-      }
-
-      offenderMock.mockImplementation(() => {
-        return offender
-      })
-
-      const result = page.viewData(appointment, form)
-
-      expect(result.heading).toEqual({
-        title: offender.name,
-        caption: offender.crn,
-      })
-    })
-
     it('should return an object containing a back link to the attendance outcome page', async () => {
       jest.spyOn(paths.appointments, 'update')
       const result = page.viewData(appointment, form)
@@ -439,10 +415,6 @@ describe('LogHoursPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toEqual({
-        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
-        caption: 'Bulk update',
-      })
     })
   })
 

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -6,6 +6,7 @@ import sessionFactory from '../../testutils/factories/sessionFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
 import LogHoursPage, { LogHoursQuery } from './logHoursPage'
 import * as Utils from '../../utils/utils'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
@@ -438,7 +439,10 @@ describe('LogHoursPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.heading).toBeUndefined()
+      expect(result.heading).toEqual({
+        title: `${session.projectName}(${DateTimeFormats.isoDateToUIDate(session.date)})`,
+        caption: 'Bulk update',
+      })
     })
   })
 

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -374,7 +374,7 @@ describe('LogHoursPage', () => {
       })
     })
 
-    it('should return an object containing offender', () => {
+    it('should return an object containing heading details', () => {
       const offender = {
         name: 'Sam Smith',
         crn: 'CRN123',
@@ -387,7 +387,10 @@ describe('LogHoursPage', () => {
 
       const result = page.viewData(appointment, form)
 
-      expect(result.offender).toBe(offender)
+      expect(result.heading).toEqual({
+        title: offender.name,
+        caption: offender.crn,
+      })
     })
 
     it('should return an object containing a back link to the attendance outcome page', async () => {
@@ -435,7 +438,7 @@ describe('LogHoursPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.offender).toBeUndefined()
+      expect(result.heading).toBeUndefined()
     })
   })
 

--- a/server/pages/appointments/updateTravelTimePage.test.ts
+++ b/server/pages/appointments/updateTravelTimePage.test.ts
@@ -197,7 +197,7 @@ describe('UpdateTravelTimePage', () => {
       })
 
       expect(result).toEqual({
-        offender,
+        heading: { title: offender.name, caption: offender.crn },
         updatePath: paths.appointments.travelTime.update({
           projectCode: appointment.projectCode,
           appointmentId: appointment.id.toString(),

--- a/server/pages/appointments/updateTravelTimePage.ts
+++ b/server/pages/appointments/updateTravelTimePage.ts
@@ -25,7 +25,7 @@ interface AppointmentDetails {
 
 interface PageViewData {
   backLink: string
-  offender: Offender
+  heading: { title: string; caption: string }
   updatePath: string
   completeTaskPath: string
   appointment: AppointmentDetails
@@ -73,8 +73,9 @@ export default class UpdateTravelTimePage extends PageWithValidation<ObjectWithD
     req: Request
     upwDetails: UnpaidWorkDetailsDto
   }): PageViewData {
+    const offender = new Offender(appointment.offender)
     return {
-      offender: new Offender(appointment.offender),
+      heading: { title: offender.name, caption: offender.crn },
       backLink: this.exitPath(originalSearch),
       updatePath: this.updatePath(appointment, taskId, originalSearch),
       completeTaskPath: pathWithQuery(

--- a/server/views/appointments/_appointmentHeader.njk
+++ b/server/views/appointments/_appointmentHeader.njk
@@ -1,9 +1,9 @@
-{% macro offenderDetails(offender) %}
+{% macro appointmentHeader(heading) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full cpb-offender-details">
       <div>
-        <span class="govuk-caption-l">{{ offender.crn }}</span>
-        <h1 class="govuk-heading-l">{{ offender.name }}</h1>
+        <span class="govuk-caption-l">{{ heading.caption }}</span>
+        <h1 class="govuk-heading-l">{{ heading.title }}</h1>
       </div>
       {{ caller() }}
     </div>

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "../_offenderDetails.njk" import offenderDetails %}
+{% from "../_appointmentHeader.njk" import appointmentHeader %}
 
 {% from "../../showErrorSummary.njk" import showErrorSummary %}
 
@@ -37,7 +37,7 @@
   {% endif %}
 
 
-  {% call offenderDetails(offender) %}
+  {% call appointmentHeader(heading) %}
     {% block headerCallToAction %}
     {% endblock %}
   {% endcall %}


### PR DESCRIPTION
## Context

This adds an alternate heading for appointment form pages if a bulk update.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

Also:
- Create a generic header object for pages, rather than mapping from offender details in view
- Refactor tests across page classes to reduce repetition

### Screenshots of UI changes

<img width="1002" height="662" alt="Attendance outcome form page with project name in heading" src="https://github.com/user-attachments/assets/5651ced0-f241-43d3-8a5f-7a71d2b72633" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ