### PR TITLE
CPB-1026: Add selected people widget

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -1,3 +1,11 @@
 .govuk-main-wrapper {
   min-height: 600px;
 }
+
+.govuk-summary-list--no-fixed-width {
+  .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+      width: unset;
+    }
+  }
+}

--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -6,9 +6,12 @@ import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
 import { AppointmentDto, SessionDto } from '../../../server/@types/shared'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import SelectedPeopleCardComponent from './selectedPeopleCardComponent'
 
 export default abstract class BaseAppointmentFormPage extends Page {
   protected readonly isSingleAppointment: boolean
+
+  readonly selectedPeopleCard = new SelectedPeopleCardComponent()
 
   protected abstract page: AppointmentFormPage
 

--- a/integration_tests/pages/appointments/bulkUpdatePage.ts
+++ b/integration_tests/pages/appointments/bulkUpdatePage.ts
@@ -1,0 +1,13 @@
+import { SessionDto } from '../../../server/@types/shared'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import Page from '../page'
+
+export default class BulkUpdatePage extends Page {
+  constructor(session: SessionDto) {
+    super(`${session.projectName} (${DateTimeFormats.isoDateToUIDate(session.date)})`)
+  }
+
+  protected override customCheckOnPage(): void {
+    cy.get('legend').should('contain.text', 'Select all people with the same attendance outcome')
+  }
+}

--- a/integration_tests/pages/appointments/selectedPeopleCardComponent.ts
+++ b/integration_tests/pages/appointments/selectedPeopleCardComponent.ts
@@ -1,0 +1,28 @@
+import { AppointmentSummaryDto } from '../../../server/@types/shared'
+import Offender from '../../../server/models/offender'
+import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import SummaryListComponent from '../components/summaryListComponent'
+
+export default class SelectedPeopleCardComponent {
+  private readonly card = new SummaryListComponent('Selected people')
+
+  clickChangeLink() {
+    this.card.getAction('Change').click()
+  }
+
+  shouldShowSelectedPeople(expectedAppointmentSummaries: Array<AppointmentSummaryDto>) {
+    expectedAppointmentSummaries.forEach(appointment => {
+      const offender = new Offender(appointment.offender)
+      this.card
+        .getValueWithLabel(`${offender.name} (${offender.crn})`)
+        .should('contain.text', `${DateTimeFormats.timePeriod(appointment.startTime, appointment.endTime)}`)
+    })
+  }
+
+  shouldNotShowPeople(appointments: Array<AppointmentSummaryDto>) {
+    appointments.forEach(appointment => {
+      const offender = new Offender(appointment.offender)
+      this.card.shouldNotContainRowWithLabel(`${offender.name} (${offender.crn})`)
+    })
+  }
+}

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -1,9 +1,19 @@
 export default class SummaryListComponent {
   constructor(private readonly title: string = undefined) {}
 
+  // This only works if one action link with given text
+  // Visually hidden text can be used to find unique links with given text!
+  getAction(text: string) {
+    return this.component().contains('a').contains(text)
+  }
+
   getValueWithLabel(label: string, options?: { exact?: boolean }) {
     const matcher = options?.exact ? this.exactMatcher(label) : label
     return this.component().find('dt').contains(matcher).find('+dd')
+  }
+
+  shouldNotContainRowWithLabel(label: string) {
+    return this.component().find('dt').contains(label).should('not.exist')
   }
 
   clickActionWithLabel(label: string, options?: { exact?: boolean }) {

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -4,7 +4,7 @@ export default class SummaryListComponent {
   // This only works if one action link with given text
   // Visually hidden text can be used to find unique links with given text!
   getAction(text: string) {
-    return this.component().contains('a').contains(text)
+    return this.component().contains('a', text)
   }
 
   getValueWithLabel(label: string, options?: { exact?: boolean }) {
@@ -13,7 +13,7 @@ export default class SummaryListComponent {
   }
 
   shouldNotContainRowWithLabel(label: string) {
-    return this.component().find('dt').contains(label).should('not.exist')
+    return this.component().find('dt').should('not.contain.text', label)
   }
 
   clickActionWithLabel(label: string, options?: { exact?: boolean }) {

--- a/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
@@ -10,6 +10,8 @@ import {
 } from '../../../../server/testutils/factories/contactOutcomeFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
+import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
+import BulkUpdatePage from '../../../pages/appointments/bulkUpdatePage'
 
 context('Group Session Bulk Update - Attendance Outcome', () => {
   beforeEach(() => {
@@ -19,8 +21,14 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
 
     const project = projectFactory.build()
     cy.wrap(project).as('project')
-
-    const session = sessionFactory.build({ projectCode: project.projectCode })
+    const selectedAppointments = appointmentSummaryFactory.buildList(2)
+    cy.wrap(selectedAppointments).as('selectedAppointments')
+    const unselectedAppointment = appointmentSummaryFactory.build()
+    cy.wrap(unselectedAppointment).as('unselectedAppointment')
+    const session = sessionFactory.build({
+      projectCode: project.projectCode,
+      appointmentSummaries: [...selectedAppointments, unselectedAppointment],
+    })
     cy.wrap(session).as('session')
 
     const attendedOutcome = contactOutcomeFactory.build({ attended: true })
@@ -30,7 +38,12 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
     cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
     cy.task('stubGetContactOutcomes', { contactOutcomes })
-    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
+    cy.task(
+      'stubGetAppointmentForm',
+      appointmentOutcomeFormFactory.build({
+        appointments: selectedAppointments.map(appointment => ({ id: appointment.id, deliusVersion: '' })),
+      }),
+    )
   })
 
   // Scenario: sees validation errors with any entered answers when form is not valid
@@ -51,6 +64,18 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
     page.clickBack()
 
     Page.verifyOnPage(ChooseSupervisorPage, this.session)
+  })
+
+  // Scenario: can view and change people selected on the bulk update
+  it('enables navigation back to change selected people', function test() {
+    const page = AttendanceOutcomePage.visitForSession(this.session)
+    page.selectedPeopleCard.shouldShowSelectedPeople(this.selectedAppointments)
+    page.selectedPeopleCard.shouldNotShowPeople([this.unselectedAppointment])
+    cy.task('stubSaveAppointmentForm')
+
+    page.selectedPeopleCard.clickChangeLink()
+
+    Page.verifyOnPage(BulkUpdatePage, this.session)
   })
 
   // Scenario: can complete the form and navigate to the next page

--- a/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
@@ -7,6 +7,8 @@ import providerTeamSummaryFactory from '../../../../server/testutils/factories/p
 import supervisorSummaryFactory from '../../../../server/testutils/factories/supervisorSummaryFactory'
 import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../../../server/testutils/factories/contactOutcomeFactory'
+import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
+import BulkUpdatePage from '../../../pages/appointments/bulkUpdatePage'
 
 context('Group Session Bulk Update - Choose Supervisor', () => {
   beforeEach(() => {
@@ -17,35 +19,58 @@ context('Group Session Bulk Update - Choose Supervisor', () => {
     const project = projectFactory.build()
     cy.wrap(project).as('project')
 
-    const session = sessionFactory.build({ projectCode: project.projectCode })
+    const selectedAppointments = appointmentSummaryFactory.buildList(2)
+    cy.wrap(selectedAppointments).as('selectedAppointments')
+    const unselectedAppointment = appointmentSummaryFactory.build()
+    cy.wrap(unselectedAppointment).as('unselectedAppointment')
+    const session = sessionFactory.build({
+      projectCode: project.projectCode,
+      appointmentSummaries: [...selectedAppointments, unselectedAppointment],
+    })
     cy.wrap(session).as('session')
 
     cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
-    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
+    cy.task(
+      'stubGetAppointmentForm',
+      appointmentOutcomeFormFactory.build({
+        appointments: selectedAppointments.map(appointment => ({ id: appointment.id, deliusVersion: '' })),
+      }),
+    )
     cy.task('stubSaveAppointmentForm')
+
+    const teams = providerTeamSummaryFactory.buildList(2)
+    cy.wrap(teams).as('teams')
+
+    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: project.providerCode })
   })
 
   // Scenario: sees validation errors with any entered answers when form is not valid
   it('validates form data', function test() {
-    const teams = providerTeamSummaryFactory.buildList(2)
-    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
-
     const page = ChooseSupervisorPage.visitForSession(this.session)
     page.clickSubmit()
 
     page.shouldShowErrorSummary('team', 'Select a supervising team')
   })
 
+  // Scenario: can view and change people selected on the bulk update
+  it('enables navigation back to change selected people', function test() {
+    const page = ChooseSupervisorPage.visitForSession(this.session)
+    page.selectedPeopleCard.shouldShowSelectedPeople(this.selectedAppointments)
+    page.selectedPeopleCard.shouldNotShowPeople([this.unselectedAppointment])
+    cy.task('stubSaveAppointmentForm')
+
+    page.selectedPeopleCard.clickChangeLink()
+
+    Page.verifyOnPage(BulkUpdatePage, this.session)
+  })
+
   // Scenario: can complete the form and navigate to the next page
   describe('submit', function describe() {
     it('submits the form and navigates to the next page', function test() {
-      const teams = providerTeamSummaryFactory.buildList(2)
-      cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
-
       const supervisors = supervisorSummaryFactory.buildList(2)
       cy.task('stubGetSupervisors', {
-        teamCode: teams[0].code,
+        teamCode: this.teams[0].code,
         providerCode: this.project.providerCode,
         supervisors,
       })
@@ -54,7 +79,7 @@ context('Group Session Bulk Update - Choose Supervisor', () => {
 
       const page = ChooseSupervisorPage.visitForSession(this.session)
 
-      page.selectTeam(teams[0].code)
+      page.selectTeam(this.teams[0].code)
       page.supervisorInput.select(supervisors[0].code)
       page.clickSubmit()
 

--- a/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
@@ -5,16 +5,16 @@ import sessionFactory from '../../../../server/testutils/factories/sessionFactor
 import projectFactory from '../../../../server/testutils/factories/projectFactory'
 import appointmentOutcomeFormFactory from '../../../../server/testutils/factories/appointmentOutcomeFormFactory'
 import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
+import BulkUpdatePage from '../../../pages/appointments/bulkUpdatePage'
+import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
 
 context('Group Session Bulk Update - Log Compliance', () => {
-  const form = appointmentOutcomeFormFactory.build({
-    attendanceData: {
-      hiVisWorn: null,
-      workedIntensively: null,
-      workQuality: null,
-      behaviour: null,
-    },
-  })
+  const attendanceData = {
+    hiVisWorn: null,
+    workedIntensively: null,
+    workQuality: null,
+    behaviour: null,
+  }
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -23,12 +23,25 @@ context('Group Session Bulk Update - Log Compliance', () => {
     const project = projectFactory.build()
     cy.wrap(project).as('project')
 
-    const session = sessionFactory.build({ projectCode: project.projectCode })
+    const selectedAppointments = appointmentSummaryFactory.buildList(2)
+    cy.wrap(selectedAppointments).as('selectedAppointments')
+    const unselectedAppointment = appointmentSummaryFactory.build()
+    cy.wrap(unselectedAppointment).as('unselectedAppointment')
+    const session = sessionFactory.build({
+      projectCode: project.projectCode,
+      appointmentSummaries: [...selectedAppointments, unselectedAppointment],
+    })
     cy.wrap(session).as('session')
 
     cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
-    cy.task('stubGetAppointmentForm', form)
+    cy.task(
+      'stubGetAppointmentForm',
+      appointmentOutcomeFormFactory.build({
+        attendanceData,
+        appointments: selectedAppointments.map(appointment => ({ id: appointment.id, deliusVersion: '' })),
+      }),
+    )
   })
 
   // Scenario: sees validation errors with any entered answers when form is not valid
@@ -49,6 +62,18 @@ context('Group Session Bulk Update - Log Compliance', () => {
     page.clickBack()
 
     Page.verifyOnPage(LogHoursPage, this.session)
+  })
+
+  // Scenario: can view and change people selected on the bulk update
+  it('enables navigation back to change selected people', function test() {
+    const page = LogCompliancePage.visitForSession(this.session)
+    page.selectedPeopleCard.shouldShowSelectedPeople(this.selectedAppointments)
+    page.selectedPeopleCard.shouldNotShowPeople([this.unselectedAppointment])
+    cy.task('stubSaveAppointmentForm')
+
+    page.selectedPeopleCard.clickChangeLink()
+
+    Page.verifyOnPage(BulkUpdatePage, this.session)
   })
 
   // Scenario: can complete the form and navigate to the next page

--- a/integration_tests/tests/group-sessions/bulk-update/logHours.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/logHours.cy.ts
@@ -6,6 +6,8 @@ import appointmentOutcomeFormFactory from '../../../../server/testutils/factorie
 import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
 import { contactOutcomeFactory } from '../../../../server/testutils/factories/contactOutcomeFactory'
 import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
+import appointmentSummaryFactory from '../../../../server/testutils/factories/appointmentSummaryFactory'
+import BulkUpdatePage from '../../../pages/appointments/bulkUpdatePage'
 
 context('Group Session Bulk Update - Log Hours', () => {
   beforeEach(() => {
@@ -16,7 +18,14 @@ context('Group Session Bulk Update - Log Hours', () => {
     const project = projectFactory.build()
     cy.wrap(project).as('project')
 
-    const session = sessionFactory.build({ projectCode: project.projectCode })
+    const selectedAppointments = appointmentSummaryFactory.buildList(2)
+    cy.wrap(selectedAppointments).as('selectedAppointments')
+    const unselectedAppointment = appointmentSummaryFactory.build()
+    cy.wrap(unselectedAppointment).as('unselectedAppointment')
+    const session = sessionFactory.build({
+      projectCode: project.projectCode,
+      appointmentSummaries: [...selectedAppointments, unselectedAppointment],
+    })
     cy.wrap(session).as('session')
   })
 
@@ -25,7 +34,10 @@ context('Group Session Bulk Update - Log Hours', () => {
     cy.task('stubFindSession', { session: this.session })
     cy.task(
       'stubGetAppointmentForm',
-      appointmentOutcomeFormFactory.build({ contactOutcome: contactOutcomeFactory.build({ attended: true }) }),
+      appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+        appointments: this.selectedAppointments.map(appointment => ({ id: appointment.id, deliusVersion: '' })),
+      }),
     )
   })
 
@@ -52,6 +64,18 @@ context('Group Session Bulk Update - Log Hours', () => {
     page.clickBack()
 
     Page.verifyOnPage(AttendanceOutcomePage, this.session)
+  })
+
+  // Scenario: can view and change people selected on the bulk update
+  it('enables navigation back to change selected people', function test() {
+    const page = LogCompliancePage.visitForSession(this.session)
+    page.selectedPeopleCard.shouldShowSelectedPeople(this.selectedAppointments)
+    page.selectedPeopleCard.shouldNotShowPeople([this.unselectedAppointment])
+    cy.task('stubSaveAppointmentForm')
+
+    page.selectedPeopleCard.clickChangeLink()
+
+    Page.verifyOnPage(BulkUpdatePage, this.session)
   })
 
   // Scenario: can complete the form and navigate to the next page

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -11,6 +11,7 @@ import {
 import ReferenceDataService from '../../services/referenceDataService'
 
 export type AppointmentUpdatePageViewData = {
+  selectedPeopleCard?: GovUkSummaryList
   heading: { title: string; caption: string }
   backLink: string
   updatePath: string
@@ -169,8 +170,20 @@ export interface LinkItem {
 export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow' | 'green' | 'teal'
 
 export type GovUKValue = { text?: string; html?: string }
+export type GovUkTitleValue = GovUKValue & { headingLevel?: number }
 
 export type GovUKActionItem = { href: string; text: string; visuallyHiddenText: string }
+
+export type GovUkSummaryList = {
+  card?: {
+    title: GovUkTitleValue
+    actions?: {
+      items: Array<GovUKActionItem>
+    }
+  }
+  classes?: string
+  rows: Array<GovUkSummaryListItem>
+}
 
 export type GovUkSummaryListItem = {
   key: GovUKValue

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -299,79 +299,94 @@ describe('AttendanceOutcomePage', () => {
       })
     })
 
-    it('returns view data for a session', () => {
-      const session = sessionFactory.build()
-      const form = appointmentOutcomeFormFactory.build({
-        contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
-      })
-      const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
-
-      jest.spyOn(paths.sessions, 'update')
-      jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
-
-      const page = new AttendanceOutcomePage({
-        query: {} as AttendanceOutcomeBody,
-        appointmentOrSession: session,
-        contactOutcomes,
-      })
-
-      const result = page.viewData(form)
-
-      const expectedItems = [
-        {
-          text: contactOutcomes[0].name,
-          value: contactOutcomes[0].code,
-          checked: false,
+    describe('given a session', () => {
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      const offender = {
+        name: 'Sam Smith',
+        crn: 'CRN123',
+        isLimited: false,
+        details: {
+          description: 'description',
         },
-        {
-          text: contactOutcomes[1].name,
-          value: contactOutcomes[1].code,
-          checked: true,
-        },
-        {
-          text: contactOutcomes[2].name,
-          value: contactOutcomes[2].code,
-          checked: false,
-        },
-      ]
-
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'attendance-outcome',
-      })
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'choose-supervisor',
+      }
+      beforeEach(() => {
+        offenderMock.mockImplementation(() => offender)
       })
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          backLink: pathWithQuery,
-          updatePath: pathWithQuery,
-          ...notesItems,
-          items: expectedItems,
-        }),
-      )
-    })
+      it('returns view data for a session', () => {
+        const session = sessionFactory.build()
+        const form = appointmentOutcomeFormFactory.build({
+          contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
+        })
+        const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
 
-    it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build()
-      const form = appointmentOutcomeFormFactory.build()
-      const notesItems = { notes: 'some note', showIsSensitiveQuestion: false }
-      const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
+        jest.spyOn(paths.sessions, 'update')
+        jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const page = new AttendanceOutcomePage({
-        query: {} as AttendanceOutcomeBody,
-        appointmentOrSession: session,
-        contactOutcomes,
+        const page = new AttendanceOutcomePage({
+          query: {} as AttendanceOutcomeBody,
+          appointmentOrSession: session,
+          contactOutcomes,
+        })
+
+        const result = page.viewData(form)
+
+        const expectedItems = [
+          {
+            text: contactOutcomes[0].name,
+            value: contactOutcomes[0].code,
+            checked: false,
+          },
+          {
+            text: contactOutcomes[1].name,
+            value: contactOutcomes[1].code,
+            checked: true,
+          },
+          {
+            text: contactOutcomes[2].name,
+            value: contactOutcomes[2].code,
+            checked: false,
+          },
+        ]
+
+        expect(paths.sessions.update).toHaveBeenCalledWith({
+          projectCode: session.projectCode,
+          date: session.date,
+          page: 'attendance-outcome',
+        })
+        expect(paths.sessions.update).toHaveBeenCalledWith({
+          projectCode: session.projectCode,
+          date: session.date,
+          page: 'choose-supervisor',
+        })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            backLink: pathWithQuery,
+            updatePath: pathWithQuery,
+            ...notesItems,
+            items: expectedItems,
+          }),
+        )
       })
 
-      const viewData = page.viewData(form)
+      it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {
+        const session = sessionFactory.build()
+        const form = appointmentOutcomeFormFactory.build()
+        const notesItems = { notes: 'some note', showIsSensitiveQuestion: false }
+        const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
-      expect(viewData).toEqual(expect.objectContaining(notesItems))
+        const page = new AttendanceOutcomePage({
+          query: {} as AttendanceOutcomeBody,
+          appointmentOrSession: session,
+          contactOutcomes,
+        })
+
+        const viewData = page.viewData(form)
+
+        expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
+        expect(viewData).toEqual(expect.objectContaining(notesItems))
+      })
     })
 
     describe('items', () => {

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -90,7 +90,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     const isSingleAppointment = this.isSingleAppointment(this.appointmentOrSession)
     const appointment = isSingleAppointment ? (this.appointmentOrSession as AppointmentDto) : undefined
     return {
-      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession }),
+      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession, form }),
       ...NotesUtils.questionItems(this.query, form, appointment, isSingleAppointment),
       items: this.items(form, hasErrors),
     }

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -4,16 +4,31 @@ import { ProjectDto } from '../../@types/shared'
 import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
 import Offender from '../../models/offender'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import SessionUtils from '../../utils/sessionUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
 jest.mock('../../models/offender')
 
 describe('BaseAppointmentUpdatePage', () => {
+  const form = appointmentOutcomeFormFactory.build()
+
+  const offender = {
+    name: 'Sam Smith',
+    crn: 'CRN123',
+    isLimited: false,
+    details: {
+      description: 'Some description',
+    },
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
+    const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+    offenderMock.mockImplementation(() => offender)
   })
 
   describe('next()', () => {
@@ -30,42 +45,69 @@ describe('BaseAppointmentUpdatePage', () => {
     })
   })
 
-  describe('viewData: heading', () => {
-    it('returns heading containing offender details when appointment is provided', () => {
-      const page = new PageWithNextPage({})
-      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-      }
+  describe('viewData', () => {
+    describe('heading', () => {
+      it('returns heading containing offender details when appointment is provided', () => {
+        const page = new PageWithNextPage({})
 
-      offenderMock.mockImplementation(() => offender)
+        const result = page.getCommonViewDataForTest({
+          appointmentOrSession: appointmentFactory.build(),
+          form,
+        })
 
-      const result = page.getCommonViewDataForTest({
-        appointmentOrSession: appointmentFactory.build(),
+        expect(result.heading).toEqual({
+          title: offender.name,
+          caption: offender.crn,
+        })
       })
 
-      expect(result.heading).toEqual({
-        title: offender.name,
-        caption: offender.crn,
+      it('returns heading containing project name and formatted date when session is provided', () => {
+        const page = new PageWithNextPage({})
+        const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
+        const formattedDate = '10 June 2026'
+
+        jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
+
+        const result = page.getCommonViewDataForTest({
+          appointmentOrSession: session,
+          form,
+        })
+
+        expect(result.heading).toEqual({
+          title: `${session.projectName} (${formattedDate})`,
+          caption: 'Bulk update',
+        })
+        expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
       })
     })
+    describe('selectedPeopleCard', () => {
+      it('should be undefined given appointment', () => {
+        const page = new PageWithNextPage({})
 
-    it('returns heading containing project name and formatted date when session is provided', () => {
-      const page = new PageWithNextPage({})
-      const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
-      const formattedDate = '10 June 2026'
+        const result = page.getCommonViewDataForTest({
+          appointmentOrSession: appointmentFactory.build(),
+          form,
+        })
 
-      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
-
-      const result = page.getCommonViewDataForTest({ appointmentOrSession: session })
-
-      expect(result.heading).toEqual({
-        title: `${session.projectName} (${formattedDate})`,
-        caption: 'Bulk update',
+        expect(result.selectedPeopleCard).toBeUndefined()
       })
-      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
+
+      it('should return card given session', () => {
+        const page = new PageWithNextPage({})
+        page.formId = '1'
+        const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
+
+        const selectedPeopleCard = {
+          rows: [{ key: { text: 'person 1' }, value: { text: '09:00 - 13:00' } }],
+        }
+
+        jest.spyOn(SessionUtils, 'selectedPeopleCard').mockReturnValue(selectedPeopleCard)
+
+        const result = page.getCommonViewDataForTest({ appointmentOrSession: session, form })
+
+        expect(result.selectedPeopleCard).toEqual(selectedPeopleCard)
+        expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(session, form.appointments, '1')
+      })
     })
   })
 })
@@ -77,6 +119,7 @@ class PageWithNextPage extends BaseAppointmentUpdatePage {
     appointmentOrSession: AppointmentOrSession
     originalSearch?: Record<string, string>
     project?: ProjectDto
+    form: AppointmentOutcomeForm
   }): AppointmentUpdatePageViewData {
     return this.commonViewData(args)
   }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -100,16 +100,26 @@ export default abstract class BaseAppointmentUpdatePage {
     appointmentOrSession,
     originalSearch,
     project,
+    form,
   }: {
     appointmentOrSession: AppointmentOrSession
     originalSearch?: Record<string, string>
     project?: ProjectDto
+    form: AppointmentOutcomeForm
   }): AppointmentUpdatePageViewData {
     const viewData: AppointmentUpdatePageViewData = {
       backLink: this.backPath(appointmentOrSession, originalSearch, project),
       updatePath: this.updatePath(appointmentOrSession),
       form: this.formId,
       heading: this.buildHeading(appointmentOrSession),
+    }
+
+    if (this.page !== 'confirm-details' && !this.isSingleAppointment(appointmentOrSession)) {
+      viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(
+        appointmentOrSession,
+        form.appointments ?? [],
+        this.formId,
+      )
     }
 
     return viewData

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -71,7 +71,12 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     contactOutcome?: ContactOutcomeDto
   }): ViewData {
     return {
-      ...this.commonViewData({ appointmentOrSession: appointment, originalSearch, project }),
+      ...this.commonViewData({
+        appointmentOrSession: appointment,
+        originalSearch,
+        project,
+        form: {} as AppointmentOutcomeForm,
+      }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
       showContinueButton: !appointment.contactOutcomeCode,

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -10,6 +10,7 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import ChooseSupervisorPage from './chooseSupervisorPage'
 import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
+import Offender from '../../models/offender'
 
 jest.mock('../../models/offender')
 
@@ -119,6 +120,16 @@ describe('ChooseSupervisorPage', () => {
     })
 
     it('should return expected viewData when appointmentOrSession is a session', () => {
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      offenderMock.mockImplementation(() => ({
+        name: 'Sam Smith',
+        crn: 'CRN123',
+        isLimited: false,
+        details: {
+          description: 'description',
+        },
+      }))
+
       const session = sessionFactory.build()
       const teamItems = [
         { text: 'Choose team', value: '' },

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -63,7 +63,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData({ appointmentOrSession }),
+      ...this.commonViewData({ appointmentOrSession, form }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -100,6 +100,7 @@ describe('ConfirmPage', () => {
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
+      expect(result.selectedPeopleCard).toBeUndefined()
     })
 
     describe('alertPractitionerItems', () => {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -45,7 +45,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     this.form = form
 
     return {
-      ...this.commonViewData({ appointmentOrSession }),
+      ...this.commonViewData({ appointmentOrSession, form }),
       submittedItems: this.formItems(form, appointmentOrSession),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -61,7 +61,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
     const formValues = this.getFormDisplayValues(form)
     return {
-      ...this.commonViewData({ appointmentOrSession }),
+      ...this.commonViewData({ appointmentOrSession, form }),
       hiVisItems: GovUkRadioGroup.yesNoItems({
         checkedValue: formValues.hiVis,
       }),

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -137,7 +137,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     const isOutcomeAcceptableAbsenceStoodDown = form.contactOutcome?.code === 'AASD'
 
     const viewData = {
-      ...this.commonViewData({ appointmentOrSession }),
+      ...this.commonViewData({ appointmentOrSession, form }),
       startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
       endTime: form.endTime ? DateTimeFormats.stripTime(form.endTime) : '',
       showPenaltyHours: isAttended,

--- a/server/utils/dateTimeUtils.test.ts
+++ b/server/utils/dateTimeUtils.test.ts
@@ -312,6 +312,39 @@ describe('DateTimeFormats', () => {
     )
   })
 
+  describe('timePeriod', () => {
+    it('returns a formatted time period with HH:MM format', () => {
+      const startTime = '09:00'
+      const endTime = '12:00'
+
+      expect(DateTimeFormats.timePeriod(startTime, endTime)).toEqual('09:00 - 12:00')
+    })
+
+    it('strips seconds from HH:MM:SS format times', () => {
+      const startTime = '09:00:30'
+      const endTime = '12:00:45'
+
+      expect(DateTimeFormats.timePeriod(startTime, endTime)).toEqual('09:00 - 12:00')
+    })
+
+    it.each(['not', '09:00;30', '12:00;45'])(
+      'throws an error if start time is not in a valid format',
+      (startTime: string) => {
+        expect(() => DateTimeFormats.timePeriod(startTime, '12:00')).toThrow(
+          new InvalidDateStringError(`Invalid time: ${startTime}`),
+        )
+      },
+    )
+    it.each(['not', '09:00;30', '12:00;45'])(
+      'throws an error if end time is not in a valid format',
+      (endTime: string) => {
+        expect(() => DateTimeFormats.timePeriod('12:00', endTime)).toThrow(
+          new InvalidDateStringError(`Invalid time: ${endTime}`),
+        )
+      },
+    )
+  })
+
   describe('isValidTime', () => {
     it.each([
       ['234:00', false],

--- a/server/utils/dateTimeUtils.ts
+++ b/server/utils/dateTimeUtils.ts
@@ -231,10 +231,21 @@ export default class DateTimeFormats {
     dateFormatOptions: DateFormatOptions = { format: 'long' },
   ) {
     const formattedDate = DateTimeFormats.isoDateToUIDate(isoDate, dateFormatOptions)
+
+    return `${formattedDate}, ${this.timePeriod(startTime, endTime)}`
+  }
+
+  /**
+   * Returns a sentence containing a time period
+   * @param startTime - a time string in HH:MM or HH:MM:SS format
+   * @param endTime - a time string in HH:MM or HH:MM:SS format
+   * @returns A string
+   */
+  static timePeriod(startTime: string, endTime: string) {
     const formattedStartTime = DateTimeFormats.stripTime(startTime)
     const formattedEndTime = DateTimeFormats.stripTime(endTime)
 
-    return `${formattedDate}, ${formattedStartTime} - ${formattedEndTime}`
+    return `${formattedStartTime} - ${formattedEndTime}`
   }
 
   /**

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -329,6 +329,81 @@ describe('SessionUtils', () => {
     })
   })
 
+  describe('selectedPeopleCard', () => {
+    it('returns a selected people card with two appointment summary rows', () => {
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+
+      offenderMock
+        .mockImplementationOnce(() => {
+          return {
+            details: { description: 'Sam Smith (CRN123)' },
+          }
+        })
+        .mockImplementationOnce(() => {
+          return {
+            details: { description: 'Alex Jones (CRN456)' },
+          }
+        })
+
+      jest
+        .spyOn(DateTimeFormats, 'timePeriod')
+        .mockReturnValueOnce('09:00 - 10:00')
+        .mockReturnValueOnce('10:30 - 11:30')
+
+      const session = sessionFactory.build()
+
+      const [firstAppointment, secondAppointment] = session.appointmentSummaries
+
+      const selectedAppointments = [
+        { id: firstAppointment.id, deliusVersion: '' },
+        { id: secondAppointment.id, deliusVersion: '' },
+      ]
+
+      const formId = '1'
+      const result = SessionUtils.selectedPeopleCard(session, selectedAppointments, formId)
+
+      expect(result).toEqual({
+        card: {
+          title: { text: 'Selected people', headingLevel: 2 },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery(
+                  paths.sessions.bulkUpdate({ projectCode: session.projectCode, date: session.date }),
+                  { form: formId },
+                ),
+                text: 'Change',
+                visuallyHiddenText: 'selected people',
+              },
+            ],
+          },
+        },
+        rows: [
+          {
+            key: { text: 'Sam Smith (CRN123)' },
+            value: { text: '09:00 - 10:00' },
+          },
+          {
+            key: { text: 'Alex Jones (CRN456)' },
+            value: { text: '10:30 - 11:30' },
+          },
+        ],
+        classes: 'govuk-summary-list--no-fixed-width',
+      })
+
+      expect(DateTimeFormats.timePeriod).toHaveBeenNthCalledWith(
+        1,
+        firstAppointment.startTime,
+        firstAppointment.endTime,
+      )
+      expect(DateTimeFormats.timePeriod).toHaveBeenNthCalledWith(
+        2,
+        secondAppointment.startTime,
+        secondAppointment.endTime,
+      )
+    })
+  })
+
   describe('getSessionLink', () => {
     beforeEach(() => {
       jest.spyOn(paths.sessions, 'show')

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -3,7 +3,7 @@ import Offender from '../models/offender'
 import paths from '../paths'
 import DateTimeFormats from './dateTimeUtils'
 import HtmlUtils from './htmlUtils'
-import { GovUKValue } from '../@types/user-defined'
+import { AppointmentOutcomeForm, GovUkSummaryList, GovUKValue } from '../@types/user-defined'
 import { pathWithQuery } from './utils'
 import { GroupSessionIndexPageInput } from '../pages/groupSessionIndexPage'
 
@@ -93,6 +93,43 @@ export default class SessionUtils {
     )
 
     return { html: linkHtml }
+  }
+
+  static selectedPeopleCard(
+    session: SessionDto,
+    selectedAppointments: AppointmentOutcomeForm['appointments'],
+    formId: string,
+  ): GovUkSummaryList {
+    const ids = selectedAppointments.map(appointment => appointment.id)
+    const rows = session.appointmentSummaries
+      .filter(appointment => ids.includes(appointment.id))
+      .map(appointment => {
+        const offender = new Offender(appointment.offender)
+
+        return {
+          key: { text: offender.details.description },
+          value: { text: DateTimeFormats.timePeriod(appointment.startTime, appointment.endTime) },
+        }
+      })
+
+    return {
+      card: {
+        title: { text: 'Selected people', headingLevel: 2 },
+        actions: {
+          items: [
+            {
+              href: pathWithQuery(paths.sessions.bulkUpdate({ date: session.date, projectCode: session.projectCode }), {
+                form: formId,
+              }),
+              text: 'Change',
+              visuallyHiddenText: 'selected people',
+            },
+          ],
+        },
+      },
+      rows,
+      classes: 'govuk-summary-list--no-fixed-width',
+    }
   }
 
   private static getNotEnteredTag() {

--- a/server/views/appointments/update/attendanceOutcome.njk
+++ b/server/views/appointments/update/attendanceOutcome.njk
@@ -7,25 +7,17 @@
 {% block formHeader %}{% endblock %}
 
 {% block formContent %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {{ govukRadios({
-        name: "attendanceOutcome",
-        fieldset: {
-          legend: {
-            text: "Log attendance",
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: items,
-        errorMessage: errors.attendanceOutcome
-      }) }}
-    </div>
-  </div>
+  {{ govukRadios({
+    name: "attendanceOutcome",
+    fieldset: {
+      legend: {
+        text: "Log attendance",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: items,
+    errorMessage: errors.attendanceOutcome
+  }) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {% include "../../partials/notesQuestions.njk" %}
-    </div>
-  </div>
+  {% include "../../partials/notesQuestions.njk" %}
 {% endblock %}

--- a/server/views/appointments/update/chooseSupervisor.njk
+++ b/server/views/appointments/update/chooseSupervisor.njk
@@ -34,20 +34,16 @@
 
 {% block formContent %}
   {% if supervisorItems | length %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <input type="hidden" name="team" value="{{ team }}">
-        {{ govukSelect({
-          label: {
-              text: "Supervising officer",
-              classes: "govuk-label--s"
-          },
-          id: "supervisor",
-          name: "supervisor",
-          items: supervisorItems,
-          errorMessage: errors.supervisor
-        }) }}
-      </div>
-    </div>
+    <input type="hidden" name="team" value="{{ team }}">
+    {{ govukSelect({
+      label: {
+          text: "Supervising officer",
+          classes: "govuk-label--s"
+      },
+      id: "supervisor",
+      name: "supervisor",
+      items: supervisorItems,
+      errorMessage: errors.supervisor
+    }) }}
   {% endif %}
 {% endblock %}

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -50,17 +50,18 @@
     </div>
   {% endblock %}
 
-  {% block beforeForm %}{% endblock %}
 
-  {% block form %}
-  <form id="appointmentForm" action="{{ updatePath }}" method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    <input type="hidden" name="form" value="{{ form }}">
-    {% block formContent %}
-    {% endblock %}
-  </form>
+
   <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
+    <div class="{{ columnWidthClass }}">
+      {% block beforeForm %}{% endblock %}
+      {% block form %}
+      <form id="appointmentForm" action="{{ updatePath }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <input type="hidden" name="form" value="{{ form }}">
+        {% block formContent %}
+        {% endblock %}
+      </form>
         <div class="govuk-button-group">
           {% if showContinue %}
             {{ govukButton({
@@ -75,7 +76,7 @@
           {% block secondaryButton %}
           {% endblock %}
         </div>
-      </div>
+      {% endblock %}
     </div>
-  {% endblock %}
+  </div>
 {% endblock %}

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -1,7 +1,10 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
 {% from "../_appointmentHeader.njk" import appointmentHeader %}
+
 
 {% from "../../showErrorSummary.njk" import showErrorSummary %}
 
@@ -14,6 +17,11 @@
 
 {% if showContinue is not defined %}
   {% set showContinue = true %}
+{% endif %}
+
+{% set columnWidthClass = "govuk-grid-column-full" %}
+{% if selectedPeopleCard %}
+  {% set columnWidthClass = "govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop" %}
 {% endif %}
 
 {% block beforeContent %}
@@ -78,5 +86,10 @@
         </div>
       {% endblock %}
     </div>
+    {% if (selectedPeopleCard) %}
+      <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
+        {{ govukSummaryList(selectedPeopleCard) }}
+      </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/server/views/appointments/update/logCompliance.njk
+++ b/server/views/appointments/update/logCompliance.njk
@@ -5,8 +5,6 @@
 {% set pageTitle = 'Log compliance' %}
 
 {% block formContent %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       {{ govukRadios({
         name: "hiVis",
         fieldset: {
@@ -18,10 +16,6 @@
         items: hiVisItems,
         errorMessage: errors.hiVis
       }) }}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       {{ govukRadios({
         name: "workedIntensively",
         fieldset: {
@@ -33,10 +27,6 @@
         items: workedIntensivelyItems,
         errorMessage: errors.workedIntensively
       }) }}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       {{ govukRadios({
         name: "workQuality",
         fieldset: {
@@ -48,10 +38,6 @@
         items: workQualityItems,
         errorMessage: errors.workQuality
       }) }}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       {{ govukRadios({
         name: "behaviour",
         fieldset: {
@@ -63,6 +49,4 @@
         items: behaviourItems,
         errorMessage: errors.behaviour
       }) }}
-    </div>
-  </div>
 {% endblock %}

--- a/server/views/appointments/update/logHours.njk
+++ b/server/views/appointments/update/logHours.njk
@@ -8,13 +8,7 @@
 {% block formHeader %}{% endblock %}
 
 {% block formContent %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Log start and end time</h1>
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
     {% if isOutcomeAcceptableAbsenceStoodDown %}
       <div class="govuk-form-group">
         <span class="govuk-label govuk-label--s">
@@ -36,11 +30,7 @@
         errorMessage: errors.startTime
       }) }}
     {% endif %}
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
     {% if isOutcomeAcceptableAbsenceStoodDown %}
       <div class="govuk-form-group">
         <span class="govuk-label govuk-label--s">
@@ -62,12 +52,8 @@
         errorMessage: errors.endTime
       }) }}
     {% endif %}
-  </div>
-</div>
 
   {% if showPenaltyHours %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" role="group" aria-describedby="penalty-time-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -110,7 +96,6 @@
             </div>
           </fieldset>
         </div>
-      </div>
-    </div>
+
   {% endif %}
 {% endblock %}

--- a/server/views/appointments/update/logHours.njk
+++ b/server/views/appointments/update/logHours.njk
@@ -8,7 +8,7 @@
 {% block formHeader %}{% endblock %}
 
 {% block formContent %}
-      <h2 class="govuk-heading-m">Log start and end time</h1>
+      <h2 class="govuk-heading-m">Log start and end time</h2>
     {% if isOutcomeAcceptableAbsenceStoodDown %}
       <div class="govuk-form-group">
         <span class="govuk-label govuk-label--s">


### PR DESCRIPTION
## Context

Adds a repeatable widget which lets a user know which people they have selected for bulk update on every step of the form.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- Add selectedPeopleCard view data for session update pages and render it in the shared update layout as a GOV.UK Summary List card.
- Introduce DateTimeFormats.timePeriod() and reuse it for consistent time-range formatting.
- Add a summary list style variation which overrides the fixed width of 30% for the key value in a summary list on large screens.

### Screenshots of UI changes

https://github.com/user-attachments/assets/72ca3170-74f5-4463-b74e-3268ed42c2ea

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ