### PR TITLE
Add small seed data file for group session

### DIFF
--- a/seed_data/seed_data_group.yml
+++ b/seed_data/seed_data_group.yml
@@ -1,0 +1,21 @@
+seed_data:
+  - region: East of England
+    team:
+      name: CPB Automated Test Team
+      provider: East of England
+      supervisor: some supervisor
+      pdu: Northamptonshire
+    projects:
+      - projectName: Clearing Manor House allotment
+        projectType: Group Placement - Regional Project
+        pickupPoint: Chelmsford
+        startTime: 09:00
+        endTime: 16:00
+        allocations:
+          count: 10
+          percentage_with_pickup_specified: 1
+          percentage_that_are_rescheduled: 0
+    course_completions:
+      - Community Campus Test
+      - ETE Automated Test Bucket
+      - CC A Beginners Guide to Microsoft Outlook


### PR DESCRIPTION
## Context

This configuration creates a single group session with a standard set of 10 allocations.

We might want to look into a more convenient way of providing custom seed data.