### PR TITLE
CPB-1026: Add integration tests for bulk update form journey

### DIFF
--- a/integration_tests/pages/appointments/attendanceOutcomePage.ts
+++ b/integration_tests/pages/appointments/attendanceOutcomePage.ts
@@ -1,37 +1,20 @@
-import paths from '../../../server/paths'
-import Offender from '../../../server/models/offender'
-import Page from '../page'
-import { AppointmentDto } from '../../../server/@types/shared'
-import { pathWithQuery } from '../../../server/utils/utils'
 import RadioGroupComponent from '../components/radioGroupComponent'
 import NotesQuestionComponent from '../components/notesQuestionComponent'
+import { AppointmentOrSession } from '../../../server/@types/user-defined'
+import BaseAppointmentFormPage from './baseAppointmentFormPage'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
-export default class AttendanceOutcomePage extends Page {
+export default class AttendanceOutcomePage extends BaseAppointmentFormPage {
+  protected override page: AppointmentFormPage = 'attendance-outcome'
+
   readonly contactOutcomeOptions: RadioGroupComponent
 
   readonly notesQuestions: NotesQuestionComponent
 
-  constructor(appointment: AppointmentDto) {
-    const offender = new Offender(appointment.offender)
-    super(offender.name)
+  constructor(appointmentOrSession: AppointmentOrSession) {
+    super(appointmentOrSession)
     this.contactOutcomeOptions = new RadioGroupComponent('attendanceOutcome')
     this.notesQuestions = new NotesQuestionComponent()
-  }
-
-  static visit(appointment: AppointmentDto): AttendanceOutcomePage {
-    const path = pathWithQuery(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'attendance-outcome',
-      }),
-      {
-        form: '123',
-      },
-    )
-    cy.visit(path)
-
-    return new AttendanceOutcomePage(appointment)
   }
 
   completeForm(contactOutcomeCode: string) {

--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -4,7 +4,7 @@ import Page from '../page'
 import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
-import { AppointmentDto } from '../../../server/@types/shared'
+import { AppointmentDto, SessionDto } from '../../../server/@types/shared'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 
 export default abstract class BaseAppointmentFormPage extends Page {
@@ -32,11 +32,32 @@ export default abstract class BaseAppointmentFormPage extends Page {
     return page
   }
 
+  static visitForSession<T extends BaseAppointmentFormPage, A extends unknown[]>(
+    this: new (session: SessionDto, ...args: A) => T,
+    session: SessionDto,
+    ...args: A
+  ): T {
+    const page = new this(session, ...args)
+    cy.visit(page.sessionPath(session))
+    page.checkOnPage()
+    return page
+  }
+
   protected appointmentPath = (appointment: AppointmentDto) =>
     pathWithQuery(
       paths.appointments.update({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        page: this.page,
+      }),
+      { form: '123' },
+    )
+
+  protected sessionPath = (session: SessionDto) =>
+    pathWithQuery(
+      paths.sessions.update({
+        projectCode: session.projectCode,
+        date: session.date,
         page: this.page,
       }),
       { form: '123' },

--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -1,0 +1,44 @@
+import { AppointmentOrSession } from '../../../server/@types/user-defined'
+import Offender from '../../../server/models/offender'
+import Page from '../page'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
+import { pathWithQuery } from '../../../server/utils/utils'
+import paths from '../../../server/paths'
+import { AppointmentDto } from '../../../server/@types/shared'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+
+export default abstract class BaseAppointmentFormPage extends Page {
+  protected readonly isSingleAppointment: boolean
+
+  protected abstract page: AppointmentFormPage
+
+  constructor(appointment: AppointmentOrSession) {
+    const isSingleAppointment = 'offender' in appointment
+    const title = isSingleAppointment
+      ? new Offender(appointment.offender).name
+      : `${appointment.projectName} (${DateTimeFormats.isoDateToUIDate(appointment.date)})`
+    super(title)
+    this.isSingleAppointment = isSingleAppointment
+  }
+
+  static visit<T extends BaseAppointmentFormPage, A extends unknown[]>(
+    this: new (appointment: AppointmentDto, ...args: A) => T,
+    appointment: AppointmentDto,
+    ...args: A
+  ): T {
+    const page = new this(appointment, ...args)
+    cy.visit(page.appointmentPath(appointment))
+    page.checkOnPage()
+    return page
+  }
+
+  protected appointmentPath = (appointment: AppointmentDto) =>
+    pathWithQuery(
+      paths.appointments.update({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: this.page,
+      }),
+      { form: '123' },
+    )
+}

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -57,9 +57,7 @@ export default class CheckAppointmentDetailsPage extends Page {
       }),
       originalSearch,
     )
-    cy.visit(path)
-
-    return new CheckAppointmentDetailsPage(appointment, project)
+    return this.visitAndCheck(path, appointment, project)
   }
 
   clickUpdate() {

--- a/integration_tests/pages/appointments/chooseSupervisorPage.ts
+++ b/integration_tests/pages/appointments/chooseSupervisorPage.ts
@@ -1,11 +1,11 @@
 import { AppointmentDto } from '../../../server/@types/shared'
-import paths from '../../../server/paths'
 import SelectInput from '../components/selectComponent'
-import Page from '../page'
-import Offender from '../../../server/models/offender'
-import { pathWithQuery } from '../../../server/utils/utils'
+import BaseAppointmentFormPage from './baseAppointmentFormPage'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
-export default class ChooseSupervisorPage extends Page {
+export default class ChooseSupervisorPage extends BaseAppointmentFormPage {
+  protected override page: AppointmentFormPage = 'choose-supervisor'
+
   readonly teamInput: SelectInput
 
   readonly supervisorInput: SelectInput
@@ -13,27 +13,10 @@ export default class ChooseSupervisorPage extends Page {
   readonly appointment: AppointmentDto
 
   constructor(appointment: AppointmentDto) {
-    const offender = new Offender(appointment.offender)
-
-    super(offender.name)
+    super(appointment)
     this.appointment = appointment
     this.teamInput = new SelectInput('team')
     this.supervisorInput = new SelectInput('supervisor')
-  }
-
-  static visit(appointment: AppointmentDto): ChooseSupervisorPage {
-    const path = pathWithQuery(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'choose-supervisor',
-      }),
-      { form: '123' },
-    )
-
-    cy.visit(path)
-
-    return new ChooseSupervisorPage(appointment)
   }
 
   protected override customCheckOnPage(): void {

--- a/integration_tests/pages/appointments/chooseSupervisorPage.ts
+++ b/integration_tests/pages/appointments/chooseSupervisorPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto } from '../../../server/@types/shared'
+import { AppointmentOrSession } from '../../../server/@types/user-defined'
 import SelectInput from '../components/selectComponent'
 import BaseAppointmentFormPage from './baseAppointmentFormPage'
 import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
@@ -10,16 +10,18 @@ export default class ChooseSupervisorPage extends BaseAppointmentFormPage {
 
   readonly supervisorInput: SelectInput
 
-  readonly appointment: AppointmentDto
-
-  constructor(appointment: AppointmentDto) {
-    super(appointment)
-    this.appointment = appointment
+  constructor(appointmentOrSession: AppointmentOrSession) {
+    super(appointmentOrSession)
     this.teamInput = new SelectInput('team')
     this.supervisorInput = new SelectInput('supervisor')
   }
 
   protected override customCheckOnPage(): void {
     cy.get('h2').should('contain.text', 'Add supervisor details')
+  }
+
+  selectTeam(teamCode: string) {
+    this.teamInput.select(teamCode)
+    cy.get('button').contains('Select team').click()
   }
 }

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -1,13 +1,13 @@
 import { AppointmentDto } from '../../../server/@types/shared'
-import paths from '../../../server/paths'
-import Offender from '../../../server/models/offender'
-import Page from '../page'
 import { AppointmentOutcomeForm } from '../../../server/@types/user-defined'
 import SummaryListComponent from '../components/summaryListComponent'
-import { pathWithQuery } from '../../../server/utils/utils'
 import RadioGroupComponent from '../components/radioGroupComponent'
+import BaseAppointmentFormPage from './baseAppointmentFormPage'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
-export default class ConfirmDetailsPage extends Page {
+export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
+  protected override page: AppointmentFormPage = 'confirm-details'
+
   private readonly formDetails: SummaryListComponent
 
   readonly alertPractitionerQuestion: RadioGroupComponent
@@ -16,26 +16,9 @@ export default class ConfirmDetailsPage extends Page {
     appointment: AppointmentDto,
     private readonly form: AppointmentOutcomeForm,
   ) {
-    const offender = new Offender(appointment.offender)
-    super(offender.name)
+    super(appointment)
     this.formDetails = new SummaryListComponent()
     this.alertPractitionerQuestion = new RadioGroupComponent('alertPractitioner')
-  }
-
-  static visit(appointment: AppointmentDto, form: AppointmentOutcomeForm, formId: string): ConfirmDetailsPage {
-    const path = pathWithQuery(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'confirm-details',
-      }),
-      {
-        form: formId,
-      },
-    )
-    cy.visit(path)
-
-    return new ConfirmDetailsPage(appointment, form)
   }
 
   shouldShowCompletedDetails(): void {

--- a/integration_tests/pages/appointments/logCompliancePage.ts
+++ b/integration_tests/pages/appointments/logCompliancePage.ts
@@ -1,11 +1,11 @@
 import { AppointmentDto, AttendanceDataDto } from '../../../server/@types/shared'
-import paths from '../../../server/paths'
-import Page from '../page'
-import Offender from '../../../server/models/offender'
-import { pathWithQuery } from '../../../server/utils/utils'
 import RadioGroupComponent from '../components/radioGroupComponent'
+import BaseAppointmentFormPage from './baseAppointmentFormPage'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
-export default class LogCompliancePage extends Page {
+export default class LogCompliancePage extends BaseAppointmentFormPage {
+  protected override page: AppointmentFormPage = 'log-compliance'
+
   private readonly hiVisOptions = new RadioGroupComponent('hiVis')
 
   private readonly workedIntensivelyOptions = new RadioGroupComponent('workedIntensively')
@@ -15,24 +15,7 @@ export default class LogCompliancePage extends Page {
   private readonly behaviourOptions = new RadioGroupComponent('behaviour')
 
   constructor(appointment: AppointmentDto) {
-    const offender = new Offender(appointment.offender)
-    super(offender.name)
-  }
-
-  static visit(appointment: AppointmentDto): LogCompliancePage {
-    const path = pathWithQuery(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'log-compliance',
-      }),
-      {
-        form: '123',
-      },
-    )
-    cy.visit(path)
-
-    return new LogCompliancePage(appointment)
+    super(appointment)
   }
 
   completeForm(): void {

--- a/integration_tests/pages/appointments/logCompliancePage.ts
+++ b/integration_tests/pages/appointments/logCompliancePage.ts
@@ -1,4 +1,5 @@
-import { AppointmentDto, AttendanceDataDto } from '../../../server/@types/shared'
+import { AttendanceDataDto } from '../../../server/@types/shared'
+import { AppointmentOrSession } from '../../../server/@types/user-defined'
 import RadioGroupComponent from '../components/radioGroupComponent'
 import BaseAppointmentFormPage from './baseAppointmentFormPage'
 import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
@@ -14,8 +15,8 @@ export default class LogCompliancePage extends BaseAppointmentFormPage {
 
   private readonly behaviourOptions = new RadioGroupComponent('behaviour')
 
-  constructor(appointment: AppointmentDto) {
-    super(appointment)
+  constructor(appointmentOrSession: AppointmentOrSession) {
+    super(appointmentOrSession)
   }
 
   completeForm(): void {

--- a/integration_tests/pages/appointments/logHoursPage.ts
+++ b/integration_tests/pages/appointments/logHoursPage.ts
@@ -1,13 +1,12 @@
 import { AppointmentDto } from '../../../server/@types/shared'
-import paths from '../../../server/paths'
-import Offender from '../../../server/models/offender'
-import Page from '../page'
-import { pathWithQuery } from '../../../server/utils/utils'
+import BaseAppointmentFormPage from './baseAppointmentFormPage'
+import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
-export default class LogHoursPage extends Page {
+export default class LogHoursPage extends BaseAppointmentFormPage {
+  protected override page: AppointmentFormPage = 'log-hours'
+
   constructor(appointment: AppointmentDto) {
-    const offender = new Offender(appointment.offender)
-    super(offender.name)
+    super(appointment)
   }
 
   private startTimeInput = () => this.getTextInputById('startTime')
@@ -17,22 +16,6 @@ export default class LogHoursPage extends Page {
   private penaltyHoursInput = () => this.getTextInputById('penaltyTimeHours')
 
   private penaltyMinutesInput = () => this.getTextInputById('penaltyTimeMinutes')
-
-  static visit(appointment: AppointmentDto): LogHoursPage {
-    const path = pathWithQuery(
-      paths.appointments.update({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'log-hours',
-      }),
-      {
-        form: '123',
-      },
-    )
-    cy.visit(path)
-
-    return new LogHoursPage(appointment)
-  }
 
   enterStartTime(time: string): void {
     this.startTimeInput().clear()

--- a/integration_tests/pages/appointments/logHoursPage.ts
+++ b/integration_tests/pages/appointments/logHoursPage.ts
@@ -1,12 +1,12 @@
-import { AppointmentDto } from '../../../server/@types/shared'
+import { AppointmentOrSession } from '../../../server/@types/user-defined'
 import BaseAppointmentFormPage from './baseAppointmentFormPage'
 import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 
 export default class LogHoursPage extends BaseAppointmentFormPage {
   protected override page: AppointmentFormPage = 'log-hours'
 
-  constructor(appointment: AppointmentDto) {
-    super(appointment)
+  constructor(appointmentOrSession: AppointmentOrSession) {
+    super(appointmentOrSession)
   }
 
   private startTimeInput = () => this.getTextInputById('startTime')
@@ -36,7 +36,7 @@ export default class LogHoursPage extends BaseAppointmentFormPage {
   }
 
   shouldShowEnteredTimes(
-    args: { startTime: string; endTime: string; penaltyHours: string; penaltyMinutes: string } = {
+    args: { startTime: string; endTime: string; penaltyHours?: string; penaltyMinutes?: string } = {
       startTime: '09:00',
       endTime: '17:00',
       penaltyHours: '1',
@@ -45,8 +45,13 @@ export default class LogHoursPage extends BaseAppointmentFormPage {
   ) {
     this.startTimeInput().should('have.value', args.startTime)
     this.endTimeInput().should('have.value', args.endTime)
-    this.penaltyHoursInput().should('have.value', args.penaltyHours)
-    this.penaltyMinutesInput().should('have.value', args.penaltyMinutes)
+    if (args.penaltyHours) {
+      this.penaltyHoursInput().should('have.value', args.penaltyHours)
+    }
+
+    if (args.penaltyMinutes) {
+      this.penaltyMinutesInput().should('have.value', args.penaltyMinutes)
+    }
   }
 
   shouldShowReadOnlyStartAndEndTimes(startTime: string, endTime: string): void {

--- a/integration_tests/pages/appointments/searchAttendedPage.ts
+++ b/integration_tests/pages/appointments/searchAttendedPage.ts
@@ -23,9 +23,7 @@ export default class SearchAttendedPage extends Page {
   }
 
   static visit(appointments: Array<AppointmentTaskSummaryDto> = []) {
-    cy.visit(paths.appointments.travelTime.index({}))
-
-    return new SearchAttendedPage(appointments)
+    return this.visitAndCheck(paths.appointments.travelTime.index({}), appointments)
   }
 
   shouldShowSearchForm() {

--- a/integration_tests/pages/appointments/updateTravelTimePage.ts
+++ b/integration_tests/pages/appointments/updateTravelTimePage.ts
@@ -31,10 +31,7 @@ export default class UpdateTravelTimePage extends Page {
       taskId,
     })
     const path = originalSearch ? pathWithQuery(basePath, originalSearch) : basePath
-
-    cy.visit(path)
-
-    return new UpdateTravelTimePage(appointment)
+    return this.visitAndCheck(path, appointment)
   }
 
   clickNotEligible() {

--- a/integration_tests/pages/courseCompletions/courseCompletionPage.ts
+++ b/integration_tests/pages/courseCompletions/courseCompletionPage.ts
@@ -26,9 +26,7 @@ export default class CourseCompletionPage extends Page {
     searchParams?: CourseCompletionPageInput,
   ): CourseCompletionPage {
     const path = pathWithQuery(paths.courseCompletions.show({ id: courseCompletion.id }), searchParams)
-    cy.visit(path)
-
-    return new CourseCompletionPage(courseCompletion)
+    return this.visitAndCheck(path, courseCompletion)
   }
 
   shouldShowCourseCompletionDetails() {

--- a/integration_tests/pages/courseCompletions/process/appointmentPage.ts
+++ b/integration_tests/pages/courseCompletions/process/appointmentPage.ts
@@ -16,9 +16,7 @@ export default class AppointmentPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'appointments', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new AppointmentPage(title)
+    return this.visitAndCheck(path, title)
   }
 
   selectAppointment(appointmentId: number) {

--- a/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
+++ b/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
@@ -28,9 +28,7 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'confirm', id: courseCompletion.id }), {
       form: '1',
     })
-    cy.visit(path)
-
-    return new ConfirmDetailsPage(form)
+    return this.visitAndCheck(path, form)
   }
 
   shouldShowCompletedDetails(

--- a/integration_tests/pages/courseCompletions/process/crnPage.ts
+++ b/integration_tests/pages/courseCompletions/process/crnPage.ts
@@ -20,9 +20,7 @@ export default class CrnPage extends BaseCourseCompletionsPage {
       ...originalSearch,
       form: formId,
     })
-    cy.visit(path)
-
-    return new CrnPage()
+    return this.visitAndCheck(path)
   }
 
   enterCrn(crn: string) {

--- a/integration_tests/pages/courseCompletions/process/historyPage.ts
+++ b/integration_tests/pages/courseCompletions/process/historyPage.ts
@@ -13,9 +13,7 @@ export default class HistoryPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'history', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new HistoryPage()
+    return this.visitAndCheck(path)
   }
 
   shouldShowAppointmentDetails(appointments: Array<AppointmentSummaryDto>) {

--- a/integration_tests/pages/courseCompletions/process/outcomePage.ts
+++ b/integration_tests/pages/courseCompletions/process/outcomePage.ts
@@ -34,9 +34,7 @@ export default class OutcomePage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'outcome', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new OutcomePage(courseCompletion)
+    return this.visitAndCheck(path, courseCompletion)
   }
 
   enterAppointmentDate(day: string, month: string, year: string) {

--- a/integration_tests/pages/courseCompletions/process/personPage.ts
+++ b/integration_tests/pages/courseCompletions/process/personPage.ts
@@ -23,9 +23,7 @@ export default class PersonPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'person', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new PersonPage(courseCompletion, offender)
+    return this.visitAndCheck(path, courseCompletion, offender)
   }
 
   clickEnterAnotherCrn() {

--- a/integration_tests/pages/courseCompletions/process/projectPage.ts
+++ b/integration_tests/pages/courseCompletions/process/projectPage.ts
@@ -21,9 +21,7 @@ export default class ProjectPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'project', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new ProjectPage()
+    return this.visitAndCheck(path)
   }
 
   selectTeam(team: ProviderTeamSummaryDto) {

--- a/integration_tests/pages/courseCompletions/process/requirementPage.ts
+++ b/integration_tests/pages/courseCompletions/process/requirementPage.ts
@@ -19,9 +19,7 @@ export default class RequirementPage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.process({ page: 'requirement', id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new RequirementPage()
+    return this.visitAndCheck(path)
   }
 
   selectRequirement(deliusEventNumber: number) {

--- a/integration_tests/pages/courseCompletions/process/unableToCreditTimePage.ts
+++ b/integration_tests/pages/courseCompletions/process/unableToCreditTimePage.ts
@@ -14,9 +14,7 @@ export default class UnableToCreditTimePage extends BaseCourseCompletionsPage {
     const path = pathWithQuery(paths.courseCompletions.unableToCreditTime({ id: courseCompletion.id }), {
       form: '12',
     })
-    cy.visit(path)
-
-    return new UnableToCreditTimePage()
+    return this.visitAndCheck(path)
   }
 
   enterNotes() {

--- a/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -18,9 +18,7 @@ export default class SearchCourseCompletionsPage extends Page {
   }
 
   static visit(): SearchCourseCompletionsPage {
-    cy.visit(paths.courseCompletions.index({}))
-
-    return new SearchCourseCompletionsPage()
+    return this.visitAndCheck(paths.courseCompletions.index({}))
   }
 
   shouldShowSearchForm() {

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -14,9 +14,7 @@ export default class FindASessionPage extends Page {
   }
 
   static visit(): FindASessionPage {
-    cy.visit(paths.sessions.index({}))
-
-    return new FindASessionPage()
+    return this.visitAndCheck(paths.sessions.index({}))
   }
 
   shouldShowSearchForm() {

--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -6,9 +6,7 @@ export default class HomePage extends Page {
   }
 
   static visit(): HomePage {
-    cy.visit('/')
-
-    return new HomePage()
+    return this.visitAndCheck('/')
   }
 
   shouldShowSignOutButton(): void {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -4,13 +4,22 @@ import { Result } from 'axe-core'
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page {
-  static verifyOnPage<T>(constructor: new (...args: Array<unknown>) => T, ...args: Array<unknown>): T {
-    return new constructor(...args)
+  static verifyOnPage<T extends Page>(constructor: new (...args: Array<unknown>) => T, ...args: Array<unknown>): T {
+    const page = new constructor(...args)
+    page.checkOnPage()
+    return page
   }
 
-  protected constructor(private readonly title: string) {
-    this.checkOnPage()
+  protected static visitAndCheck<T extends Page, A extends Array<unknown>>(
+    this: new (...args: A) => T,
+    path: string,
+    ...args: A
+  ): T {
+    cy.visit(path)
+    return Page.verifyOnPage(this, ...args)
   }
+
+  protected constructor(private readonly title: string) {}
 
   // Ignoring rule `no-empty-function`
   // This is designed to be empty to provide an optional page verification override at the class implementation level

--- a/integration_tests/pages/projects/findIndividualPlacementPage.ts
+++ b/integration_tests/pages/projects/findIndividualPlacementPage.ts
@@ -21,9 +21,7 @@ export default class FindIndividualPlacementPage extends Page {
   }
 
   static visit(projects: Array<ProjectOutcomeSummaryDto> = []) {
-    cy.visit(paths.projects.index({}))
-
-    return new FindIndividualPlacementPage(projects)
+    return this.visitAndCheck(paths.projects.index({}), projects)
   }
 
   shouldShowSearchForm() {

--- a/integration_tests/pages/projects/projectPage.ts
+++ b/integration_tests/pages/projects/projectPage.ts
@@ -20,9 +20,7 @@ export default class ProjectPage extends Page {
 
   static visit(project: ProjectDto): ProjectPage {
     const path = `${paths.projects.show({ projectCode: project.projectCode.toString() })}`
-    cy.visit(path)
-
-    return new ProjectPage(project)
+    return this.visitAndCheck(path, project)
   }
 
   clickUpdateAnAppointment() {

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -22,9 +22,7 @@ export default class ViewSessionPage extends Page {
 
   static visit(session: SessionDto): ViewSessionPage {
     const path = `${paths.sessions.show({ projectCode: session.projectCode, date: session.date })}`
-    cy.visit(path)
-
-    return new ViewSessionPage(session)
+    return this.visitAndCheck(path, session)
   }
 
   clickUpdateAnAppointment() {

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -123,7 +123,7 @@ context('Confirm appointment details page', () => {
     cy.task('stubFindAppointment', { appointment: this.appointment })
     cy.task('stubGetAppointmentForm', form)
 
-    const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+    const page = ConfirmDetailsPage.visit(this.appointment, form)
     page.checkOnPage()
 
     // Then I can see my submitted answers
@@ -150,7 +150,7 @@ context('Confirm appointment details page', () => {
     cy.task('stubFindAppointment', { appointment: this.appointment })
     cy.task('stubGetAppointmentForm', form)
 
-    const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+    const page = ConfirmDetailsPage.visit(this.appointment, form)
     page.checkOnPage()
 
     // Then I can see my completed answers without attendance
@@ -173,7 +173,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
       page.shouldShowCompletedDetails()
 
       //  Then I also see a question asking if I want to alert the probation practitioner
@@ -194,7 +194,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
       page.shouldShowCompletedDetails()
 
       //  Then I can answer yes or no to question asking if I want to alert the probation practitioner
@@ -216,7 +216,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubGetAppointmentForm', form)
 
       // Given I am on the confirm page of an in progress update
-      const page = ConfirmDetailsPage.visit(appointmentWithSensitive, form, '1')
+      const page = ConfirmDetailsPage.visit(appointmentWithSensitive, form)
       page.shouldShowSensitiveValue('Yes')
       page.shouldNotShowChangeLink('Sensitive')
     })
@@ -235,7 +235,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubGetContactOutcomes', { contactOutcomes })
 
       // Given I am on the confirm page of an in progress update
-      const page = ConfirmDetailsPage.visit(appointmentWithoutSensitive, form, '1')
+      const page = ConfirmDetailsPage.visit(appointmentWithoutSensitive, form)
       page.shouldShowSensitiveValue(properCase(form.isSensitive))
       page.clickChange('Sensitive')
       Page.verifyOnPage(AttendanceOutcomePage, appointmentWithoutSensitive)
@@ -255,7 +255,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       // And I click back
       page.clickBack()
@@ -281,7 +281,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       // And I click back
       page.clickBack()
@@ -309,7 +309,7 @@ context('Confirm appointment details page', () => {
       const provider = providerSummaryFactory.build({ code: this.appointment.providerCode })
       cy.task('stubGetProviders', { providers: { providers: [provider] } })
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       const supervisors = [
         ...supervisorSummaryFactory.buildList(2),
@@ -342,7 +342,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
 
@@ -363,7 +363,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
 
@@ -384,7 +384,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       cy.task('stubGetContactOutcomes', { contactOutcomes })
 
@@ -405,7 +405,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       // And I click change
       page.clickChange('Start and end time')
@@ -422,7 +422,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       // And I click change
       page.clickChange('Penalty hours')
@@ -439,7 +439,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment: this.appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(this.appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(this.appointment, form)
 
       // And I click change
       page.clickChange('Compliance')
@@ -477,7 +477,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(appointment, form)
 
       const session = sessionFactory.build({
         date: appointment.date,
@@ -549,7 +549,7 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubFindProject', { project })
 
-      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(appointment, form)
 
       const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
 
@@ -608,7 +608,7 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubFindProject', { project })
 
-      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(appointment, form)
 
       const session = sessionFactory.build({
         date: appointment.date,
@@ -652,7 +652,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(appointment, form)
 
       const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
 
@@ -696,7 +696,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubFindAppointment', { appointment })
       cy.task('stubGetAppointmentForm', form)
 
-      const page = ConfirmDetailsPage.visit(appointment, form, '1')
+      const page = ConfirmDetailsPage.visit(appointment, form)
 
       // And the API returns a 400 error
       const userMessage = 'Invalid appointment data'

--- a/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
@@ -1,0 +1,69 @@
+import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
+import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
+import Page from '../../../pages/page'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import {
+  contactOutcomeFactory,
+  contactOutcomesFactory,
+} from '../../../../server/testutils/factories/contactOutcomeFactory'
+import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
+import LogHoursPage from '../../../pages/appointments/logHoursPage'
+
+context('Group Session Bulk Update - Attendance Outcome', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+
+    const project = projectFactory.build()
+    cy.wrap(project).as('project')
+
+    const session = sessionFactory.build({ projectCode: project.projectCode })
+    cy.wrap(session).as('session')
+
+    const attendedOutcome = contactOutcomeFactory.build({ attended: true })
+    const contactOutcomes = contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] })
+    cy.wrap(contactOutcomes).as('contactOutcomes')
+
+    cy.task('stubFindProject', { project })
+    cy.task('stubFindSession', { session })
+    cy.task('stubGetContactOutcomes', { contactOutcomes })
+    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
+  })
+
+  // Scenario: sees validation errors with any entered answers when form is not valid
+  it('validates form data', function test() {
+    const page = AttendanceOutcomePage.visitForSession(this.session)
+    page.clickSubmit()
+
+    page.shouldShowErrorSummary('attendanceOutcome', 'Select an attendance outcome')
+  })
+
+  // Scenario: can navigate back to the previous page
+  it('navigates back to the previous page', function test() {
+    const teams = providerTeamSummaryFactory.buildList(2)
+
+    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
+
+    const page = AttendanceOutcomePage.visitForSession(this.session)
+    page.clickBack()
+
+    Page.verifyOnPage(ChooseSupervisorPage, this.session)
+  })
+
+  // Scenario: can complete the form and navigate to the next page
+  describe('submit', function describe() {
+    it('submits the form and navigates to the next page', function test() {
+      const page = AttendanceOutcomePage.visitForSession(this.session)
+
+      page.completeForm(this.contactOutcomes.contactOutcomes[0].code)
+
+      cy.task('stubSaveAppointmentForm')
+      page.clickSubmit()
+
+      Page.verifyOnPage(LogHoursPage, this.session)
+    })
+  })
+})

--- a/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
@@ -1,0 +1,64 @@
+import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
+import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
+import Page from '../../../pages/page'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
+import supervisorSummaryFactory from '../../../../server/testutils/factories/supervisorSummaryFactory'
+import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import { contactOutcomeFactory } from '../../../../server/testutils/factories/contactOutcomeFactory'
+
+context('Group Session Bulk Update - Choose Supervisor', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+
+    const project = projectFactory.build()
+    cy.wrap(project).as('project')
+
+    const session = sessionFactory.build({ projectCode: project.projectCode })
+    cy.wrap(session).as('session')
+
+    cy.task('stubFindProject', { project })
+    cy.task('stubFindSession', { session })
+    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
+    cy.task('stubSaveAppointmentForm')
+  })
+
+  // Scenario: sees validation errors with any entered answers when form is not valid
+  it('validates form data', function test() {
+    const teams = providerTeamSummaryFactory.buildList(2)
+    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
+
+    const page = ChooseSupervisorPage.visitForSession(this.session)
+    page.clickSubmit()
+
+    page.shouldShowErrorSummary('team', 'Select a supervising team')
+  })
+
+  // Scenario: can complete the form and navigate to the next page
+  describe('submit', function describe() {
+    it('submits the form and navigates to the next page', function test() {
+      const teams = providerTeamSummaryFactory.buildList(2)
+      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
+
+      const supervisors = supervisorSummaryFactory.buildList(2)
+      cy.task('stubGetSupervisors', {
+        teamCode: teams[0].code,
+        providerCode: this.project.providerCode,
+        supervisors,
+      })
+
+      cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes: contactOutcomeFactory.buildList(2) } })
+
+      const page = ChooseSupervisorPage.visitForSession(this.session)
+
+      page.selectTeam(teams[0].code)
+      page.supervisorInput.select(supervisors[0].code)
+      page.clickSubmit()
+
+      Page.verifyOnPage(AttendanceOutcomePage, this.session)
+    })
+  })
+})

--- a/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
@@ -1,0 +1,68 @@
+import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
+import LogHoursPage from '../../../pages/appointments/logHoursPage'
+import Page from '../../../pages/page'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
+
+context('Group Session Bulk Update - Log Compliance', () => {
+  const form = appointmentOutcomeFormFactory.build({
+    attendanceData: {
+      hiVisWorn: null,
+      workedIntensively: null,
+      workQuality: null,
+      behaviour: null,
+    },
+  })
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+
+    const project = projectFactory.build()
+    cy.wrap(project).as('project')
+
+    const session = sessionFactory.build({ projectCode: project.projectCode })
+    cy.wrap(session).as('session')
+
+    cy.task('stubFindProject', { project })
+    cy.task('stubFindSession', { session })
+    cy.task('stubGetAppointmentForm', form)
+  })
+
+  // Scenario: sees validation errors with any entered answers when form is not valid
+  it('validates form data', function test() {
+    const page = LogCompliancePage.visitForSession(this.session)
+    page.clickSubmit()
+
+    page.shouldShowErrorSummary('hiVis', 'Select whether a Hi-Vis was worn')
+    page.shouldShowErrorSummary('workedIntensively', 'Select whether they worked intensively')
+    page.shouldShowErrorSummary('workQuality', 'Select their work quality')
+    page.shouldShowErrorSummary('behaviour', 'Select their behaviour')
+    page.shouldNotHaveAnySelectedValues()
+  })
+
+  // Scenario: can navigate back to the previous page
+  it('navigates back to the previous page', function test() {
+    const page = LogCompliancePage.visitForSession(this.session)
+    page.clickBack()
+
+    Page.verifyOnPage(LogHoursPage, this.session)
+  })
+
+  // Scenario: can complete the form and navigate to the next page
+  describe('submit', function describe() {
+    it('submits the form and navigates to the next page', function test() {
+      const page = LogCompliancePage.visitForSession(this.session)
+
+      page.completeForm()
+
+      cy.task('stubSaveAppointmentForm')
+
+      page.clickSubmit()
+
+      Page.verifyOnPage(ConfirmDetailsPage, this.session)
+    })
+  })
+})

--- a/integration_tests/tests/group-sessions/bulk-update/logHours.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/logHours.cy.ts
@@ -1,0 +1,72 @@
+import LogHoursPage from '../../../pages/appointments/logHoursPage'
+import Page from '../../../pages/page'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
+import { contactOutcomeFactory } from '../../../../server/testutils/factories/contactOutcomeFactory'
+import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
+
+context('Group Session Bulk Update - Log Hours', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+
+    const project = projectFactory.build()
+    cy.wrap(project).as('project')
+
+    const session = sessionFactory.build({ projectCode: project.projectCode })
+    cy.wrap(session).as('session')
+  })
+
+  beforeEach(function test() {
+    cy.task('stubFindProject', { project: this.project })
+    cy.task('stubFindSession', { session: this.session })
+    cy.task(
+      'stubGetAppointmentForm',
+      appointmentOutcomeFormFactory.build({ contactOutcome: contactOutcomeFactory.build({ attended: true }) }),
+    )
+  })
+
+  // Scenario: sees validation errors with any entered answers when form is not valid
+  it('validates form data', function test() {
+    const page = LogHoursPage.visitForSession(this.session)
+    page.enterStartTime('0')
+    page.enterEndTime('1')
+
+    // When I submit the form
+    page.clickSubmit()
+
+    // Then I see the log hours page with errors
+    page.shouldShowErrorSummary('startTime', 'Enter a valid start time, for example 09:00')
+    page.shouldShowErrorSummary('endTime', 'Enter a valid end time, for example 17:00')
+
+    page.shouldShowEnteredTimes({ startTime: '0', endTime: '1' })
+  })
+
+  // Scenario: can navigate back to the previous page
+  it('navigates back to the previous page', function test() {
+    const page = LogHoursPage.visitForSession(this.session)
+    cy.task('stubGetContactOutcomes', { contactOutcomes: { contactOutcomes: contactOutcomeFactory.buildList(2) } })
+    page.clickBack()
+
+    Page.verifyOnPage(AttendanceOutcomePage, this.session)
+  })
+
+  // Scenario: can complete the form and navigate to the next page
+  describe('submit', function describe() {
+    it('submits the form and navigates to the next page', function test() {
+      const page = LogHoursPage.visitForSession(this.session)
+
+      page.enterStartTime('09:00')
+      page.enterEndTime('17:00')
+      page.enterPenaltyTime('1', '00')
+
+      cy.task('stubSaveAppointmentForm')
+      page.clickSubmit()
+
+      Page.verifyOnPage(LogCompliancePage, this.session)
+    })
+  })
+})

--- a/integration_tests/tests/group-sessions/findASession.cy.ts
+++ b/integration_tests/tests/group-sessions/findASession.cy.ts
@@ -60,17 +60,17 @@
 //    When I select a region
 //    Then I should see the error page
 
-import sessionFactory from '../../server/testutils/factories/sessionFactory'
-import sessionSummaryFactory from '../../server/testutils/factories/sessionSummaryFactory'
-import providerTeamSummaryFactory from '../../server/testutils/factories/providerTeamSummaryFactory'
-import FindASessionPage from '../pages/findASessionPage'
-import Page from '../pages/page'
-import ViewSessionPage from '../pages/viewSessionPage'
-import { ProviderSummaryDto, ProviderTeamSummaryDto } from '../../server/@types/shared'
-import providerSummaryFactory from '../../server/testutils/factories/providerSummaryFactory'
-import AuthSignInPage from '../pages/authSignIn'
-import ServerErrorPage from '../pages/serverErrorPage'
-import pagedMetadataFactory from '../../server/testutils/factories/pagedMetadataFactory'
+import sessionFactory from '../../../server/testutils/factories/sessionFactory'
+import sessionSummaryFactory from '../../../server/testutils/factories/sessionSummaryFactory'
+import providerTeamSummaryFactory from '../../../server/testutils/factories/providerTeamSummaryFactory'
+import FindASessionPage from '../../pages/findASessionPage'
+import Page from '../../pages/page'
+import ViewSessionPage from '../../pages/viewSessionPage'
+import { ProviderSummaryDto, ProviderTeamSummaryDto } from '../../../server/@types/shared'
+import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
+import AuthSignInPage from '../../pages/authSignIn'
+import ServerErrorPage from '../../pages/serverErrorPage'
+import pagedMetadataFactory from '../../../server/testutils/factories/pagedMetadataFactory'
 
 context('Home', () => {
   const date = '2025-09-07'

--- a/server/testutils/factories/sessionFactory.ts
+++ b/server/testutils/factories/sessionFactory.ts
@@ -9,7 +9,7 @@ export default Factory.define<SessionDto>(() => ({
   projectName: faker.company.name(),
   projectLocation: fakerEngb.location.county(),
   location: locationFactory.build(),
-  date: faker.date.recent().toISOString(),
+  date: faker.date.recent().toISOString().split('T')[0],
   startTime: '09:00',
   endTime: '17:00',
   appointmentSummaries: appointmentSummaryFactory.buildList(3),


### PR DESCRIPTION
## Context

Adds integration tests for the bulk update form routes.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- Includes a rewiring of the `checkOnPage()` pattern for integration tests, removing it from page model constructors
- Introduce a new base page model for appointment forms
- Add new test suites for each page in the appointment form journey for a bulk update - have kept the scenarios simple for now:
  - page shows validation messages
  - can continue to the next page in the form
  - can navigate back

Confirm page tests will be added in a future PR

### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ