### PR TITLE
CPB-1031 Update outcome page detail sections

### DIFF
--- a/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
+++ b/integration_tests/pages/courseCompletions/courseDetailsComponent.ts
@@ -20,15 +20,7 @@ export default class CourseDetailsComponent {
       Math.round(this.courseCompletion.expectedTimeMinutes * 1.2),
     )
 
-    const totalTimeSpent = DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(
-      this.courseCompletion.totalTimeMinutes,
-    )
-
-    const completionDate = DateTimeFormats.isoDateToUIDate(this.courseCompletion.completionDateTime)
-
-    this.details.getValueWithLabel('Completion date').should('contain.text', completionDate)
     this.details.getValueWithLabel('Expected time').should('contain.text', expectedTime)
     this.details.getValueWithLabel('Expected time with 20% allowance').should('contain.text', expectedTimeWithAllowance)
-    this.details.getValueWithLabel('Total time spent').should('contain.text', totalTimeSpent)
   }
 }

--- a/integration_tests/pages/courseCompletions/process/outcomePage.ts
+++ b/integration_tests/pages/courseCompletions/process/outcomePage.ts
@@ -25,7 +25,7 @@ export default class OutcomePage extends BaseCourseCompletionsPage {
 
   constructor(private readonly courseCompletion: EteCourseCompletionEventDto) {
     super('Record an outcome')
-    this.courseDetails = new CourseDetailsComponent(this.courseCompletion, 'Community Campus record')
+    this.courseDetails = new CourseDetailsComponent(this.courseCompletion, 'Course details')
     this.requirementDetails = new SummaryListComponent('Requirement details')
     this.completionDetails = new CompletionDetailsComponent()
   }

--- a/integration_tests/pages/courseCompletions/process/outcomePage.ts
+++ b/integration_tests/pages/courseCompletions/process/outcomePage.ts
@@ -26,7 +26,7 @@ export default class OutcomePage extends BaseCourseCompletionsPage {
   constructor(private readonly courseCompletion: EteCourseCompletionEventDto) {
     super('Record an outcome')
     this.courseDetails = new CourseDetailsComponent(this.courseCompletion, 'Community Campus record')
-    this.requirementDetails = new SummaryListComponent('Unpaid work requirement')
+    this.requirementDetails = new SummaryListComponent('Requirement details')
     this.completionDetails = new CompletionDetailsComponent()
   }
 

--- a/server/views/courseCompletions/_courseDetails.njk
+++ b/server/views/courseCompletions/_courseDetails.njk
@@ -11,14 +11,6 @@
   rows: [
     {
       key: {
-        text: 'Completion date'
-      },
-      value: {
-        text: courseDetailsItems.completionDate
-      }
-    },
-    {
-      key: {
         text: 'Expected time'
       },
       value: {
@@ -30,13 +22,6 @@
         text: 'Expected time with 20% allowance'
       }, value: {
         text: courseDetailsItems.expectedTimeWithAllowance
-      }
-    },
-    {
-      key: {
-        text: 'Total time spent'
-      }, value: {
-        text: courseDetailsItems.totalTimeSpent
       }
     }
   ]

--- a/server/views/courseCompletions/process/_requirementDetails.njk
+++ b/server/views/courseCompletions/process/_requirementDetails.njk
@@ -3,7 +3,7 @@
 {{ govukSummaryList({
   card: {
     title: {
-      text: 'Unpaid work requirement',
+      text: 'Requirement details',
       headingLevel: 3
     }
   },

--- a/server/views/courseCompletions/process/outcome.njk
+++ b/server/views/courseCompletions/process/outcome.njk
@@ -10,8 +10,8 @@
   <h2>View records</h2>
   <p class="govuk-!-margin-bottom-7">Check the Community Campus record and hours remaining in the unpaid work requirement before deciding on the credited hours.</p>
 
-  {{ courseDetails(courseDetailsItems)}}
   {% include "./_requirementDetails.njk" %}
+  {{ courseDetails(courseDetailsItems)}}
   {{ completionDetails(courseCompletion, completionDetailsRows) }}
 {% endblock %}
 {% block formContent %}

--- a/server/views/courseCompletions/process/outcome.njk
+++ b/server/views/courseCompletions/process/outcome.njk
@@ -10,7 +10,7 @@
   <h2>View records</h2>
   <p class="govuk-!-margin-bottom-7">Check the Community Campus record and hours remaining in the unpaid work requirement before deciding on the credited hours.</p>
 
-  {{ courseDetails(courseDetailsItems, 'Community Campus record')}}
+  {{ courseDetails(courseDetailsItems)}}
   {% include "./_requirementDetails.njk" %}
   {{ completionDetails(courseCompletion, completionDetailsRows) }}
 {% endblock %}


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1031?atlOrigin=eyJpIjoiYTYxMDE4ZjI2NzIzNGVjMzhmMmVjYTQzZmU1ZjQ1NWMiLCJwIjoiaiJ9)

## Context
Update details on the record outcome page now that we have included the completion details section.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR
* Update section titles
* Remove completion date from course details section (this is now in completion details)
* Remove total time spent (now in completion details)

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
#### Before
<img width="1217" height="853" alt="image" src="https://github.com/user-attachments/assets/6ad47c66-c557-4f5f-b5c0-51a3e5f1d30c" />

#### After
<img width="1228" height="764" alt="Screenshot 2026-06-15 at 15 49 28" src="https://github.com/user-attachments/assets/27bb3c37-a3f3-43ad-8d7b-39ae208c9ecf" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
