### PR TITLE
CPB-1026: Hide sensitive question for bulk appointment updates

### DIFF
--- a/integration_tests/pages/appointments/attendanceOutcomePage.ts
+++ b/integration_tests/pages/appointments/attendanceOutcomePage.ts
@@ -17,9 +17,9 @@ export default class AttendanceOutcomePage extends BaseAppointmentFormPage {
     this.notesQuestions = new NotesQuestionComponent()
   }
 
-  completeForm(contactOutcomeCode: string) {
+  completeForm(contactOutcomeCode: string, expectIsSensitiveQuestion = true) {
     this.contactOutcomeOptions.checkOptionWithValue(contactOutcomeCode)
-    this.notesQuestions.completeForm()
+    this.notesQuestions.completeForm(expectIsSensitiveQuestion)
   }
 
   protected override customCheckOnPage(): void {

--- a/integration_tests/pages/components/notesQuestionComponent.ts
+++ b/integration_tests/pages/components/notesQuestionComponent.ts
@@ -6,9 +6,11 @@ export default class NotesQuestionComponent {
 
   notesField = () => cy.get('#notes')
 
-  completeForm() {
+  completeForm(expectIsSensitiveQuestion = true) {
     this.notesField().type('Attendance notes')
-    this.selectIsSensitive('no')
+    if (expectIsSensitiveQuestion) {
+      this.selectIsSensitive('no')
+    }
   }
 
   selectIsSensitive(value: YesOrNo = 'yes') {

--- a/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
@@ -57,8 +57,9 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
   describe('submit', function describe() {
     it('submits the form and navigates to the next page', function test() {
       const page = AttendanceOutcomePage.visitForSession(this.session)
+      page.notesQuestions.shouldNotShowIsSensitiveQuestion()
 
-      page.completeForm(this.contactOutcomes.contactOutcomes[0].code)
+      page.completeForm(this.contactOutcomes.contactOutcomes[0].code, false)
 
       cy.task('stubSaveAppointmentForm')
       page.clickSubmit()

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -283,7 +283,7 @@ describe('AttendanceOutcomePage', () => {
         page: 'choose-supervisor',
       })
 
-      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment)
+      expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment, true)
 
       expect(result).toEqual({
         heading: {
@@ -370,7 +370,7 @@ describe('AttendanceOutcomePage', () => {
 
       const viewData = page.viewData(form)
 
-      expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined)
+      expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
       expect(viewData).toEqual(expect.objectContaining(notesItems))
     })
 
@@ -441,7 +441,7 @@ describe('AttendanceOutcomePage', () => {
 
         expect(result.items).toEqual(expectedItems)
         expect(result.notes).toEqual(notesItems.notes)
-        expect(NotesUtils.questionItems).toHaveBeenCalledWith(query, form, appointment)
+        expect(NotesUtils.questionItems).toHaveBeenCalledWith(query, form, appointment, true)
       })
 
       it('should return items if page has Errors and contact outcome is undefined', () => {

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -87,12 +87,11 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
-    const appointment = this.isSingleAppointment(this.appointmentOrSession)
-      ? (this.appointmentOrSession as AppointmentDto)
-      : undefined
+    const isSingleAppointment = this.isSingleAppointment(this.appointmentOrSession)
+    const appointment = isSingleAppointment ? (this.appointmentOrSession as AppointmentDto) : undefined
     return {
       ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession }),
-      ...NotesUtils.questionItems(this.query, form, appointment),
+      ...NotesUtils.questionItems(this.query, form, appointment, isSingleAppointment),
       items: this.items(form, hasErrors),
     }
   }

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -122,6 +122,43 @@ describe('NotesUtils', () => {
           { checked: true, text: 'No, they are not sensitive', value: 'no' },
         ])
       })
+
+      describe('includeIsSensitiveQuestion', () => {
+        it('shows sensitive question when appointment is present and includeIsSensitiveQuestion is true', () => {
+          const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+          const appointment = appointmentFactory.build({ sensitive: false })
+
+          const result = NotesUtils.questionItems({}, form, appointment, true)
+
+          expect(result.showIsSensitiveQuestion).toBe(true)
+          expect(result.isSensitiveItems).toEqual([
+            { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
+            { checked: false, text: 'No, they are not sensitive', value: 'no' },
+          ])
+        })
+
+        it('does not show sensitive question when appointment is present and includeIsSensitiveQuestion is false', () => {
+          const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+          const appointment = appointmentFactory.build({ sensitive: false })
+
+          const result = NotesUtils.questionItems({}, form, appointment, false)
+
+          expect(result.showIsSensitiveQuestion).toBe(false)
+          expect(result.isSensitiveItems).toBeUndefined()
+        })
+
+        it('shows sensitive question when appointment is undefined and includeIsSensitiveQuestion is true', () => {
+          const form = courseCompletionFormFactory.build({ isSensitive: 'yes' })
+
+          const result = NotesUtils.questionItems({}, form, undefined, true)
+
+          expect(result.showIsSensitiveQuestion).toBe(true)
+          expect(result.isSensitiveItems).toEqual([
+            { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
+            { checked: false, text: 'No, they are not sensitive', value: 'no' },
+          ])
+        })
+      })
     })
   })
 

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -86,9 +86,14 @@ export default class NotesUtils {
     return form.isSensitive ? properCase(form.isSensitive) : 'Not entered'
   }
 
-  static questionItems(query: BodyWithNotes, form: BodyWithNotes, appointment?: AppointmentDto): ViewDataWithNotes {
+  static questionItems(
+    query: BodyWithNotes,
+    form: BodyWithNotes,
+    appointment?: AppointmentDto,
+    includeIsSensitiveQuestion: boolean = true,
+  ): ViewDataWithNotes {
     const notes = query.notes ?? form.notes
-    const showIsSensitiveQuestion = appointment?.sensitive !== true
+    const showIsSensitiveQuestion = includeIsSensitiveQuestion ? appointment?.sensitive !== true : false
 
     if (showIsSensitiveQuestion) {
       const sensitive =


### PR DESCRIPTION
## Context

Updates the appointment update journey so that the 'Do these notes contain sensitive information' question is hidden during bulk updates, while remaining available for single appointment updates.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

### Screenshots of UI changes

Bulk update attendance outcome page:
<img width="985" height="659" alt="Attendance outcome form page for bulk updates with no sensitivity question" src="https://github.com/user-attachments/assets/7d51e888-9c97-4635-9903-ffab90c87333" />

Single appointment outcome page:
<img width="1002" height="662" alt="Attendance outcome form page for single appointment update with sensitivity question" src="https://github.com/user-attachments/assets/9971e5eb-4b12-4a0f-9d55-2966f00df759" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ