### PR TITLE
CPB-1026: Handle bulk update submit

### DIFF
--- a/integration_tests/mockApis/appointments.ts
+++ b/integration_tests/mockApis/appointments.ts
@@ -68,6 +68,45 @@ export default {
     })
   },
 
+  stubBulkUpdateAppointmentOutcome: ({ projectCode }: { projectCode: string }): SuperAgentRequest => {
+    const pattern = paths.appointments.bulkUpdate({ projectCode })
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPath: pattern,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    })
+  },
+
+  stubBulkUpdateAppointmentOutcomeWithError: ({
+    projectCode,
+    userMessage,
+  }: {
+    projectCode: string
+    userMessage: string
+  }): SuperAgentRequest => {
+    const pattern = paths.appointments.bulkUpdate({ projectCode })
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPath: pattern,
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          status: 400,
+          userMessage,
+          developerMessage: 'Bad request',
+        },
+      },
+    })
+  },
+
   stubUpdateAppointmentOutcomeWithError: ({
     appointment,
     userMessage,

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -1,5 +1,4 @@
-import { AppointmentDto } from '../../../server/@types/shared'
-import { AppointmentOutcomeForm } from '../../../server/@types/user-defined'
+import { AppointmentOrSession, AppointmentOutcomeForm } from '../../../server/@types/user-defined'
 import SummaryListComponent from '../components/summaryListComponent'
 import RadioGroupComponent from '../components/radioGroupComponent'
 import BaseAppointmentFormPage from './baseAppointmentFormPage'
@@ -13,7 +12,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
   readonly alertPractitionerQuestion: RadioGroupComponent
 
   constructor(
-    appointment: AppointmentDto,
+    appointment: AppointmentOrSession,
     private readonly form: AppointmentOutcomeForm,
   ) {
     super(appointment)

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -1,0 +1,93 @@
+import appointmentFactory from '../../../../server/testutils/factories/appointmentFactory'
+import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
+import Offender from '../../../../server/models/offender'
+import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
+import Page from '../../../pages/page'
+import ViewSessionPage from '../../../pages/viewSessionPage'
+
+context('Group Session Bulk Update - Confirm appointment details page', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+
+    const project = projectFactory.build()
+    cy.wrap(project).as('project')
+
+    const session = sessionFactory.build({ projectCode: project.projectCode })
+    cy.wrap(session).as('session')
+
+    cy.task('stubFindProject', { project })
+    cy.task('stubFindSession', { session })
+
+    const appointments = session.appointmentSummaries.map(appointment =>
+      appointmentFactory.build({
+        ...appointment,
+        projectCode: project.projectCode,
+      }),
+    )
+    cy.wrap(appointments).as('appointments')
+
+    const form = appointmentOutcomeFormFactory.build({
+      appointments: appointments.map(appointment => ({ id: appointment.id, deliusVersion: appointment.version })),
+    })
+    cy.wrap(form).as('form')
+
+    cy.task('stubGetAppointmentForm', form)
+    appointments.forEach(appointment => {
+      cy.task('stubFindAppointment', { appointment })
+    })
+  })
+
+  describe('submit update for 2 appointments', () => {
+    it('redirects back to session page with success message', function test() {
+      const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+      cy.task('stubBulkUpdateAppointmentOutcome', { projectCode: this.project.projectCode })
+
+      page.clickSubmit('Confirm')
+
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
+      viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+    })
+
+    it('with 1 different Delius version => redirects back to session page with 1 error message and success message', function test() {
+      const form = appointmentOutcomeFormFactory.build({
+        appointments: [
+          { id: this.appointments[0].id, deliusVersion: this.appointments[0].version },
+          { id: this.appointments[1].id, deliusVersion: '1' },
+        ],
+      })
+
+      cy.task('stubGetAppointmentForm', form)
+
+      const page = ConfirmDetailsPage.visitForSession(this.session, form)
+
+      cy.task('stubBulkUpdateAppointmentOutcome', { projectCode: this.project.projectCode })
+
+      page.clickSubmit('Confirm')
+
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
+      const offender = new Offender(this.appointments[1].offender)
+      const message = `The appointment for ${offender.name} (${offender.crn}) has already been updated in the database. Try again.`
+
+      viewSessionPage.shouldShowErrorMessage(message, false)
+      viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+    })
+
+    it('with API error response => stays on page and shows error message', function test() {
+      const userMessage = 'Invalid bulk appointment update data'
+
+      cy.task('stubBulkUpdateAppointmentOutcomeWithError', {
+        projectCode: this.project.projectCode,
+        userMessage,
+      })
+
+      const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+      page.clickSubmit('Confirm')
+
+      page.shouldShowErrorSummary(userMessage)
+    })
+  })
+})

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -40,6 +40,7 @@ export type AppointmentOutcomeForm = {
   attendanceData?: AttendanceDataDto
   enforcement?: EnforcementOutcomeForm
   originalSearch: Record<string, string>
+  appointments?: Array<{ id: number; deliusVersion: string }>
 } & BodyWithNotes
 
 export interface AuditParams {

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -12,6 +12,7 @@ import projectFactory from '../../testutils/factories/projectFactory'
 import ProjectService from '../../services/projectService'
 import * as ErrorUtils from '../../utils/errorUtils'
 import SessionService from '../../services/sessionService'
+import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 
 jest.mock('../../pages/appointments/confirmPage')
 
@@ -738,6 +739,118 @@ describe('ConfirmController', () => {
           },
           'user-name',
         )
+      })
+
+      describe('validation errors', () => {
+        it('calls flash with a single validation error', async () => {
+          const offender = offenderFullFactory.build()
+          const nextPath = 'next'
+          const message = `The appointments have already been updated in the database. Try again.`
+          const deliusVersionChangedMessage = jest.fn().mockReturnValue(message)
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              exitForm: () => nextPath,
+              deliusVersionChangedMessage,
+            }
+          })
+          formAppointmentVersion = '1'
+          appointmentVersion = '2'
+
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointments = appointmentFactory.buildList(2, {
+            version: appointmentVersion,
+            offender,
+          })
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome: contactOutcomeFactory.build({ attended: false }),
+            appointments: [
+              { id: appointments[0].id, deliusVersion: formAppointmentVersion },
+              { id: appointments[1].id, deliusVersion: appointmentVersion },
+            ],
+          })
+          appointmentService.getAppointment
+            .mockResolvedValueOnce(appointments[0])
+            .mockResolvedValueOnce(appointments[1])
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.getAppointment).toHaveBeenCalledTimes(2)
+          expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+            projectCode,
+            {
+              updates: [
+                expect.objectContaining({
+                  deliusId: appointments[1].id,
+                  deliusVersionToUpdate: appointments[1].version,
+                }),
+              ],
+            },
+            'user-name',
+          )
+          expect(bulkRequest.flash).toHaveBeenCalledWith('error', message)
+          expect(deliusVersionChangedMessage).toHaveBeenCalledWith([appointments[0]])
+          expect(bulkRequest.flash).toHaveBeenCalledWith('success', 'Attendance recorded')
+          expect(response.redirect).toHaveBeenCalledWith(nextPath)
+        })
+
+        it('calls flash with multiple validation errors', async () => {
+          const offenders = offenderFullFactory.buildList(3)
+          const nextPath = 'next'
+          const message = `The appointments have already been updated in the database. Try again.`
+          const deliusVersionChangedMessage = jest.fn().mockReturnValue(message)
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              exitForm: () => nextPath,
+              deliusVersionChangedMessage,
+            }
+          })
+          formAppointmentVersion = '1'
+          appointmentVersion = '2'
+
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointments = offenders.map(offender =>
+            appointmentFactory.build({
+              version: appointmentVersion,
+              offender,
+            }),
+          )
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome: contactOutcomeFactory.build({ attended: false }),
+            appointments: [
+              { id: appointments[0].id, deliusVersion: formAppointmentVersion },
+              { id: appointments[1].id, deliusVersion: appointmentVersion },
+              { id: appointments[2].id, deliusVersion: formAppointmentVersion },
+            ],
+          })
+          appointmentService.getAppointment
+            .mockResolvedValueOnce(appointments[0])
+            .mockResolvedValueOnce(appointments[1])
+            .mockResolvedValue(appointments[2])
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+            projectCode,
+            {
+              updates: [
+                expect.objectContaining({
+                  deliusId: appointments[1].id,
+                  deliusVersionToUpdate: appointments[1].version,
+                }),
+              ],
+            },
+            'user-name',
+          )
+          expect(bulkRequest.flash).toHaveBeenCalledWith('error', message)
+          expect(bulkRequest.flash).toHaveBeenCalledWith('success', 'Attendance recorded')
+          expect(response.redirect).toHaveBeenCalledWith(nextPath)
+        })
       })
     })
   })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -848,7 +848,53 @@ describe('ConfirmController', () => {
             'user-name',
           )
           expect(bulkRequest.flash).toHaveBeenCalledWith('error', message)
+          expect(deliusVersionChangedMessage).toHaveBeenCalledWith([appointments[0], appointments[2]])
           expect(bulkRequest.flash).toHaveBeenCalledWith('success', 'Attendance recorded')
+          expect(response.redirect).toHaveBeenCalledWith(nextPath)
+        })
+
+        it('does not attempt submit if no valid appointments', async () => {
+          const offenders = offenderFullFactory.buildList(2)
+          const nextPath = 'next'
+          const message = `The appointments have already been updated in the database. Try again.`
+          const deliusVersionChangedMessage = jest.fn().mockReturnValue(message)
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              exitForm: () => nextPath,
+              deliusVersionChangedMessage,
+            }
+          })
+          formAppointmentVersion = '1'
+          appointmentVersion = '2'
+
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointments = offenders.map(offender =>
+            appointmentFactory.build({
+              version: appointmentVersion,
+              offender,
+            }),
+          )
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome: contactOutcomeFactory.build({ attended: false }),
+            appointments: [
+              { id: appointments[0].id, deliusVersion: formAppointmentVersion },
+              { id: appointments[1].id, deliusVersion: formAppointmentVersion },
+            ],
+          })
+          appointmentService.getAppointment
+            .mockResolvedValueOnce(appointments[0])
+            .mockResolvedValueOnce(appointments[1])
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.saveAppointments).not.toHaveBeenCalled()
+
+          expect(bulkRequest.flash).toHaveBeenCalledWith('error', message)
+          expect(deliusVersionChangedMessage).toHaveBeenCalledWith(appointments)
+          expect(bulkRequest.flash).not.toHaveBeenCalledWith('success', 'Attendance recorded')
           expect(response.redirect).toHaveBeenCalledWith(nextPath)
         })
       })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -399,7 +399,7 @@ describe('ConfirmController', () => {
                 deliusId: appointments[0].id,
                 deliusVersionToUpdate: appointments[0].version,
                 alertActive: true,
-                sensitive: true,
+                sensitive: appointments[0].sensitive,
                 startTime: form.startTime,
                 endTime: form.endTime,
                 contactOutcomeCode: form.contactOutcome.code,
@@ -412,7 +412,7 @@ describe('ConfirmController', () => {
                 deliusId: appointments[1].id,
                 deliusVersionToUpdate: appointments[1].version,
                 alertActive: true,
-                sensitive: true,
+                sensitive: appointments[1].sensitive,
                 startTime: form.startTime,
                 endTime: form.endTime,
                 contactOutcomeCode: form.contactOutcome.code,
@@ -581,13 +581,16 @@ describe('ConfirmController', () => {
       })
 
       describe('bulk sensitive data', () => {
-        it('uses appointment value when appointment sensitive is true', async () => {
+        it.each([false, undefined, null, true])('uses appointment value', async (appointmentIsSensitive?: boolean) => {
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
-          const appointment = appointmentFactory.build({ version: appointmentVersion, sensitive: true })
+          const appointment = appointmentFactory.build({
+            version: appointmentVersion,
+            sensitive: appointmentIsSensitive,
+          })
           const form = appointmentOutcomeFormFactory.build({
             deliusVersion: formAppointmentVersion,
-            isSensitive: 'no',
+            isSensitive: 'yes',
             appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
           })
 
@@ -602,48 +605,13 @@ describe('ConfirmController', () => {
             {
               updates: [
                 expect.objectContaining({
-                  sensitive: true,
+                  sensitive: appointmentIsSensitive,
                 }),
               ],
             },
             'user-name',
           )
         })
-
-        it.each([false, undefined, null])(
-          'uses form value when appointment sensitive is not true',
-          async (appointmentIsSensitive?: boolean) => {
-            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-            const appointment = appointmentFactory.build({
-              version: appointmentVersion,
-              sensitive: appointmentIsSensitive,
-            })
-            const form = appointmentOutcomeFormFactory.build({
-              deliusVersion: formAppointmentVersion,
-              isSensitive: 'yes',
-              appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
-            })
-
-            appointmentService.getAppointment.mockResolvedValue(appointment)
-            appointmentFormService.getForm.mockResolvedValue(form)
-
-            const requestHandler = confirmController.submit()
-            await requestHandler(bulkRequest, response, next)
-
-            expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
-              projectCode,
-              {
-                updates: [
-                  expect.objectContaining({
-                    sensitive: true,
-                  }),
-                ],
-              },
-              'user-name',
-            )
-          },
-        )
       })
 
       it('should call catchApiValidationErrorOrPropagate when saveAppointments throws a SanitisedError', async () => {
@@ -726,7 +694,7 @@ describe('ConfirmController', () => {
                 deliusId: appointment.id,
                 deliusVersionToUpdate: appointment.version,
                 alertActive: true,
-                sensitive: true,
+                sensitive: appointment.sensitive,
                 startTime: appointment.startTime,
                 endTime: appointment.endTime,
                 contactOutcomeCode: form.contactOutcome.code,

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -8,6 +8,7 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
+import projectFactory from '../../testutils/factories/projectFactory'
 import ProjectService from '../../services/projectService'
 import * as ErrorUtils from '../../utils/errorUtils'
 import SessionService from '../../services/sessionService'
@@ -107,136 +108,24 @@ describe('ConfirmController', () => {
       appointmentVersion = '1'
     })
 
-    it('should send appointment data and redirect to checkAppointmentDetails page', async () => {
-      const nextPath = 'next'
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: () => nextPath,
-          isAlertSelected: true,
-        }
-      })
-      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-      const appointment = appointmentFactory.build({ version: appointmentVersion })
-      const contactOutcome = contactOutcomeFactory.build({ attended: true })
-      const form = appointmentOutcomeFormFactory.build({
-        contactOutcome,
-        deliusVersion: formAppointmentVersion,
-        isSensitive: 'yes',
-      })
-
-      appointmentService.getAppointment.mockResolvedValue(appointment)
-      appointmentFormService.getForm.mockResolvedValue(form)
-
-      const requestHandler = confirmController.submit()
-      await requestHandler(request, response, next)
-
-      expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
-        appointment.projectCode,
-        {
-          deliusId: appointment.id,
-          deliusVersionToUpdate: appointment.version,
-          alertActive: true,
-          sensitive: true,
-          startTime: form.startTime,
-          endTime: form.endTime,
-          contactOutcomeCode: form.contactOutcome.code,
-          attendanceData: form.attendanceData,
-          supervisorOfficerCode: form.supervisor.code,
-          notes: form.notes,
-          date: appointment.date,
-        },
-        'user-name',
-      )
-      expect(response.redirect).toHaveBeenCalledWith(nextPath)
-    })
-
-    it('should save appointmentData without attendance data if did not attend', async () => {
-      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-      const appointment = appointmentFactory.build({ version: appointmentVersion })
-      const contactOutcome = contactOutcomeFactory.build({ attended: false })
-      const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
-
-      appointmentService.getAppointment.mockResolvedValue(appointment)
-      appointmentFormService.getForm.mockResolvedValue(form)
-
-      const requestHandler = confirmController.submit()
-      await requestHandler(request, response, next)
-
-      expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
-        appointment.projectCode,
-        expect.objectContaining({ attendanceData: undefined }),
-        'user-name',
-      )
-    })
-
-    describe('alertActive', () => {
-      it.each([true, false])(
-        'any user selected value is submitted with the update',
-        async (userSelectedValue: boolean) => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              isAlertSelected: userSelectedValue,
-              exitForm: () => '',
-            }
-          })
-          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-          const appointment = appointmentFactory.build({ version: appointmentVersion })
-          const contactOutcome = contactOutcomeFactory.build({ attended: false })
-          const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
-
-          appointmentService.getAppointment.mockResolvedValue(appointment)
-          appointmentFormService.getForm.mockResolvedValue(form)
-
-          const requestHandler = confirmController.submit()
-          await requestHandler(request, response, next)
-
-          expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
-            appointment.projectCode,
-            expect.objectContaining({ alertActive: userSelectedValue }),
-            'user-name',
-          )
-        },
-      )
-
-      it.each([true, false, undefined])(
-        'sends original appointment value if user selected value is undefined',
-        async (appointmentValue?: boolean) => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              isAlertSelected: null,
-              exitForm: () => '',
-            }
-          })
-          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-          const appointment = appointmentFactory.build({ version: appointmentVersion, alertActive: appointmentValue })
-          const contactOutcome = contactOutcomeFactory.build({ attended: false })
-          const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
-
-          appointmentService.getAppointment.mockResolvedValue(appointment)
-          appointmentFormService.getForm.mockResolvedValue(form)
-
-          const requestHandler = confirmController.submit()
-          await requestHandler(request, response, next)
-
-          expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
-            appointment.projectCode,
-            expect.objectContaining({ alertActive: appointmentValue }),
-            'user-name',
-          )
-        },
-      )
-    })
-
-    describe('sensitive', () => {
-      it('sends the appointment value if the appointment value is true', async () => {
+    describe('given an individual appointment route', () => {
+      it('should send appointment data and redirect to checkAppointmentDetails page', async () => {
+        const nextPath = 'next'
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => nextPath,
+            isAlertSelected: true,
+          }
+        })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
-        const appointment = appointmentFactory.build({ version: '1', sensitive: true })
-        const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          isSensitive: 'yes',
+        })
 
         appointmentService.getAppointment.mockResolvedValue(appointment)
         appointmentFormService.getForm.mockResolvedValue(form)
@@ -246,18 +135,110 @@ describe('ConfirmController', () => {
 
         expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
           appointment.projectCode,
-          expect.objectContaining({ sensitive: true }),
+          {
+            deliusId: appointment.id,
+            deliusVersionToUpdate: appointment.version,
+            alertActive: true,
+            sensitive: true,
+            startTime: form.startTime,
+            endTime: form.endTime,
+            contactOutcomeCode: form.contactOutcome.code,
+            attendanceData: form.attendanceData,
+            supervisorOfficerCode: form.supervisor.code,
+            notes: form.notes,
+            date: appointment.date,
+          },
+          'user-name',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(nextPath)
+      })
+
+      it('should save appointmentData without attendance data if did not attend', async () => {
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: false })
+        const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(request, response, next)
+
+        expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+          appointment.projectCode,
+          expect.objectContaining({ attendanceData: undefined }),
           'user-name',
         )
       })
 
-      it.each([false, undefined, null])(
-        'sends the form value if the appointment value is not true',
-        async (appointmentIsSensitive?: boolean) => {
+      describe('alertActive', () => {
+        it.each([true, false])(
+          'any user selected value is submitted with the update',
+          async (userSelectedValue: boolean) => {
+            confirmPageMock.mockImplementationOnce(() => {
+              return {
+                isAlertSelected: userSelectedValue,
+                exitForm: () => '',
+              }
+            })
+            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+            const appointment = appointmentFactory.build({ version: appointmentVersion })
+            const contactOutcome = contactOutcomeFactory.build({ attended: false })
+            const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
+
+            appointmentService.getAppointment.mockResolvedValue(appointment)
+            appointmentFormService.getForm.mockResolvedValue(form)
+
+            const requestHandler = confirmController.submit()
+            await requestHandler(request, response, next)
+
+            expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+              appointment.projectCode,
+              expect.objectContaining({ alertActive: userSelectedValue }),
+              'user-name',
+            )
+          },
+        )
+
+        it.each([true, false, undefined])(
+          'sends original appointment value if user selected value is undefined',
+          async (appointmentValue?: boolean) => {
+            confirmPageMock.mockImplementationOnce(() => {
+              return {
+                isAlertSelected: null,
+                exitForm: () => '',
+              }
+            })
+            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+            const appointment = appointmentFactory.build({ version: appointmentVersion, alertActive: appointmentValue })
+            const contactOutcome = contactOutcomeFactory.build({ attended: false })
+            const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
+
+            appointmentService.getAppointment.mockResolvedValue(appointment)
+            appointmentFormService.getForm.mockResolvedValue(form)
+
+            const requestHandler = confirmController.submit()
+            await requestHandler(request, response, next)
+
+            expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+              appointment.projectCode,
+              expect.objectContaining({ alertActive: appointmentValue }),
+              'user-name',
+            )
+          },
+        )
+      })
+
+      describe('sensitive', () => {
+        it('sends the appointment value if the appointment value is true', async () => {
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
-          const appointment = appointmentFactory.build({ version: '1', sensitive: appointmentIsSensitive })
-          const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1', isSensitive: 'yes' })
+          const appointment = appointmentFactory.build({ version: '1', sensitive: true })
+          const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
 
           appointmentService.getAppointment.mockResolvedValue(appointment)
           appointmentFormService.getForm.mockResolvedValue(form)
@@ -270,80 +251,494 @@ describe('ConfirmController', () => {
             expect.objectContaining({ sensitive: true }),
             'user-name',
           )
-        },
-      )
+        })
+
+        it.each([false, undefined, null])(
+          'sends the form value if the appointment value is not true',
+          async (appointmentIsSensitive?: boolean) => {
+            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+            const appointment = appointmentFactory.build({ version: '1', sensitive: appointmentIsSensitive })
+            const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1', isSensitive: 'yes' })
+
+            appointmentService.getAppointment.mockResolvedValue(appointment)
+            appointmentFormService.getForm.mockResolvedValue(form)
+
+            const requestHandler = confirmController.submit()
+            await requestHandler(request, response, next)
+
+            expect(appointmentService.saveAppointment).toHaveBeenCalledWith(
+              appointment.projectCode,
+              expect.objectContaining({ sensitive: true }),
+              'user-name',
+            )
+          },
+        )
+      })
+
+      it('redirects to next page if appointment was updated elsewhere', async () => {
+        const nextPath = 'next'
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => nextPath,
+          }
+        })
+        formAppointmentVersion = '1'
+        appointmentVersion = '2'
+
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: false })
+        const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(nextPath)
+        expect(request.flash).toHaveBeenCalledWith(
+          'error',
+          'The arrival time has already been updated in the database, try again.',
+        )
+      })
+
+      it('calls catchApiValidationErrorOrPropagate when saveAppointment throws a SanitisedError', async () => {
+        jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+        const error: SanitisedError = {
+          name: 'SanitisedError',
+          message: 'API error',
+          responseStatus: 400,
+          data: {
+            userMessage: 'An error occurred',
+            developerMessage: 'Developer message',
+            status: 400,
+          },
+        }
+
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            isAlertSelected: true,
+            updatePath: () => '/update/path',
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+        })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+        appointmentService.saveAppointment.mockRejectedValue(error)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(request, response, next)
+
+        expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
+          request,
+          response,
+          error,
+          '/update/path',
+        )
+      })
     })
 
-    it('redirects to next page if appointment was updated elsewhere', async () => {
-      const nextPath = 'next'
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: () => nextPath,
+    describe('given a session route', () => {
+      let bulkRequest: DeepMocked<Request>
+
+      beforeEach(() => {
+        bulkRequest = createMock<Request>({
+          params: { projectCode, date: '2026-06-01' },
+          query: { form: formId },
+          flash: jest.fn(),
+        })
+        projectService.getProject.mockResolvedValue(projectFactory.build({ projectCode }))
+      })
+
+      it('should send multiple appointment updates via saveAppointments and redirect', async () => {
+        const nextPath = 'next'
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => nextPath,
+            isAlertSelected: true,
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          isSensitive: 'yes',
+          appointments: [
+            { id: appointments[0].id, deliusVersion: appointmentVersion },
+            { id: appointments[1].id, deliusVersion: appointmentVersion },
+          ],
+        })
+
+        appointmentService.getAppointment.mockResolvedValueOnce(appointments[0]).mockResolvedValueOnce(appointments[1])
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(appointmentService.getAppointment).toHaveBeenCalledTimes(2)
+        expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+          projectCode,
+          {
+            updates: [
+              {
+                deliusId: appointments[0].id,
+                deliusVersionToUpdate: appointments[0].version,
+                alertActive: true,
+                sensitive: true,
+                startTime: form.startTime,
+                endTime: form.endTime,
+                contactOutcomeCode: form.contactOutcome.code,
+                attendanceData: form.attendanceData,
+                supervisorOfficerCode: form.supervisor.code,
+                date: appointments[0].date,
+                notes: form.notes,
+              },
+              {
+                deliusId: appointments[1].id,
+                deliusVersionToUpdate: appointments[1].version,
+                alertActive: true,
+                sensitive: true,
+                startTime: form.startTime,
+                endTime: form.endTime,
+                contactOutcomeCode: form.contactOutcome.code,
+                attendanceData: form.attendanceData,
+                supervisorOfficerCode: form.supervisor.code,
+                date: appointments[1].date,
+                notes: form.notes,
+              },
+            ],
+          },
+          'user-name',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(nextPath)
+      })
+
+      it('should include attendance data when didAttend is true', async () => {
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => '',
+            isAlertSelected: false,
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+        })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+          projectCode,
+          {
+            updates: [
+              expect.objectContaining({
+                attendanceData: form.attendanceData,
+              }),
+            ],
+          },
+          'user-name',
+        )
+      })
+
+      it('should exclude attendance data when didAttend is false', async () => {
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => '',
+            isAlertSelected: false,
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: false })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+        })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+          projectCode,
+          {
+            updates: [
+              expect.objectContaining({
+                attendanceData: undefined,
+              }),
+            ],
+          },
+          'user-name',
+        )
+      })
+
+      describe('alertActive', () => {
+        it.each([true, false])('uses user selected value for alertActive', async (userSelectedValue: boolean) => {
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              isAlertSelected: userSelectedValue,
+              exitForm: () => '',
+            }
+          })
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointment = appointmentFactory.build({ version: appointmentVersion, alertActive: false })
+          const contactOutcome = contactOutcomeFactory.build({ attended: false })
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome,
+            deliusVersion: formAppointmentVersion,
+            appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+          })
+
+          appointmentService.getAppointment.mockResolvedValue(appointment)
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+            projectCode,
+            {
+              updates: [
+                expect.objectContaining({
+                  alertActive: userSelectedValue,
+                }),
+              ],
+            },
+            'user-name',
+          )
+        })
+
+        it.each([true, false, undefined])(
+          'uses appointment value when user selected value is not set',
+          async (appointmentValue?: boolean) => {
+            confirmPageMock.mockImplementationOnce(() => {
+              return {
+                isAlertSelected: null,
+                exitForm: () => '',
+              }
+            })
+            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+            const appointment = appointmentFactory.build({
+              version: appointmentVersion,
+              alertActive: appointmentValue,
+            })
+            const contactOutcome = contactOutcomeFactory.build({ attended: false })
+            const form = appointmentOutcomeFormFactory.build({
+              contactOutcome,
+              deliusVersion: formAppointmentVersion,
+              appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+            })
+
+            appointmentService.getAppointment.mockResolvedValue(appointment)
+            appointmentFormService.getForm.mockResolvedValue(form)
+
+            const requestHandler = confirmController.submit()
+            await requestHandler(bulkRequest, response, next)
+
+            expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+              projectCode,
+              {
+                updates: [
+                  expect.objectContaining({
+                    alertActive: appointmentValue,
+                  }),
+                ],
+              },
+              'user-name',
+            )
+          },
+        )
+      })
+
+      describe('bulk sensitive data', () => {
+        it('uses appointment value when appointment sensitive is true', async () => {
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointment = appointmentFactory.build({ version: appointmentVersion, sensitive: true })
+          const form = appointmentOutcomeFormFactory.build({
+            deliusVersion: formAppointmentVersion,
+            isSensitive: 'no',
+            appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+          })
+
+          appointmentService.getAppointment.mockResolvedValue(appointment)
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+            projectCode,
+            {
+              updates: [
+                expect.objectContaining({
+                  sensitive: true,
+                }),
+              ],
+            },
+            'user-name',
+          )
+        })
+
+        it.each([false, undefined, null])(
+          'uses form value when appointment sensitive is not true',
+          async (appointmentIsSensitive?: boolean) => {
+            const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+            const appointment = appointmentFactory.build({
+              version: appointmentVersion,
+              sensitive: appointmentIsSensitive,
+            })
+            const form = appointmentOutcomeFormFactory.build({
+              deliusVersion: formAppointmentVersion,
+              isSensitive: 'yes',
+              appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+            })
+
+            appointmentService.getAppointment.mockResolvedValue(appointment)
+            appointmentFormService.getForm.mockResolvedValue(form)
+
+            const requestHandler = confirmController.submit()
+            await requestHandler(bulkRequest, response, next)
+
+            expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+              projectCode,
+              {
+                updates: [
+                  expect.objectContaining({
+                    sensitive: true,
+                  }),
+                ],
+              },
+              'user-name',
+            )
+          },
+        )
+      })
+
+      it('should call catchApiValidationErrorOrPropagate when saveAppointments throws a SanitisedError', async () => {
+        jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+        const error: SanitisedError = {
+          name: 'SanitisedError',
+          message: 'API error',
+          responseStatus: 400,
+          data: {
+            userMessage: 'An error occurred',
+            developerMessage: 'Developer message',
+            status: 400,
+          },
         }
-      })
-      formAppointmentVersion = '1'
-      appointmentVersion = '2'
 
-      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            isAlertSelected: false,
+            updatePath: () => '/bulk/update/path',
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
-      const appointment = appointmentFactory.build({ version: appointmentVersion })
-      const contactOutcome = contactOutcomeFactory.build({ attended: false })
-      const form = appointmentOutcomeFormFactory.build({ contactOutcome, deliusVersion: formAppointmentVersion })
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+        })
 
-      appointmentService.getAppointment.mockResolvedValue(appointment)
-      appointmentFormService.getForm.mockResolvedValue(form)
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+        appointmentService.saveAppointments.mockRejectedValue(error)
 
-      const requestHandler = confirmController.submit()
-      await requestHandler(request, response, next)
+        const requestHandler = confirmController.submit()
+        await requestHandler(bulkRequest, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(nextPath)
-      expect(request.flash).toHaveBeenCalledWith(
-        'error',
-        'The arrival time has already been updated in the database, try again.',
-      )
-    })
-
-    it('calls catchApiValidationErrorOrPropagate when saveAppointment throws a SanitisedError', async () => {
-      jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
-      const error: SanitisedError = {
-        name: 'SanitisedError',
-        message: 'API error',
-        responseStatus: 400,
-        data: {
-          userMessage: 'An error occurred',
-          developerMessage: 'Developer message',
-          status: 400,
-        },
-      }
-
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          isAlertSelected: true,
-          updatePath: () => '/update/path',
-        }
-      })
-      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
-
-      const appointment = appointmentFactory.build({ version: appointmentVersion })
-      const contactOutcome = contactOutcomeFactory.build({ attended: true })
-      const form = appointmentOutcomeFormFactory.build({
-        contactOutcome,
-        deliusVersion: formAppointmentVersion,
+        expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
+          bulkRequest,
+          response,
+          error,
+          '/bulk/update/path',
+        )
       })
 
-      appointmentService.getAppointment.mockResolvedValue(appointment)
-      appointmentFormService.getForm.mockResolvedValue(form)
-      appointmentService.saveAppointment.mockRejectedValue(error)
+      it('should send appointment start and end times if undefined on form', async () => {
+        const nextPath = 'next'
 
-      const requestHandler = confirmController.submit()
-      await requestHandler(request, response, next)
+        confirmPageMock.mockImplementationOnce(() => {
+          return {
+            exitForm: () => nextPath,
+            isAlertSelected: true,
+          }
+        })
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
-      expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
-        request,
-        response,
-        error,
-        '/update/path',
-      )
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          startTime: undefined,
+          endTime: undefined,
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          isSensitive: 'yes',
+          appointments: [{ id: appointment.id, deliusVersion: appointmentVersion }],
+        })
+
+        appointmentService.getAppointment.mockResolvedValueOnce(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submit()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+          projectCode,
+          {
+            updates: [
+              {
+                deliusId: appointment.id,
+                deliusVersionToUpdate: appointment.version,
+                alertActive: true,
+                sensitive: true,
+                startTime: appointment.startTime,
+                endTime: appointment.endTime,
+                contactOutcomeCode: form.contactOutcome.code,
+                attendanceData: form.attendanceData,
+                supervisorOfficerCode: form.supervisor.code,
+                date: appointment.date,
+                notes: form.notes,
+              },
+            ],
+          },
+          'user-name',
+        )
+      })
     })
   })
 })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -108,14 +108,18 @@ export default class ConfirmController implements IFormPageController {
           _req.flash('error', message)
         }
 
-        try {
-          await this.appointmentService.saveAppointments(project.projectCode, { updates }, res.locals.user.username)
+        if (updates.length > 0) {
+          try {
+            await this.appointmentService.saveAppointments(project.projectCode, { updates }, res.locals.user.username)
 
-          _req.flash('success', 'Attendance recorded')
-          return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
-        } catch (error) {
-          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointmentOrSession))
+            _req.flash('success', 'Attendance recorded')
+            return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
+          } catch (error) {
+            return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointmentOrSession))
+          }
         }
+
+        return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
       }
     }
   }

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -68,7 +68,7 @@ export default class ConfirmController implements IFormPageController {
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         }
 
-        const payload = this.buildAppointmentUpdate(form, appointment, page, didAttend)
+        const payload = this.buildAppointmentUpdate(form, appointment, page, didAttend, false)
 
         try {
           await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
@@ -99,7 +99,7 @@ export default class ConfirmController implements IFormPageController {
               return undefined
             }
 
-            return this.buildAppointmentUpdate(form, appointment, page, didAttend)
+            return this.buildAppointmentUpdate(form, appointment, page, didAttend, true)
           }),
         ).then(appointmentsToUpdate => appointmentsToUpdate.filter(update => update !== undefined))
 
@@ -129,9 +129,11 @@ export default class ConfirmController implements IFormPageController {
     appointment: AppointmentDto,
     page: ConfirmPage,
     didAttend: boolean,
+    isBulk: boolean,
   ): UpdateAppointmentDto {
+    const allowSensitiveUpdate = !isBulk
     return {
-      ...NotesUtils.requestBody(form, appointment.sensitive),
+      ...NotesUtils.requestBody(form, appointment.sensitive, allowSensitiveUpdate),
       deliusId: appointment.id,
       deliusVersionToUpdate: appointment.version,
       alertActive: page.isAlertSelected ?? appointment.alertActive,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -2,7 +2,7 @@ import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import ConfirmPage from '../../pages/appointments/confirmPage'
-import { AppointmentDto, UpdateAppointmentOutcomeDto } from '../../@types/shared'
+import { AppointmentDto, UpdateAppointmentDto } from '../../@types/shared'
 import { AppointmentOrSessionParams, AppointmentOutcomeForm, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
@@ -43,54 +43,89 @@ export default class ConfirmController implements IFormPageController {
 
   submit(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const { projectCode, appointmentId } = _req.params
-      const appointment = await this.appointmentService.getAppointment({
-        projectCode,
-        appointmentId,
-        username: res.locals.user.username,
-      })
+      const appointmentOrSessionParams = _req.params as unknown as AppointmentOrSessionParams
 
       const project = await this.projectService.getProject({
         username: res.locals.user.username,
-        projectCode,
+        projectCode: appointmentOrSessionParams.projectCode,
+      })
+
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
       })
 
       const page = new ConfirmPage(_req.body)
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
-
-      if (this.appointmentHasChangedSinceLoaded(form, appointment)) {
-        _req.flash('error', 'The arrival time has already been updated in the database, try again.')
-        return res.redirect(page.exitForm(appointment, project, form.originalSearch))
-      }
-
       const didAttend = form.contactOutcome.attended
 
-      const payload: UpdateAppointmentOutcomeDto = {
-        ...NotesUtils.requestBody(form, appointment.sensitive),
-        deliusId: appointment.id,
-        deliusVersionToUpdate: appointment.version,
-        alertActive: page.isAlertSelected ?? appointment.alertActive,
-        startTime: form.startTime,
-        endTime: form.endTime,
-        contactOutcomeCode: form.contactOutcome.code,
-        attendanceData: didAttend ? form.attendanceData : undefined,
-        supervisorOfficerCode: form.supervisor.code,
-        date: appointment.date,
-      }
-
-      try {
-        await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
-
-        res.locals.audit = {
-          subjectType: 'CRN',
-          subjectId: appointment.offender.crn,
+      if (appointmentOrSessionParams.appointmentId) {
+        const appointment = appointmentOrSession as AppointmentDto
+        if (this.appointmentHasChangedSinceLoaded(form, appointment)) {
+          _req.flash('error', 'The arrival time has already been updated in the database, try again.')
+          return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         }
 
-        _req.flash('success', 'Attendance recorded')
-        return res.redirect(page.exitForm(appointment, project, form.originalSearch))
-      } catch (error) {
-        return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment))
+        const payload = this.buildAppointmentUpdate(form, appointment, page, didAttend)
+
+        try {
+          await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
+
+          // TODO: how is this sent? Does it need an audit event set on the router?
+          res.locals.audit = {
+            subjectType: 'CRN',
+            subjectId: appointment.offender.crn,
+          }
+
+          _req.flash('success', 'Attendance recorded')
+          return res.redirect(page.exitForm(appointment, project, form.originalSearch))
+        } catch (error) {
+          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment))
+        }
+      } else {
+        const updates = await Promise.all(
+          form.appointments.map(async formAppointment => {
+            const appointment = await this.appointmentService.getAppointment({
+              projectCode: appointmentOrSessionParams.projectCode,
+              appointmentId: formAppointment.id.toString(),
+              username: res.locals.user.username,
+            })
+
+            return this.buildAppointmentUpdate(form, appointment, page, didAttend)
+          }),
+        )
+
+        try {
+          await this.appointmentService.saveAppointments(project.projectCode, { updates }, res.locals.user.username)
+
+          _req.flash('success', 'Attendance recorded')
+          return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
+        } catch (error) {
+          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointmentOrSession))
+        }
       }
+    }
+  }
+
+  private buildAppointmentUpdate(
+    form: AppointmentOutcomeForm,
+    appointment: AppointmentDto,
+    page: ConfirmPage,
+    didAttend: boolean,
+  ): UpdateAppointmentDto {
+    return {
+      ...NotesUtils.requestBody(form, appointment.sensitive),
+      deliusId: appointment.id,
+      deliusVersionToUpdate: appointment.version,
+      alertActive: page.isAlertSelected ?? appointment.alertActive,
+      startTime: form.startTime || appointment.startTime,
+      endTime: form.endTime || appointment.endTime,
+      contactOutcomeCode: form.contactOutcome.code,
+      attendanceData: didAttend ? form.attendanceData : undefined,
+      supervisorOfficerCode: form.supervisor.code,
+      date: appointment.date,
     }
   }
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -63,7 +63,7 @@ export default class ConfirmController implements IFormPageController {
 
       if (appointmentOrSessionParams.appointmentId) {
         const appointment = appointmentOrSession as AppointmentDto
-        if (this.appointmentHasChangedSinceLoaded(form, appointment)) {
+        if (this.appointmentHasChangedSinceLoaded(form.deliusVersion, appointment)) {
           _req.flash('error', 'The arrival time has already been updated in the database, try again.')
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         }
@@ -85,6 +85,7 @@ export default class ConfirmController implements IFormPageController {
           return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment))
         }
       } else {
+        const appointmentsWithDeliusVersionError: Array<AppointmentDto> = []
         const updates = await Promise.all(
           form.appointments.map(async formAppointment => {
             const appointment = await this.appointmentService.getAppointment({
@@ -93,9 +94,19 @@ export default class ConfirmController implements IFormPageController {
               username: res.locals.user.username,
             })
 
+            if (this.appointmentHasChangedSinceLoaded(formAppointment.deliusVersion, appointment)) {
+              appointmentsWithDeliusVersionError.push(appointment)
+              return undefined
+            }
+
             return this.buildAppointmentUpdate(form, appointment, page, didAttend)
           }),
-        )
+        ).then(appointmentsToUpdate => appointmentsToUpdate.filter(update => update !== undefined))
+
+        if (appointmentsWithDeliusVersionError.length > 0) {
+          const message = page.deliusVersionChangedMessage(appointmentsWithDeliusVersionError)
+          _req.flash('error', message)
+        }
 
         try {
           await this.appointmentService.saveAppointments(project.projectCode, { updates }, res.locals.user.username)
@@ -129,7 +140,7 @@ export default class ConfirmController implements IFormPageController {
     }
   }
 
-  private appointmentHasChangedSinceLoaded(form: AppointmentOutcomeForm, appointment: AppointmentDto): boolean {
-    return form.deliusVersion !== appointment.version
+  private appointmentHasChangedSinceLoaded(formDeliusVersion: string, appointment: AppointmentDto): boolean {
+    return formDeliusVersion !== appointment.version
   }
 }

--- a/server/controllers/courseCompletions/process/personController.test.ts
+++ b/server/controllers/courseCompletions/process/personController.test.ts
@@ -41,6 +41,7 @@ describe('PersonController', () => {
       dateOfBirth: '12 January 1990',
       crn: 'X000000',
       isLimited: false,
+      description: '',
     },
     crnPagePath: 'crn-page-path',
   }

--- a/server/data/appointmentClient.test.ts
+++ b/server/data/appointmentClient.test.ts
@@ -65,6 +65,31 @@ describe('appointmentClient', () => {
     })
   })
 
+  describe('bulkUpdate', () => {
+    it('should make a PUT request to the bulk appointment update path using user token', async () => {
+      const projectCode = 'PROJECT-123'
+      const updates = [
+        {
+          deliusId: 1001,
+          deliusVersionToUpdate: '1',
+          date: '2026-06-09',
+          startTime: '09:00',
+          endTime: '10:00',
+          supervisorOfficerCode: 'SUP-123',
+        },
+      ]
+
+      nock(config.apis.communityPaybackApi.url)
+        .put(paths.appointments.bulkUpdate({ projectCode }), { updates })
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200)
+
+      const response = await appointmentClient.bulkUpdate('some-user-name', projectCode, { updates })
+
+      expect(response).toBeTruthy()
+    })
+  })
+
   describe('getAppointmentTasks', () => {
     it('should make a GET request to the appointment tasks path using user token and return the response body', async () => {
       const appointments = pagedModelAppointmentTaskSummaryFactory.build()

--- a/server/data/appointmentClient.ts
+++ b/server/data/appointmentClient.ts
@@ -8,6 +8,7 @@ import {
   PagedModelAppointmentTaskSummaryDto,
   ProjectTypeDto,
   UpdateAppointmentOutcomeDto,
+  UpdateAppointmentsDto,
 } from '../@types/shared'
 import { GetAppointmentTasksRequest, PagedRequest } from '../@types/user-defined'
 import { createQueryString } from '../utils/utils'
@@ -43,6 +44,11 @@ export default class AppointmentClient extends RestClient {
 
   async save(username: string, projectCode: string, data: UpdateAppointmentOutcomeDto): Promise<void> {
     const path = paths.appointments.outcome({ projectCode, appointmentId: data.deliusId.toString() })
+    return this.put({ path, data }, asSystem(username))
+  }
+
+  bulkUpdate(username: string, projectCode: string, data: UpdateAppointmentsDto): Promise<void> {
+    const path = paths.appointments.bulkUpdate({ projectCode })
     return this.put({ path, data }, asSystem(username))
   }
 

--- a/server/models/offender.test.ts
+++ b/server/models/offender.test.ts
@@ -38,6 +38,7 @@ describe('Offender', () => {
         firstName: offenderDto.forename,
         lastName: offenderDto.surname,
         dateOfBirth: offenderDto.dateOfBirth,
+        description: `${offenderDto.forename} ${offenderDto.surname} (${offenderDto.crn})`,
       })
     })
 
@@ -79,6 +80,7 @@ describe('Offender', () => {
     it('has details', () => {
       expect(offender.details).toEqual({
         crn: offenderDto.crn,
+        description: offenderDto.crn,
       })
     })
 
@@ -119,6 +121,7 @@ describe('Offender', () => {
     it('has details', () => {
       expect(offender.details).toEqual({
         crn: offenderDto.crn,
+        description: offenderDto.crn,
       })
     })
 

--- a/server/models/offender.ts
+++ b/server/models/offender.ts
@@ -6,6 +6,7 @@ export interface OffenderDetails {
   lastName?: string
   crn: string
   dateOfBirth?: string
+  description: string
 }
 
 export default class Offender {
@@ -36,6 +37,7 @@ export default class Offender {
     if (this.isLimited) {
       return {
         crn: this.crn,
+        description: this.crn,
       }
     }
 
@@ -46,6 +48,7 @@ export default class Offender {
       firstName: fullOffender.forename,
       lastName: fullOffender.surname,
       dateOfBirth: fullOffender.dateOfBirth,
+      description: `${fullOffender.forename} ${fullOffender.surname} (${fullOffender.crn})`,
     }
   }
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -10,6 +10,7 @@ import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeF
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import projectFactory from '../../testutils/factories/projectFactory'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
+import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 
 describe('ConfirmPage', () => {
   beforeEach(() => {
@@ -689,5 +690,50 @@ describe('ConfirmPage', () => {
         expect(result).toEqual(mockReturnValue)
       },
     )
+  })
+
+  describe('deliusVersionChangedMessage', () => {
+    it('should return singular form message for 1 appointment', () => {
+      const page = new ConfirmPage({})
+      const appointment = appointmentFactory.build({
+        offender: offenderFullFactory.build({
+          forename: 'John',
+          surname: 'Smith',
+          crn: 'X123456',
+        }),
+      })
+
+      const result = page.deliusVersionChangedMessage([appointment])
+
+      expect(result).toBe(
+        'The appointment for John Smith (X123456) has already been updated in the database. Try again.',
+      )
+    })
+
+    it('should return plural form message for multiple appointments', () => {
+      const page = new ConfirmPage({})
+      const appointments = [
+        appointmentFactory.build({
+          offender: offenderFullFactory.build({
+            forename: 'John',
+            surname: 'Smith',
+            crn: 'X123456',
+          }),
+        }),
+        appointmentFactory.build({
+          offender: offenderFullFactory.build({
+            forename: 'Jane',
+            surname: 'Doe',
+            crn: 'Y654321',
+          }),
+        }),
+      ]
+
+      const result = page.deliusVersionChangedMessage(appointments)
+
+      expect(result).toBe(
+        'The appointments for John Smith (X123456), Jane Doe (Y654321) have already been updated in the database. Try again.',
+      )
+    })
   })
 })

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,3 +1,4 @@
+import { AppointmentDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
@@ -8,6 +9,7 @@ import {
   YesOrNo,
 } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
+import Offender from '../../models/offender'
 import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
@@ -55,6 +57,16 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
 
   get isAlertSelected(): boolean | null {
     return GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.alertPractitioner)
+  }
+
+  deliusVersionChangedMessage(appointments: Array<AppointmentDto>): string {
+    const appointmentText = appointments.length === 1 ? 'appointment' : 'appointments'
+    const haveHas = appointments.length === 1 ? 'has' : 'have'
+    const appointmentIdentifiers = appointments.map(appointment => {
+      const offender = new Offender(appointment.offender)
+      return offender.details.description
+    })
+    return `The ${appointmentText} for ${appointmentIdentifiers.join(', ')} ${haveHas} already been updated in the database. Try again.`
   }
 
   protected nextPage(): AppointmentFormPage | undefined {

--- a/server/pages/courseCompletions/process/personPage.test.ts
+++ b/server/pages/courseCompletions/process/personPage.test.ts
@@ -85,6 +85,7 @@ describe('PersonPage', () => {
         dateOfBirth: '12 January 1990',
         crn: 'X000000',
         isLimited: false,
+        description: 'Mary Smith (CRN)',
       }
       jest.spyOn(CourseCompletionUtils, 'formattedLearnerDetails').mockReturnValue(learnerDetails)
       jest.spyOn(CourseCompletionUtils, 'formattedOffenderDetails').mockReturnValue(offenderDetails)

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -19,6 +19,7 @@ export default {
     filter: adminUiPath.path('appointments'),
     singleAppointment: projectAppointmentsPath.path(':appointmentId'),
     outcome: projectAppointmentsPath.path(':appointmentId'),
+    bulkUpdate: projectAppointmentsPath.path('bulk'),
     tasks: {
       filter: appointmentTasksPath.path('pending'),
       complete: appointmentTasksPath.path(':taskId/complete'),

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -40,6 +40,24 @@ describe('AppointmentService', () => {
     expect(appointmentClient.save).toHaveBeenCalledTimes(1)
   })
 
+  it('should call saveAppointments on the api client', async () => {
+    const updates = [
+      {
+        deliusId: 1001,
+        deliusVersionToUpdate: '1',
+        date: '2026-06-09',
+        startTime: '09:00',
+        endTime: '10:00',
+        supervisorOfficerCode: 'SUP-123',
+      },
+    ]
+
+    await appointmentService.saveAppointments('1', { updates }, 'some-username')
+
+    expect(appointmentClient.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(appointmentClient.bulkUpdate).toHaveBeenCalledWith('some-username', '1', { updates })
+  })
+
   describe('getProjectAppointmentsWithMissingOutcomes', () => {
     it('should search with the given project code, NO_OUTCOME and toDate of today and fromDate as 45 days ago', async () => {
       const projectCode = '123'

--- a/server/services/appointmentService.ts
+++ b/server/services/appointmentService.ts
@@ -3,6 +3,7 @@ import {
   PagedModelAppointmentSummaryDto,
   PagedModelAppointmentTaskSummaryDto,
   UpdateAppointmentOutcomeDto,
+  UpdateAppointmentsDto,
 } from '../@types/shared'
 import AppointmentClient, { GetAppointmentsRequest } from '../data/appointmentClient'
 import config from '../config'
@@ -26,6 +27,10 @@ export default class AppointmentService {
     username: string,
   ): Promise<void> {
     return this.appointmentClient.save(username, projectCode, appointmentData)
+  }
+
+  saveAppointments(projectCode: string, appointmentsToUpdate: UpdateAppointmentsDto, username: string): Promise<void> {
+    return this.appointmentClient.bulkUpdate(username, projectCode, appointmentsToUpdate)
   }
 
   async getProjectAppointmentsWithMissingOutcomes({

--- a/server/testutils/factories/appointmentOutcomeFormFactory.ts
+++ b/server/testutils/factories/appointmentOutcomeFormFactory.ts
@@ -5,6 +5,11 @@ import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import { contactOutcomeFactory } from './contactOutcomeFactory'
 import supervisorSummaryFactory from './supervisorSummaryFactory'
 
+const selectedAppointmentFactory = Factory.define<{ id: number; deliusVersion: string }>(() => ({
+  id: faker.number.int(),
+  deliusVersion: faker.string.alpha(8),
+}))
+
 export default Factory.define<AppointmentOutcomeForm>(
   () =>
     ({
@@ -19,5 +24,6 @@ export default Factory.define<AppointmentOutcomeForm>(
         provider: faker.string.alpha(8),
         team: faker.string.alpha(8),
       },
+      appointments: selectedAppointmentFactory.buildList(1),
     }) satisfies AppointmentOutcomeForm,
 )

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -64,6 +64,7 @@ describe('CourseCompletionUtils', () => {
         const result = CourseCompletionUtils.formattedOffenderDetails(offender)
         expect(result).toEqual({
           crn: offender.crn,
+          description: offender.crn,
           isLimited: true,
         })
       })
@@ -83,6 +84,7 @@ describe('CourseCompletionUtils', () => {
           firstName: offender.forename,
           lastName: offender.surname,
           dateOfBirth,
+          description: `${offender.forename} ${offender.surname} (${offender.crn})`,
         })
       })
     })

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -336,6 +336,25 @@ describe('NotesUtils', () => {
       expect(result.sensitive).toBe(true)
     })
 
+    it.each([true, false, undefined])(
+      'should always return appointment sensitive value when sensitive updates are not allowed',
+      (appointmentIsSensitive?: boolean) => {
+        const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+
+        const result = NotesUtils.requestBody(form, appointmentIsSensitive, false)
+
+        expect(result.sensitive).toBe(appointmentIsSensitive)
+      },
+    )
+
+    it('should use form sensitive value when sensitive updates are explicitly allowed', () => {
+      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+
+      const result = NotesUtils.requestBody(form, undefined, true)
+
+      expect(result.sensitive).toBe(false)
+    })
+
     it.each([false, undefined, null])(
       'should include form sensitive value if appointment sensitive value is not true',
       (appointmentIsSensitive?: boolean) => {

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -8,12 +8,27 @@ export default class NotesUtils {
     return { notes: query.notes, isSensitive: query.isSensitive }
   }
 
-  static requestBody(form: BodyWithNotes, appointmentIsSensitive?: boolean) {
+  static requestBody(
+    form: BodyWithNotes,
+    appointmentIsSensitive?: boolean | null,
+    allowSensitiveUpdate: boolean = true,
+  ) {
     return {
       notes: form.notes,
-      sensitive:
-        appointmentIsSensitive === true ? true : GovUkRadioGroup.nullableValueFromYesOrNoItem(form.isSensitive),
+      sensitive: NotesUtils.sensitiveRequestBody(form, appointmentIsSensitive, allowSensitiveUpdate),
     }
+  }
+
+  private static sensitiveRequestBody(
+    form: BodyWithNotes,
+    appointmentIsSensitive?: boolean | null,
+    allowSensitiveUpdate: boolean = true,
+  ) {
+    if (!allowSensitiveUpdate) {
+      return appointmentIsSensitive
+    }
+
+    return appointmentIsSensitive === true ? true : GovUkRadioGroup.nullableValueFromYesOrNoItem(form.isSensitive)
   }
 
   static checkYourAnswersRows(


### PR DESCRIPTION
## Context

Continuation of enabling bulk updates for appointments,  handling the submit of multiple appointments on the last step of the form.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- Introduce bulk update endpoint 
- Update appointment confirm submit handler to handle session (bulk) submissions
- Update delius version validation to work for multiple appointments
- Ensure is sensitive value on appointment is always sent for bulk updates (as we will not be presenting that as a question).

### Still to implement

- Hide is sensitive question and answer
- Add appointment select page
- Add selected people and change link to confirm page
- Update success messaging if applicable, to include multiple appointments

### Screenshots of UI changes

Success and failure messages for multiple appointment updates:
<img width="1006" height="660" alt="Screenshot 2026-06-12 at 13 58 59" src="https://github.com/user-attachments/assets/975917a6-0d78-4aef-b14c-b189a57ff579" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ