### PR TITLE
Update `hmpps-probation-integration-e2e-tests` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ministryofjustice/hmpps-audit-client": "1.1.1",
         "@ministryofjustice/hmpps-auth-clients": "^1.0.2",
         "@ministryofjustice/hmpps-monitoring": "^1.0.2",
-        "@ministryofjustice/hmpps-probation-integration-e2e-tests": "1.227.0",
+        "@ministryofjustice/hmpps-probation-integration-e2e-tests": "1.236.0",
         "@ministryofjustice/hmpps-rest-client": "^1.2.0",
         "@playwright/test": "^1.60.0",
         "@sentry/node": "^10.51.0",
@@ -4545,9 +4545,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-probation-integration-e2e-tests": {
-      "version": "1.227.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-probation-integration-e2e-tests/-/hmpps-probation-integration-e2e-tests-1.227.0.tgz",
-      "integrity": "sha512-NuI6t/KBPV1uGOHQf53t32YAaj2L/It8DDPizhBaEsTExMlpzb3SFivFH3MSRpv3QKQCEHbeVRDPg4ME7ofP0A==",
+      "version": "1.236.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-probation-integration-e2e-tests/-/hmpps-probation-integration-e2e-tests-1.236.0.tgz",
+      "integrity": "sha512-W71O9Vt0hRMzIJUzSKFtJKY8ND3fi+CP71mEWBDlaVVkx9pkYUqOzwURJOcpnm+sOd+q2Wl/pr4ZkzQAle9pMQ==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@ministryofjustice/hmpps-audit-client": "1.1.1",
     "@ministryofjustice/hmpps-auth-clients": "^1.0.2",
     "@ministryofjustice/hmpps-monitoring": "^1.0.2",
-    "@ministryofjustice/hmpps-probation-integration-e2e-tests": "1.227.0",
+    "@ministryofjustice/hmpps-probation-integration-e2e-tests": "1.236.0",
     "@ministryofjustice/hmpps-rest-client": "^1.2.0",
     "@playwright/test": "^1.60.0",
     "@sentry/node": "^10.51.0",


### PR DESCRIPTION
## Context

Update [hmpps-probation-integration-e2e-tests](https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests) package. Includes an improvement to the `getRowByContent()` method on delius validation steps, which should improve timeouts on tests.

### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
