### PR TITLE
CPB-1068 Use course completion history endpoint

### DIFF
--- a/integration_tests/mockApis/courseCompletions.ts
+++ b/integration_tests/mockApis/courseCompletions.ts
@@ -116,4 +116,25 @@ export default {
       },
     })
   },
+
+  stubGetCourseCompletionHistory: ({
+    id,
+    courseCompletions,
+  }: {
+    id: string
+    courseCompletions: EteCourseCompletionEventDto[]
+  }): SuperAgentRequest => {
+    const urlPath = paths.courseCompletions.history({ id })
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: courseCompletions,
+      },
+    })
+  },
 }

--- a/integration_tests/tests/courseCompletions/process/appointment.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/appointment.cy.ts
@@ -38,7 +38,6 @@ import caseDetailsSummaryFactory from '../../../../server/testutils/factories/ca
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
 import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
-import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import pagedModelProjectOutcomeSummaryFactory from '../../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import AppointmentPage from '../../../pages/courseCompletions/process/appointmentPage'
@@ -52,9 +51,6 @@ context('Appointment Page', () => {
   const appointmentSummary = appointmentSummaryFactory.build()
   const pagedAppointments = pagedModelAppointmentSummaryFactory.build({
     content: [appointmentSummary],
-  })
-  const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-    content: [courseCompletion],
   })
   const caseDetailsSummary = caseDetailsSummaryFactory.build()
 
@@ -79,13 +75,9 @@ context('Appointment Page', () => {
     cy.task('stubGetOffenderSummary', {
       caseDetailsSummary,
     })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponse,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
   })
 

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -142,16 +142,9 @@ context('Confirm details page', () => {
     })
     cy.task('stubGetAppointments', { request, pagedAppointments })
     cy.task('stubFindAppointment', { appointment })
-    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletion],
-    })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponse,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
   })
 

--- a/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmPerson.cy.ts
@@ -120,6 +120,10 @@ context('Person Page', () => {
       },
       courseCompletions: courseCompletionResponse,
     })
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
+    })
     page.clickBack()
 
     // Then I should see the course completion details page
@@ -173,6 +177,10 @@ context('Person Page', () => {
         username: 'some-name',
       },
       courseCompletions: courseCompletionResponse,
+    })
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
 
     //  Given I am on the page

--- a/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/enterACrn.cy.ts
@@ -117,19 +117,12 @@ context('Crn Page', () => {
   it('navigates back', () => {
     //  Given I am on the form page
     const page = CrnPage.visit(courseCompletion, '12')
-    const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletion],
-    })
 
     cy.task('stubSaveCourseCompletionForm', { ...form, crn: offender.crn })
     cy.task('stubGetCourseCompletionForm', { ...form, crn: offender.crn })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponse,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
 
     //  When I click back
@@ -161,6 +154,10 @@ context('Crn Page', () => {
         username: 'some-name',
       },
       courseCompletions: courseCompletionResponse,
+    })
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
     page.clickBack()
 

--- a/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
@@ -29,7 +29,6 @@ import courseCompletionFactory from '../../../../server/testutils/factories/cour
 import courseCompletionFormFactory from '../../../../server/testutils/factories/courseCompletionFormFactory'
 import offenderFullFactory from '../../../../server/testutils/factories/offenderFullFactory'
 import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
-import pagedModelCourseCompletionEventFactory from '../../../../server/testutils/factories/pagedModelCourseCompletionEventFactory'
 import pagedModelProjectOutcomeSummaryFactory from '../../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import unpaidWorkDetailsFactory from '../../../../server/testutils/factories/unpaidWorkDetailsFactory'
@@ -62,10 +61,6 @@ context('Outcome Page', () => {
     crn: caseDetailsSummary.offender.crn,
   })
 
-  const courseCompletionResponse = pagedModelCourseCompletionEventFactory.build({
-    content: [courseCompletion],
-  })
-
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -82,13 +77,9 @@ context('Outcome Page', () => {
       projectCode: courseCompletionForm.project,
       id: courseCompletionForm.appointmentIdToUpdate,
     })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponse,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
 
     cy.task('stubFindAppointment', { appointment })

--- a/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/unableToCreditTime.cy.ts
@@ -44,7 +44,6 @@ context('Unable to credit time', () => {
   const offender = offenderFullFactory.build()
   const caseDetailsSummary = caseDetailsSummaryFactory.build({ offender })
   const form = courseCompletionFormFactory.build({ crn: offender.crn })
-  const courseCompletionsResponse = pagedModelCourseCompletionEventFactory.build({ content: [courseCompletion] })
 
   beforeEach(() => {
     cy.task('reset')
@@ -54,14 +53,6 @@ context('Unable to credit time', () => {
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubSaveCourseCompletionForm', courseCompletionFormFactory.build())
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionsResponse,
-    })
   })
 
   // Scenario: Submitting the form
@@ -119,6 +110,10 @@ context('Unable to credit time', () => {
   it('navigates back', () => {
     const recommendedSelection = courseCompletionRecommendationFactory.build({ crn: null })
     cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
+    })
     //  Given I am on the form page
     const page = UnableToCreditTimePage.visit(courseCompletion)
 

--- a/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
+++ b/integration_tests/tests/courseCompletions/searchCourseCompletions.cy.ts
@@ -304,6 +304,10 @@ context('Search course completions', () => {
       },
       courseCompletions: courseCompletionResponse,
     })
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
+    })
 
     page.submitForm()
 

--- a/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
+++ b/integration_tests/tests/courseCompletions/viewACourseCompletion.cy.ts
@@ -56,13 +56,9 @@ context('Project page', () => {
     cy.task('stubGetCourseCompletionForm', form)
     cy.task('stubFindCourseCompletion', { courseCompletion })
     cy.task('stubGetRecommendedSelection', { id: courseCompletion.id, recommendedSelection })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponse,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletion.id,
+      courseCompletions: [courseCompletion],
     })
   })
 
@@ -82,19 +78,12 @@ context('Project page', () => {
   it('shows completion details for a pass on third attempt', () => {
     // Given the course completion is a pass on the third attempt
     const courseCompletionPass = courseCompletionFactory.build({ status: 'Passed', attempts: 3 })
-    const courseCompletionResponseWithPass = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletionPass],
-    })
 
     cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionPass })
     cy.task('stubGetRecommendedSelection', { id: courseCompletionPass.id, recommendedSelection })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletionPass.pdu.providerCode,
-        pduId: courseCompletionPass.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponseWithPass,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletionPass.id,
+      courseCompletions: [courseCompletionPass],
     })
 
     // When I visit the course completion page
@@ -109,19 +98,12 @@ context('Project page', () => {
   it('shows completion details for a pass on second attempt', () => {
     // Given the course completion is a pass on the second attempt
     const courseCompletionPass = courseCompletionFactory.build({ status: 'Passed', attempts: 2 })
-    const courseCompletionResponseWithPass = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletionPass],
-    })
 
     cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionPass })
     cy.task('stubGetRecommendedSelection', { id: courseCompletionPass.id, recommendedSelection })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletionPass.pdu.providerCode,
-        pduId: courseCompletionPass.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponseWithPass,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletionPass.id,
+      courseCompletions: [courseCompletionPass],
     })
 
     // When I visit the course completion page
@@ -135,19 +117,12 @@ context('Project page', () => {
   it('shows completion details for a fail', () => {
     // Given the course completion is a fail on the third attempt
     const courseCompletionFail = courseCompletionFactory.build({ status: 'Failed', attempts: 3 })
-    const courseCompletionResponseWithFail = pagedModelCourseCompletionEventFactory.build({
-      content: [courseCompletionFail],
-    })
 
     cy.task('stubFindCourseCompletion', { courseCompletion: courseCompletionFail })
     cy.task('stubGetRecommendedSelection', { id: courseCompletionFail.id, recommendedSelection })
-    cy.task('stubGetCourseCompletions', {
-      request: {
-        providerCode: courseCompletionFail.pdu.providerCode,
-        pduId: courseCompletionFail.pdu.id,
-        username: 'some-name',
-      },
-      courseCompletions: courseCompletionResponseWithFail,
+    cy.task('stubGetCourseCompletionHistory', {
+      id: courseCompletionFail.id,
+      courseCompletions: [courseCompletionFail],
     })
 
     // When I visit the course completion page

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -123,6 +123,10 @@ export interface GetCourseCompletionsParams extends BaseRequest, PagedRequest, G
   sortDirection: SortDirection
 }
 
+export interface GetCourseCompletionHistoryParams extends GetCourseCompletionRequest {
+  blockSize?: number
+}
+
 export interface AppointmentRequest extends BaseRequest {
   appointmentId: string
   projectCode: string

--- a/server/controllers/courseCompletions/index.ts
+++ b/server/controllers/courseCompletions/index.ts
@@ -71,25 +71,9 @@ export default class CourseCompletionsController {
       )
       const total = DateTimeFormats.totalMinutesToHoursAndMinutesParts(courseCompletion.totalTimeMinutes)
 
-      const { sortBy, sortDirection } = getPaginationRequestParams<CourseCompletionSortField>(
-        req,
-        paths.courseCompletions.search({}),
-        {
-          provider: courseCompletion.provider,
-          pdu: courseCompletion.pdu,
-        },
-        courseCompletionSortFields,
-      )
-
-      const courseCompletions = await this.courseCompletionService.searchCourseCompletions({
+      const courseCompletions = await this.courseCompletionService.getHistory({
         username: res.locals.user.username,
-        providerCode: courseCompletion.pdu.providerCode,
-        pduId: courseCompletion.pdu.id,
-        sortBy,
-        sortDirection,
-        resolutionStatus: 'Unresolved',
-        showCourseFailures: 'Yes',
-        externalReference: courseCompletion.externalReference,
+        id: courseCompletion.id,
       })
 
       res.render('courseCompletions/show', {
@@ -104,7 +88,7 @@ export default class CourseCompletionsController {
         },
         completionDetailsRows: CourseCompletionUtils.completionDetailsRows({
           courseCompletion,
-          allCourseCompletions: courseCompletions.content,
+          allCourseCompletions: courseCompletions,
         }),
         backLink: this.indexLink(req.query as CourseCompletionPageInput),
         processLink: pathWithQuery(

--- a/server/controllers/courseCompletions/process/outcomeController.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.ts
@@ -4,7 +4,6 @@ import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
 import GovukFrontendDateInput, { GovUkFrontendDateInputItem } from '../../../forms/GovukFrontendDateInput'
 import {
-  CourseCompletionSortField,
   GovUkSummaryListItem,
   ValidationErrors,
   ViewDataWithNotes,
@@ -15,8 +14,6 @@ import { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import OffenderService from '../../../services/offenderService'
 import NotesUtils from '../../../utils/notesUtils'
 import AppointmentService from '../../../services/appointmentService'
-import paths from '../../../paths'
-import { getPaginationRequestParams } from '../../../utils/paginationUtils'
 import { EteCourseCompletionEventDto } from '../../../@types/shared'
 
 type ViewData = {
@@ -72,20 +69,9 @@ export default class OutcomeController extends BaseController<OutcomePage> {
       crn: formData.crn,
     })
 
-    const { sortBy, sortDirection } = getPaginationRequestParams<CourseCompletionSortField>(
-      req,
-      paths.courseCompletions.search({}),
-    )
-
-    const courseCompletions = await this.courseCompletionService.searchCourseCompletions({
+    const courseCompletions = await this.courseCompletionService.getHistory({
       username: res.locals.user.username,
-      providerCode: courseCompletion.pdu.providerCode,
-      pduId: courseCompletion.pdu.id,
-      sortBy,
-      sortDirection,
-      resolutionStatus: 'Unresolved',
-      showCourseFailures: 'Yes',
-      externalReference: courseCompletion.externalReference,
+      id: courseCompletion.id,
     })
 
     const requirementDetailsItems = this.page.requirementDetailsItems(unpaidWorkDetails, formData.deliusEventNumber)
@@ -98,7 +84,7 @@ export default class OutcomeController extends BaseController<OutcomePage> {
       requirementDetailsItems,
       completionDetailsRows: CourseCompletionUtils.completionDetailsRows({
         courseCompletion,
-        allCourseCompletions: courseCompletions.content,
+        allCourseCompletions: courseCompletions,
       }),
       courseCompletion,
     }

--- a/server/data/courseCompletionClient.test.ts
+++ b/server/data/courseCompletionClient.test.ts
@@ -8,6 +8,7 @@ import courseCompletionRecommendationFactory from '../testutils/factories/course
 import courseCompletionResolutionFactory from '../testutils/factories/courseCompletionResolutionFactory'
 import pagedModelCourseCompletionEventFactory from '../testutils/factories/pagedModelCourseCompletionEventFactory'
 import { CourseCompletionResolutionStatus } from '../@types/user-defined'
+import courseCompletionHistoryFactory from '../testutils/factories/courseCompletionHistoryFactory'
 
 describe('CourseCompletionClient', () => {
   let courseCompletionClient: CourseCompletionClient
@@ -106,6 +107,26 @@ describe('CourseCompletionClient', () => {
       const response = await courseCompletionClient.getRecommendedSelection({ username: 'some-username', id })
 
       expect(response).toEqual(recommendedSelection)
+    })
+  })
+
+  describe('getHistory', () => {
+    it('should make a GET request to the history path using user token and return the response body', async () => {
+      const id = '1'
+      const blockSize = 3
+      const courseCompletionHistory = courseCompletionHistoryFactory.build()
+
+      nock(config.apis.communityPaybackApi.url)
+        .get(paths.courseCompletions.history({ id }))
+        .query({
+          blockSize,
+        })
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200, courseCompletionHistory)
+
+      const response = await courseCompletionClient.getHistory({ username: 'some-username', id, blockSize })
+
+      expect(response).toEqual(courseCompletionHistory)
     })
   })
 })

--- a/server/data/courseCompletionClient.ts
+++ b/server/data/courseCompletionClient.ts
@@ -9,7 +9,11 @@ import {
   EteCourseCompletionEventDto,
   PagedModelEteCourseCompletionEventDto,
 } from '../@types/shared'
-import { GetCourseCompletionRequest, GetCourseCompletionsRequest } from '../@types/user-defined'
+import {
+  GetCourseCompletionHistoryParams,
+  GetCourseCompletionRequest,
+  GetCourseCompletionsRequest,
+} from '../@types/user-defined'
 import { createQueryString } from '../utils/utils'
 import idempotencyKey from '../utils/restClientUtils'
 
@@ -45,5 +49,16 @@ export default class CourseCompletionClient extends RestClient {
   }: GetCourseCompletionRequest): Promise<CourseCompletionRecommendationDto> {
     const path = paths.courseCompletions.recommendedSelection({ id })
     return (await this.get({ path }, asSystem(username))) as CourseCompletionRecommendationDto
+  }
+
+  async getHistory({
+    username,
+    id,
+    blockSize = 3,
+  }: GetCourseCompletionHistoryParams): Promise<EteCourseCompletionEventDto[]> {
+    const path = paths.courseCompletions.history({ id })
+    const query = createQueryString({ blockSize })
+
+    return (await this.get({ path, query }, asSystem(username))) as EteCourseCompletionEventDto[]
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -42,6 +42,7 @@ export default {
     save: singleCourseCompletionPath.path('resolution'),
     filter: providersPath.path(':providerCode/course-completions'),
     recommendedSelection: singleCourseCompletionPath.path('recommended-selection'),
+    history: singleCourseCompletionPath.path('history-block'),
   },
   referenceData: {
     projectTypes: referenceDataPath.path('project-types'),

--- a/server/services/courseCompletionService.test.ts
+++ b/server/services/courseCompletionService.test.ts
@@ -1,5 +1,6 @@
 import CourseCompletionClient from '../data/courseCompletionClient'
 import courseCompletionFactory from '../testutils/factories/courseCompletionFactory'
+import courseCompletionHistoryFactory from '../testutils/factories/courseCompletionHistoryFactory'
 import courseCompletionRecommendationFactory from '../testutils/factories/courseCompletionRecommendationFactory'
 import courseCompletionResolutionFactory from '../testutils/factories/courseCompletionResolutionFactory'
 import pagedModelCourseCompletionEventFactory from '../testutils/factories/pagedModelCourseCompletionEventFactory'
@@ -135,5 +136,24 @@ describe('CourseCompletionService', () => {
       username: 'some-username',
     })
     expect(result).toEqual(recommendation)
+  })
+
+  it('should call getHistory on the api client and return its result', async () => {
+    const history = courseCompletionHistoryFactory.build()
+
+    courseCompletionClient.getHistory.mockResolvedValue(history)
+
+    const result = await courseCompletionService.getHistory({
+      id: 'abc-123',
+      username: 'some-username',
+      blockSize: 3,
+    })
+
+    expect(courseCompletionClient.getHistory).toHaveBeenCalledWith({
+      id: 'abc-123',
+      username: 'some-username',
+      blockSize: 3,
+    })
+    expect(result).toEqual(history)
   })
 })

--- a/server/services/courseCompletionService.ts
+++ b/server/services/courseCompletionService.ts
@@ -4,7 +4,11 @@ import {
   EteCourseCompletionEventDto,
   PagedModelEteCourseCompletionEventDto,
 } from '../@types/shared'
-import { GetCourseCompletionRequest, GetCourseCompletionsParams } from '../@types/user-defined'
+import {
+  GetCourseCompletionHistoryParams,
+  GetCourseCompletionRequest,
+  GetCourseCompletionsParams,
+} from '../@types/user-defined'
 import CourseCompletionClient from '../data/courseCompletionClient'
 import { PAGE_SIZE, apiPageNumber, uiPageNumber } from '../utils/paginationUtils'
 
@@ -43,5 +47,9 @@ export default class CourseCompletionService {
 
   async getRecommendedSelection(details: GetCourseCompletionRequest): Promise<CourseCompletionRecommendationDto> {
     return this.courseCourseCompletionClient.getRecommendedSelection(details)
+  }
+
+  async getHistory(request: GetCourseCompletionHistoryParams): Promise<EteCourseCompletionEventDto[]> {
+    return this.courseCourseCompletionClient.getHistory(request)
   }
 }

--- a/server/testutils/factories/courseCompletionHistoryFactory.ts
+++ b/server/testutils/factories/courseCompletionHistoryFactory.ts
@@ -1,0 +1,5 @@
+import { Factory } from 'fishery'
+import { EteCourseCompletionEventDto } from '../../@types/shared'
+import courseCompletionFactory from './courseCompletionFactory'
+
+export default Factory.define<EteCourseCompletionEventDto[]>(() => courseCompletionFactory.buildList(3))


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1068?atlOrigin=eyJpIjoiZGI1ZTE0YWU2MzdkNDBjNWI4MTRiZGZlYTZkMzc0MzMiLCJwIjoiaiJ9)

## Context
We recently discovered that course completion attempts can be set to more than `3` leading to issues when displaying previous course attempts. We've now created a new endpoint which batches the attempts in 3s. Use this new endpoint on the course completion and record outcome pages.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
