### PR TITLE
CPB-1026: Reorganise notes view data and template

### DIFF
--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -249,8 +249,8 @@ export interface SummaryCard {
 
 export type ViewDataWithNotes = {
   notes?: string
+  notesHint?: GovUKValue
   isSensitiveItems?: Array<GovUkRadioOrCheckboxOption>
-  showIsSensitiveQuestion: boolean
 }
 
 export type ViewDataWithTimeToCredit = {

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -58,9 +58,7 @@ describe('OutcomeController', () => {
     )
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue({})
-    jest
-      .spyOn(NotesUtils, 'questionItems')
-      .mockReturnValue({ notes: undefined, isSensitiveItems: [], showIsSensitiveQuestion: false })
+    jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: undefined, isSensitiveItems: [] })
     jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue([])
     jest.spyOn(CourseCompletionUtils, 'formattedCourseDetails').mockReturnValue(courseDetailsItems)
 
@@ -97,7 +95,6 @@ describe('OutcomeController', () => {
         dateItems: [],
         notes: undefined,
         isSensitiveItems: [],
-        showIsSensitiveQuestion: false,
         courseDetailsItems,
         requirementDetailsItems,
         courseCompletion,
@@ -250,7 +247,6 @@ describe('OutcomeController', () => {
         notes: undefined,
         courseDetailsItems,
         requirementDetailsItems,
-        showIsSensitiveQuestion: false,
         courseCompletion,
         completionDetailsRows: mockCompletionDetailsRow,
       })

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -99,13 +99,13 @@ describe('NotesUtils', () => {
     })
 
     describe('with appointment parameter', () => {
-      it('should return only showIsSensitiveQuestion false when appointment is sensitive', () => {
+      it('should return notes hint and no sensitive items when appointment is sensitive', () => {
         const form = courseCompletionFormFactory.build()
         const appointment = appointmentFactory.build({ sensitive: true })
 
         const result = NotesUtils.questionItems({}, form, appointment)
 
-        expect(result.showIsSensitiveQuestion).toBe(false)
+        expect(result.notesHint).toEqual({ text: NotesUtils.sensitiveValueAutomatedHint })
         expect(result.isSensitiveItems).toBeUndefined()
       })
 
@@ -116,7 +116,7 @@ describe('NotesUtils', () => {
 
         const result = NotesUtils.questionItems(query, form, appointment)
 
-        expect(result.showIsSensitiveQuestion).toBe(true)
+        expect(result.notesHint).toBeUndefined()
         expect(result.isSensitiveItems).toEqual([
           { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
           { checked: true, text: 'No, they are not sensitive', value: 'no' },
@@ -130,7 +130,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, appointment, true)
 
-          expect(result.showIsSensitiveQuestion).toBe(true)
+          expect(result.notesHint).toBeUndefined()
           expect(result.isSensitiveItems).toEqual([
             { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
             { checked: false, text: 'No, they are not sensitive', value: 'no' },
@@ -143,7 +143,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, appointment, false)
 
-          expect(result.showIsSensitiveQuestion).toBe(false)
+          expect(result.notesHint).toBeUndefined()
           expect(result.isSensitiveItems).toBeUndefined()
         })
 
@@ -152,7 +152,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, undefined, true)
 
-          expect(result.showIsSensitiveQuestion).toBe(true)
+          expect(result.notesHint).toBeUndefined()
           expect(result.isSensitiveItems).toEqual([
             { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
             { checked: false, text: 'No, they are not sensitive', value: 'no' },

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -4,6 +4,9 @@ import GovUkRadioGroup from '../forms/GovUkRadioGroup'
 import { properCase } from './utils'
 
 export default class NotesUtils {
+  static sensitiveValueAutomatedHint =
+    'This note will be automatically marked sensitive as an earlier note was already flagged.'
+
   static formData(query: BodyWithNotes): BodyWithNotes {
     return { notes: query.notes, isSensitive: query.isSensitive }
   }
@@ -93,7 +96,13 @@ export default class NotesUtils {
     includeIsSensitiveQuestion: boolean = true,
   ): ViewDataWithNotes {
     const notes = query.notes ?? form.notes
-    const showIsSensitiveQuestion = includeIsSensitiveQuestion ? appointment?.sensitive !== true : false
+
+    if (!includeIsSensitiveQuestion) {
+      return {
+        notes,
+      }
+    }
+    const showIsSensitiveQuestion = appointment?.sensitive !== true
 
     if (showIsSensitiveQuestion) {
       const sensitive =
@@ -101,14 +110,13 @@ export default class NotesUtils {
 
       return {
         notes,
-        showIsSensitiveQuestion,
         isSensitiveItems: this.isSensitiveItems(sensitive),
       }
     }
 
     return {
       notes,
-      showIsSensitiveQuestion,
+      notesHint: { text: NotesUtils.sensitiveValueAutomatedHint },
     }
   }
 

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -1,13 +1,6 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% if not showIsSensitiveQuestion %}
- {% set notesHint = {
-      text: 'This note will be automatically marked sensitive as an earlier note was already flagged.'
-    }
-  %}
-{% endif %}
-
 {{ govukTextarea({
   name: "notes",
   id: "notes",
@@ -20,7 +13,7 @@
     isPageHeading: false
   }
 }) }}
-{% if showIsSensitiveQuestion %}
+{% if isSensitiveItems | length %}
   {{ govukRadios({
     name: 'isSensitive',
     fieldset: {


### PR DESCRIPTION
## Context

Fixes an issue whereby a hint message explain the automatic calculation of `sensitive` value was still being shown for bulk updates. Also reorganises and simplifies the notes view data and template.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)
### Screenshots of UI changes

The is sensitive question is hidden for bulk updates, and no hint text is shown:
<img width="2422" height="3176" alt="Screenshot 2026-06-18 at 14 27 01" src="https://github.com/user-attachments/assets/60a627d4-a18a-4373-9d3f-c410465c4e6f" />

The is sensitive question is hidden for appointments with an existing sensitive value of 'Yes', and hint text is shown to explain this: 
<img width="3594" height="3256" alt="Screenshot 2026-06-18 at 14 29 03" src="https://github.com/user-attachments/assets/fa53a3f5-b2a0-40d2-9784-7a7bcdd63ae7" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ