### PR TITLE
CPB-1026: Fix bulk update nav and add tests

### DIFF
--- a/integration_tests/pages/appointments/bulkUpdatePage.ts
+++ b/integration_tests/pages/appointments/bulkUpdatePage.ts
@@ -16,9 +16,10 @@ export default class BulkUpdatePage extends Page {
   static visitForSession(session: SessionDto, formId?: string): BulkUpdatePage {
     const query = formId ? { form: formId } : undefined
     const path = pathWithQuery(
-      paths.sessions.bulkUpdate({
+      paths.sessions.update({
         projectCode: session.projectCode,
         date: session.date,
+        page: 'select-people',
       }),
       query,
     )

--- a/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
@@ -75,6 +75,16 @@ context('Group Session Bulk Update - Choose Supervisor', () => {
     bulkUpdatePage.shouldShowNotSelectedPeople([this.unselectedAppointment])
   })
 
+  it('navigates back to bulk update page with selected appointments from the form', function test() {
+    const page = ChooseSupervisorPage.visitForSession(this.session)
+
+    page.clickBack()
+
+    const bulkUpdatePage = Page.verifyOnPage(BulkUpdatePage, this.session)
+    bulkUpdatePage.shouldShowSelectedPeople(this.selectedAppointments)
+    bulkUpdatePage.shouldShowNotSelectedPeople([this.unselectedAppointment])
+  })
+
   // Scenario: can complete the form and navigate to the next page
   describe('submit', function describe() {
     it('submits the form and navigates to the next page', function test() {

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -6,14 +6,17 @@ import {
 } from '../../../../server/testutils/factories/contactOutcomeFactory'
 import Offender from '../../../../server/models/offender'
 import projectFactory from '../../../../server/testutils/factories/projectFactory'
+import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import sessionSummaryFactory from '../../../../server/testutils/factories/sessionSummaryFactory'
 import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
 import BulkUpdatePage from '../../../pages/appointments/bulkUpdatePage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
 import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
 import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
+import FindASessionPage from '../../../pages/findASessionPage'
 import Page from '../../../pages/page'
 import ViewSessionPage from '../../../pages/viewSessionPage'
 import attendanceDataFactory from '../../../../server/testutils/factories/attendanceDataFactory'
@@ -158,13 +161,58 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
 
   describe('submit update for 2 appointments', () => {
     it('redirects back to session page with success message', function test() {
-      const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+      const provider = providerSummaryFactory.build()
+      const team = providerTeamSummaryFactory.build()
+      const originalSearch = {
+        provider: provider.code,
+        team: team.code,
+        'startDate-day': '18',
+        'startDate-month': '09',
+        'startDate-year': '2025',
+        'endDate-day': '20',
+        'endDate-month': '09',
+        'endDate-year': '2025',
+      }
+
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+        appointments: this.appointments.map(appointment => ({
+          id: appointment.id,
+          deliusVersion: appointment.version,
+        })),
+        originalSearch,
+      })
+
+      cy.task('stubGetAppointmentForm', form)
+
+      const page = ConfirmDetailsPage.visitForSession(this.session, form)
       cy.task('stubBulkUpdateAppointmentOutcome', { projectCode: this.project.projectCode })
 
       page.clickSubmit('Confirm')
 
       const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
       viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      const sessionSummary = sessionSummaryFactory.build()
+      cy.task('stubGetSessions', {
+        request: {
+          providerCode: provider.code,
+          teamCode: team.code,
+          startDate: '2025-09-18',
+          endDate: '2025-09-20',
+          username: 'some-name',
+        },
+        sessions: {
+          content: [sessionSummary],
+        },
+      })
+
+      viewSessionPage.clickBack()
+
+      const searchPage = Page.verifyOnPage(FindASessionPage)
+      searchPage.shouldShowSearchResults(sessionSummary)
     })
 
     it('with 1 different Delius version => redirects back to session page with 1 error message and success message', function test() {

--- a/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
@@ -65,6 +65,56 @@ context('Group Session Bulk Update - Bulk Update', () => {
       page.shouldShowSelectedPeople(this.selectedAppointments)
       page.shouldShowNotSelectedPeople([this.unselectedAppointment])
     })
+
+    it('can navigate back to session list', function test() {
+      const provider = providerSummaryFactory.build()
+      const team = providerTeamSummaryFactory.build()
+
+      const form = appointmentOutcomeFormFactory.build({
+        originalSearch: {
+          provider: provider.code,
+          team: team.code,
+          'startDate-day': '18',
+          'startDate-month': '09',
+          'startDate-year': '2025',
+          'endDate-day': '20',
+          'endDate-month': '09',
+          'endDate-year': '2025',
+        },
+      })
+
+      const sessionSummary = sessionSummaryFactory.build({
+        projectCode: this.session.projectCode,
+        projectName: this.session.projectName,
+        date: this.session.date,
+      })
+
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      cy.task('stubGetSessions', {
+        request: {
+          providerCode: provider.code,
+          teamCode: team.code,
+          startDate: '2025-09-18',
+          endDate: '2025-09-20',
+          username: 'some-name',
+        },
+        sessions: {
+          content: [sessionSummary],
+        },
+      })
+
+      const page = BulkUpdatePage.visitForSession(this.session, '123')
+      page.clickBack()
+
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
+      viewSessionPage.clickBack()
+
+      const findASessionPage = Page.verifyOnPage(FindASessionPage)
+      findASessionPage.shouldShowPopulatedSearchForm()
+      findASessionPage.shouldShowSearchResults(sessionSummary)
+    })
   })
 
   describe('visit without form query parameter', function describe() {
@@ -101,14 +151,11 @@ context('Group Session Bulk Update - Bulk Update', () => {
       page.shouldShowErrorSummary('appointments', 'Select people with the same outcome')
       page.shouldNotHaveAnySelectedPeople()
     })
-  })
 
-  it('can navigate back to session list', function test() {
-    const provider = providerSummaryFactory.build()
-    const team = providerTeamSummaryFactory.build()
-
-    const form = appointmentOutcomeFormFactory.build({
-      originalSearch: {
+    it('retains original session search results when navigating back', function test() {
+      const provider = providerSummaryFactory.build()
+      const team = providerTeamSummaryFactory.build()
+      const originalSearch = {
         provider: provider.code,
         team: team.code,
         'startDate-day': '18',
@@ -117,39 +164,41 @@ context('Group Session Bulk Update - Bulk Update', () => {
         'endDate-day': '20',
         'endDate-month': '09',
         'endDate-year': '2025',
-      },
+      }
+
+      const sessionSummary = sessionSummaryFactory.build({
+        projectCode: this.session.projectCode,
+        projectName: this.session.projectName,
+        date: this.session.date,
+      })
+
+      cy.task('stubGetProviders', { providers: { providers: [provider] } })
+      cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+      cy.task('stubGetSessions', {
+        request: {
+          providerCode: provider.code,
+          teamCode: team.code,
+          startDate: '2025-09-18',
+          endDate: '2025-09-20',
+          username: 'some-name',
+        },
+        sessions: {
+          content: [sessionSummary],
+        },
+      })
+
+      const sessionPage = ViewSessionPage.visitForSearch(this.session, originalSearch)
+      sessionPage.clickBulkUpdate()
+
+      const selectPeoplePage = Page.verifyOnPage(BulkUpdatePage, this.session)
+      selectPeoplePage.clickBack()
+
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
+      viewSessionPage.clickBack()
+
+      const findASessionPage = Page.verifyOnPage(FindASessionPage)
+      findASessionPage.shouldShowPopulatedSearchForm()
+      findASessionPage.shouldShowSearchResults(sessionSummary)
     })
-
-    const sessionSummary = sessionSummaryFactory.build({
-      projectCode: this.session.projectCode,
-      projectName: this.session.projectName,
-      date: this.session.date,
-    })
-
-    cy.task('stubGetAppointmentForm', form)
-    cy.task('stubGetProviders', { providers: { providers: [provider] } })
-    cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
-    cy.task('stubGetSessions', {
-      request: {
-        providerCode: provider.code,
-        teamCode: team.code,
-        startDate: '2025-09-18',
-        endDate: '2025-09-20',
-        username: 'some-name',
-      },
-      sessions: {
-        content: [sessionSummary],
-      },
-    })
-
-    const page = BulkUpdatePage.visitForSession(this.session, '123')
-    page.clickBack()
-
-    const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
-    viewSessionPage.clickBack()
-
-    const findASessionPage = Page.verifyOnPage(FindASessionPage)
-    findASessionPage.shouldShowPopulatedSearchForm()
-    findASessionPage.shouldShowSearchResults(sessionSummary)
   })
 })

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -66,14 +66,6 @@ const controllers = (services: Services) => {
     services.projectService,
   )
 
-  const updateControllers: Record<AppointmentFormPage, IFormPageController> = {
-    'choose-supervisor': chooseSupervisorController,
-    'attendance-outcome': attendanceOutcomeController,
-    'log-hours': logHoursController,
-    'log-compliance': logComplianceController,
-    'confirm-details': confirmController,
-    'appointment-details': appointmentDetailsController,
-  }
   const bulkUpdateController = new BulkUpdateController(
     services.sessionService,
     services.appointmentFormService,
@@ -81,10 +73,19 @@ const controllers = (services: Services) => {
     services.appointmentService,
   )
 
+  const updateControllers: Record<AppointmentFormPage, IFormPageController> = {
+    'choose-supervisor': chooseSupervisorController,
+    'attendance-outcome': attendanceOutcomeController,
+    'log-hours': logHoursController,
+    'log-compliance': logComplianceController,
+    'confirm-details': confirmController,
+    'appointment-details': appointmentDetailsController,
+    'select-people': bulkUpdateController,
+  }
+
   return {
     updateControllers,
     adjustTravelTimeController,
-    bulkUpdateController,
   }
 }
 

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -287,7 +287,7 @@ describe('SessionsController', () => {
         expect(response.render).toHaveBeenCalledWith(
           'sessions/show',
           expect.objectContaining({
-            bulkUpdatePath: pathWithQuery(paths.sessions.bulkUpdate({ projectCode, date }), query),
+            bulkUpdatePath: pathWithQuery(paths.sessions.update({ projectCode, date, page: 'select-people' }), query),
           }),
         )
       })

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -154,7 +154,7 @@ export default class SessionsController {
         backPath,
         errorList,
         bulkUpdatePath: shouldShowBulkUpdate
-          ? pathWithQuery(paths.sessions.bulkUpdate({ projectCode, date }), query)
+          ? pathWithQuery(paths.sessions.update({ projectCode, date, page: 'select-people' }), query)
           : undefined,
       })
     }

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -96,7 +96,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     return 'choose-supervisor'
   }
 

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -128,7 +128,7 @@ class PageWithNextPage extends BaseAppointmentUpdatePage {
     return 'confirm-details'
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     return 'choose-supervisor'
   }
 
@@ -144,7 +144,7 @@ class PageWithoutNextPage extends BaseAppointmentUpdatePage {
     return undefined
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     return 'choose-supervisor'
   }
 

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -19,7 +19,7 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract nextPage(): AppointmentFormPage | undefined
 
-  protected abstract backPage(): AppointmentFormPage | undefined
+  protected abstract backPage(appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 
@@ -87,7 +87,7 @@ export default abstract class BaseAppointmentUpdatePage {
     originalSearch?: Record<string, string>,
     project?: ProjectDto,
   ) {
-    const backPage = this.backPage()
+    const backPage = this.backPage(appointmentOrSession)
 
     if (!backPage) {
       return this.exitForm(appointmentOrSession, project, originalSearch)

--- a/server/pages/appointments/bulkUpdatePage.test.ts
+++ b/server/pages/appointments/bulkUpdatePage.test.ts
@@ -39,7 +39,7 @@ describe('BulkUpdatePage', () => {
       const result = page.viewData({ formData, session, formId })
 
       const expectedUpdatePath = pathWithQuery(
-        paths.sessions.bulkUpdate({ projectCode: session.projectCode, date: session.date }),
+        paths.sessions.update({ projectCode: session.projectCode, date: session.date, page: 'select-people' }),
         { form: formId },
       )
 

--- a/server/pages/appointments/bulkUpdatePage.ts
+++ b/server/pages/appointments/bulkUpdatePage.ts
@@ -54,7 +54,7 @@ export default class BulkUpdatePage extends PageWithValidation<Body> {
   }
 
   private updatePath(formId: string, session: SessionDto): string {
-    const path = paths.sessions.bulkUpdate({ projectCode: session.projectCode, date: session.date })
+    const path = paths.sessions.update({ projectCode: session.projectCode, date: session.date, page: 'select-people' })
     return this.pathWithFormId(path, formId)
   }
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,5 +1,6 @@
 import { AppointmentDto, ContactOutcomeDto, ProjectDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
+  AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
@@ -217,7 +218,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return GovUKComponentUtils.buildSummaryListItems(items, true)
   }
 
-  protected backPage(): AppointmentFormPage | undefined {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined {
     return undefined
   }
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -155,7 +155,7 @@ describe('ChooseSupervisorPage', () => {
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,
         date: session.date,
-        page: 'appointment-details',
+        page: 'select-people',
       })
 
       expect(result).toEqual(

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -82,8 +82,11 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  protected backPage(): AppointmentFormPage {
-    return 'appointment-details'
+  protected backPage(appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
+    if (this.isSingleAppointment(appointmentOrSession)) {
+      return 'appointment-details'
+    }
+    return 'select-people'
   }
 
   protected nextPage(): AppointmentFormPage {

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -578,7 +578,7 @@ describe('ConfirmPage', () => {
                 {
                   href: pathWithQuery,
                   text: 'Change',
-                  visuallyHiddenText: 'penalty hours',
+                  visuallyHiddenText: 'people',
                 },
               ],
             },

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -73,7 +73,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return undefined
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     if (this.form && this.form.contactOutcome?.attended) {
       return 'log-compliance'
     }

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -257,7 +257,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
             {
               href: this.changePath(appointmentOrSession, 'select-people'),
               text: 'Change',
-              visuallyHiddenText: 'penalty hours',
+              visuallyHiddenText: 'people',
             },
           ],
         },

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -255,12 +255,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.pathWithFormId(
-                paths.sessions.bulkUpdate({
-                  projectCode: appointmentOrSession.projectCode,
-                  date: appointmentOrSession.date,
-                }),
-              ),
+              href: this.changePath(appointmentOrSession, 'select-people'),
               text: 'Change',
               visuallyHiddenText: 'penalty hours',
             },

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -93,7 +93,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     this.hasError = Object.keys(this.validationErrors).length > 0
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     return 'log-hours'
   }
 

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -169,7 +169,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     return viewData
   }
 
-  protected backPage(): AppointmentFormPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
     return 'attendance-outcome'
   }
 

--- a/server/pages/appointments/pathMap.ts
+++ b/server/pages/appointments/pathMap.ts
@@ -4,4 +4,6 @@ export type AppointmentFormPage =
   | 'log-hours'
   | 'log-compliance'
   | 'confirm-details'
+  // Keeping these in the same type because it's easier to add route guards than type checks
   | 'appointment-details'
+  | 'select-people'

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -25,7 +25,6 @@ const paths = {
     search: sessionsPath.path('search'),
     show: singleSessionPath,
     update: singleSessionPath.path('update/:page'),
-    bulkUpdate: singleSessionPath.path('update'),
   },
   courseCompletions: {
     index: courseCompletionsPath,

--- a/server/routes/appointment.ts
+++ b/server/routes/appointment.ts
@@ -14,7 +14,8 @@ export default function appointmentRoutes(controllers: Controllers, router: Rout
     const page = req.params.page as AppointmentFormPage
     const controller = updateControllers[page]
 
-    if (!controller) {
+    // 'select-people' is only valid for session bulk update, not single appointments
+    if (!controller || page === 'select-people') {
       return next()
     }
 
@@ -26,7 +27,8 @@ export default function appointmentRoutes(controllers: Controllers, router: Rout
     const page = req.params.page as AppointmentFormPage
     const controller = updateControllers[page]
 
-    if (!controller) {
+    // 'select-people' is only valid for session bulk update, not single appointments
+    if (!controller || page === 'select-people') {
       return next()
     }
 

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -13,14 +13,6 @@ export default function sessionRoutes(controllers: Controllers, router: Router):
   get('/sessions/search', sessionsController.search(), { auditEvent: Page.VIEW_SESSIONS })
   get(paths.sessions.show.pattern, sessionsController.show())
 
-  get(paths.sessions.bulkUpdate.pattern, appointments.bulkUpdateController.show(), {
-    auditEvent: Page.VIEW_SESSIONS_BULK_UPDATE_SELECT,
-  })
-
-  post(paths.sessions.bulkUpdate.pattern, appointments.bulkUpdateController.submit(), {
-    auditEvent: Page.SUBMIT_SESSIONS_BULK_UPDATE_SELECT,
-  })
-
   get(paths.sessions.update.pattern, async (req, res, next) => {
     const page = req.params.page as AppointmentFormPage
     const controller = appointments.updateControllers[page]

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -369,7 +369,11 @@ describe('SessionUtils', () => {
             items: [
               {
                 href: pathWithQuery(
-                  paths.sessions.bulkUpdate({ projectCode: session.projectCode, date: session.date }),
+                  paths.sessions.update({
+                    projectCode: session.projectCode,
+                    date: session.date,
+                    page: 'select-people',
+                  }),
                   { form: formId },
                 ),
                 text: 'Change',

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -118,9 +118,12 @@ export default class SessionUtils {
         actions: {
           items: [
             {
-              href: pathWithQuery(paths.sessions.bulkUpdate({ date: session.date, projectCode: session.projectCode }), {
-                form: formId,
-              }),
+              href: pathWithQuery(
+                paths.sessions.update({ date: session.date, projectCode: session.projectCode, page: 'select-people' }),
+                {
+                  form: formId,
+                },
+              ),
               text: 'Change',
               visuallyHiddenText: 'selected people',
             },


### PR DESCRIPTION
## Context

This fixes the back navigation from choose a supervisor page to the select people page, for a bulk update journey.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- In order to simplify this change, including the bulk update page in the Union Type `AppointmentFormPage`. As the `appointment-details` and `select-people` types do not apply to bulk updates and single appointment updates respectively, I have added route guards for these pages on the respective routers.

### Screenshots of UI changes


https://github.com/user-attachments/assets/a55be194-73d7-41a9-a22d-23d644638016

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ