### PR TITLE
CPB-1068: Update `completionDetailsRows` logic to group attempts into blocks and adjust test cases accordingly

### DIFF
--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -102,13 +102,14 @@ describe('CourseCompletionUtils', () => {
 
   describe('completionDetails', () => {
     it.each([['Failed' as const], ['Passed' as const]])('returns row with completion details for %s', status => {
-      const courseCompletion = courseCompletionFactory.build({ status })
-      const [row] = CourseCompletionUtils.completionDetailsRows({
+      const courseCompletion = courseCompletionFactory.build({ status, attempts: 1 })
+      const rows = CourseCompletionUtils.completionDetailsRows({
         courseCompletion,
         allCourseCompletions: [courseCompletion],
       })
+      const row = rows.find(r => (r.key as { text: string }).text === `Attempt ${courseCompletion.attempts}`)
 
-      expect((row.key as { text: string }).text).toEqual(`Attempt ${courseCompletion.attempts}`)
+      expect(row).toBeDefined()
       expect((row.value as { html: string }).html).toContain(
         DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(courseCompletion.totalTimeMinutes),
       )
@@ -373,6 +374,95 @@ describe('CourseCompletionUtils', () => {
           expect(courseCompletionRows[2].value.html).toContain(
             CourseCompletionUtils.formattedCourseCompletionLabel('Failed'),
           )
+        })
+      })
+
+      describe('when attempts are in the second block (4-6)', () => {
+        it('returns rows for attempt 4 and hides future attempts in the block', () => {
+          const courseCompletionAttempt4 = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 4,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionAttempt4,
+            allCourseCompletions: [courseCompletionAttempt4],
+          })
+
+          expect(courseCompletionRows).toHaveLength(1)
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 4')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
+        })
+
+        it('returns rows for attempts 4, 5 and 6 when attempt 6 is current', () => {
+          const courseCompletionAttempt6 = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 6,
+            completionDateTime: new Date('2020-01-11').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionAttempt6,
+            allCourseCompletions: [courseCompletionAttempt6],
+          })
+
+          expect(courseCompletionRows).toHaveLength(3)
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 6')
+          expect(courseCompletionRows[0].value.html).toContain('11 January 2020')
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 5')
+          expect(courseCompletionRows[1].value.html).toContain('Details in Community Campus')
+
+          expect(courseCompletionRows[2].key.text).toEqual('Attempt 4')
+          expect(courseCompletionRows[2].value.html).toContain('Details in Community Campus')
+        })
+
+        it('returns rows for attempts 4 and 5 when attempt 4 is current but attempt 5 exists', () => {
+          const courseCompletionAttempt4 = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 4,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+          const courseCompletionAttempt5 = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 5,
+            completionDateTime: new Date('2020-01-10').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionAttempt4,
+            allCourseCompletions: [courseCompletionAttempt4, courseCompletionAttempt5],
+          })
+
+          expect(courseCompletionRows).toHaveLength(2)
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 5')
+          expect(courseCompletionRows[0].value.html).toContain('10 January 2020')
+
+          expect(courseCompletionRows[1].key.text).toEqual('Attempt 4')
+          expect(courseCompletionRows[1].value.html).toContain('9 January 2020')
+        })
+
+        it('hides future attempts even if they exist if the current attempt is passed', () => {
+          const courseCompletionAttempt1 = courseCompletionFactory.build({
+            status: 'Passed',
+            attempts: 1,
+            completionDateTime: new Date('2020-01-09').toISOString(),
+          })
+          const courseCompletionAttempt2 = courseCompletionFactory.build({
+            status: 'Failed',
+            attempts: 2,
+            completionDateTime: new Date('2020-01-10').toISOString(),
+          })
+
+          const courseCompletionRows = CourseCompletionUtils.completionDetailsRows({
+            courseCompletion: courseCompletionAttempt1,
+            allCourseCompletions: [courseCompletionAttempt1, courseCompletionAttempt2],
+          })
+
+          expect(courseCompletionRows).toHaveLength(1)
+          expect(courseCompletionRows[0].key.text).toEqual('Attempt 1')
+          expect(courseCompletionRows[0].value.html).toContain('9 January 2020')
         })
       })
     })

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -92,17 +92,16 @@ export default class CourseCompletionUtils {
 
     for (let attempt = blockEnd; attempt >= blockStart; attempt -= 1) {
       const currentCourseCompletion = sortedCourseCompletions.find(c => c.attempts === attempt)
+      const isFutureAttempt = attempt > courseCompletion.attempts
+      const shouldBeBuilt = !(isFutureAttempt && (courseCompletion.status === 'Passed' || !currentCourseCompletion))
 
-      if (attempt > courseCompletion.attempts && (courseCompletion.status === 'Passed' || !currentCourseCompletion)) {
-        // eslint-disable-next-line no-continue
-        continue
+      if (shouldBeBuilt) {
+        const item = currentCourseCompletion
+          ? this.buildCourseCompletionRow(currentCourseCompletion)
+          : this.buildCourseCompletionRow(undefined, attempt)
+
+        rows.push(item)
       }
-
-      const item = currentCourseCompletion
-        ? this.buildCourseCompletionRow(currentCourseCompletion)
-        : this.buildCourseCompletionRow(undefined, attempt)
-
-      rows.push(item)
     }
 
     return rows

--- a/server/utils/courseCompletionUtils.ts
+++ b/server/utils/courseCompletionUtils.ts
@@ -83,31 +83,26 @@ export default class CourseCompletionUtils {
     courseCompletion: EteCourseCompletionEventDto
     allCourseCompletions: EteCourseCompletionEventDto[]
   }): GovUkSummaryListItem[] {
-    const MAX_ATTEMPTS = 3
+    const blockStart = Math.floor((courseCompletion.attempts - 1) / 3) * 3 + 1
+    const blockEnd = blockStart + 2
 
-    const sortedCourseCompletions = [...allCourseCompletions].sort((a, b) =>
-      b.completionDateTime.localeCompare(a.completionDateTime),
-    )
-
-    const maxAttemptNumber = courseCompletion.status === 'Passed' ? courseCompletion.attempts : MAX_ATTEMPTS
+    const sortedCourseCompletions = [...allCourseCompletions].sort((a, b) => b.attempts - a.attempts)
 
     const rows: GovUkSummaryListItem[] = []
 
-    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
-      const rowLength = rows.length
-      const currentCourseCompletion = sortedCourseCompletions[i]
-      const shouldSkipBuildingRow =
-        courseCompletion.status === 'Passed' && !currentCourseCompletion && courseCompletion.attempts === rowLength
+    for (let attempt = blockEnd; attempt >= blockStart; attempt -= 1) {
+      const currentCourseCompletion = sortedCourseCompletions.find(c => c.attempts === attempt)
 
-      if (!shouldSkipBuildingRow) {
-        const attemptNumber = maxAttemptNumber - rowLength
-
-        const item = currentCourseCompletion
-          ? this.buildCourseCompletionRow(currentCourseCompletion)
-          : this.buildCourseCompletionRow(undefined, attemptNumber)
-
-        rows.push(item)
+      if (attempt > courseCompletion.attempts && (courseCompletion.status === 'Passed' || !currentCourseCompletion)) {
+        // eslint-disable-next-line no-continue
+        continue
       }
+
+      const item = currentCourseCompletion
+        ? this.buildCourseCompletionRow(currentCourseCompletion)
+        : this.buildCourseCompletionRow(undefined, attempt)
+
+      rows.push(item)
     }
 
     return rows


### PR DESCRIPTION
Update `completionDetailsRows` logic to group attempts into blocks and adjust test cases accordingly.

It needs to be in blocks of 3, the backend is returning that based on attempt number. I have checked the prod data, it is coming in a sequence - 1, 2, 3, 4, 5, 6, 7 - the attempt number is never reset.

## Context

It needs to be in blocks of 3, the backend is returning that based on attempt number. I have checked the prod data, it is coming in a sequence - 1, 2, 3, 4, 5, 6, 7 - the attempt number is never reset.
<img width="4204" height="3590" alt="screencapture-community-payback-dev-hmpps-service-justice-gov-uk-course-completions-cafe6c7f-1a8d-48a1-a0de-7cca82890bfb-2026-06-19-12_41_55" src="https://github.com/user-attachments/assets/6e3a9329-ca33-41ca-9693-584cadcd89e0" />

Please look at the screenshot above, it should only show attempt 4 - otherwise show in blocks of 3, depending on the data.

## Changes in this PR

Update `completionDetailsRows` logic to group attempts into blocks and adjust test cases accordingly.

