### PR TITLE
CPB-1026: Style card with right aligned values

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -9,3 +9,11 @@
     }
   }
 }
+
+.govuk-summary-list--float-values-right {
+  .govuk-summary-list__value {
+    @include govuk-media-query($from: tablet) {
+      text-align: right;
+    }
+  }
+}

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -388,7 +388,7 @@ describe('SessionUtils', () => {
             value: { text: '10:30 - 11:30' },
           },
         ],
-        classes: 'govuk-summary-list--no-fixed-width',
+        classes: 'govuk-summary-list--no-fixed-width govuk-summary-list--float-values-right',
       })
 
       expect(DateTimeFormats.timePeriod).toHaveBeenNthCalledWith(

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -128,7 +128,7 @@ export default class SessionUtils {
         },
       },
       rows,
-      classes: 'govuk-summary-list--no-fixed-width',
+      classes: 'govuk-summary-list--no-fixed-width govuk-summary-list--float-values-right',
     }
   }
 


### PR DESCRIPTION
The designs feature right-aligned times, so adding a style variation to implement that on larger screens (the list will reflow on smaller screens).

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

### Screenshots of UI changes

Times are aligned right on small screens:
<img width="1456" height="992" alt="Choose supervisor form page on a desktop device" src="https://github.com/user-attachments/assets/4ad2330d-890c-4ecc-b31a-54df09b194ae" />

Times are aligned left on small screens
<img width="616" height="980" alt="Choose supervisor form page on a mobile device" src="https://github.com/user-attachments/assets/a2a90953-f28e-4281-9cbc-cc81fc2724ec" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ