### PR TITLE
CPB-1026: Add e2e tests for bulk update

### DIFF
--- a/e2e-tests/delius/personOnProbation.ts
+++ b/e2e-tests/delius/personOnProbation.ts
@@ -10,6 +10,10 @@ export default class PersonOnProbation {
     return `${this.firstName} ${this.lastName}`
   }
 
+  public getNameAndCrnDisplay() {
+    return `${this.getFullName()} (${this.crn})`
+  }
+
   public getDisplayName() {
     const initial = this.firstName?.[0]?.toUpperCase() ?? ''
     return `${this.lastName}, ${initial}`

--- a/e2e-tests/fixtures/test.ts
+++ b/e2e-tests/fixtures/test.ts
@@ -80,6 +80,31 @@ export default base.extend<TestOptions>({
     },
     { scope: 'test' },
   ],
+  groupSessionCount: 2,
+  groupSession: [
+    async ({ page, team, placementType, project, isLoggedInToDelius, groupSessionCount }, use, testInfo) => {
+      const results = []
+
+      /* eslint-disable no-plusplus, no-await-in-loop */
+      for (let i = 0; i < groupSessionCount; i++) {
+        const personOnProbation = await setupPersonOnProbationFixture({ page, testInfo, team, isLoggedInToDelius })
+        const appointment = await setupAppointment({
+          page,
+          team,
+          placementType,
+          personOnProbation,
+          project,
+          isLoggedInToDelius,
+        })
+
+        results.push({ personOnProbation, appointment })
+      }
+      /* eslint-enable no-plusplus, no-await-in-loop */
+
+      use({ peopleOnProbation: results.map(result => result.personOnProbation), date: results[0].appointment.date })
+    },
+    { scope: 'test' },
+  ],
   e2eProjects: ['ETE Automated Test Bucket', 'Community Campus Test'],
 })
 

--- a/e2e-tests/fixtures/testOptions.ts
+++ b/e2e-tests/fixtures/testOptions.ts
@@ -14,9 +14,10 @@ export interface TestOptions {
     password: string
   }
   team: Team
-  testCount: number
   isLoggedInToDelius: boolean
   personOnProbation: PersonOnProbation
+  groupSession: { peopleOnProbation: Array<PersonOnProbation>; date: Date }
+  groupSessionCount: number
   project: Project
   placementType: PlacementType
   appointment: { date: Date }

--- a/e2e-tests/pages/appointments/attendanceOutcomePage.ts
+++ b/e2e-tests/pages/appointments/attendanceOutcomePage.ts
@@ -32,7 +32,6 @@ export default class AttendanceOutcomePage extends AppointmentFormPage {
   async chooseAttendedCompliedOutcome() {
     await this.attendedCompliedOutcomeLocator.check()
     await this.notesFieldLocator.fill('There were some issues')
-    await this.isSensitiveOptionLocator.check()
   }
 
   async chooseAttendedEnforceableOutcome(): Promise<void> {

--- a/e2e-tests/pages/appointments/bulkUpdatePeoplePage.ts
+++ b/e2e-tests/pages/appointments/bulkUpdatePeoplePage.ts
@@ -1,0 +1,19 @@
+import { Page } from '@playwright/test'
+import PersonOnProbation from '../../delius/personOnProbation'
+import AppointmentFormPage from './appointmentFormPage'
+
+export default class BulkUpdatePeoplePage extends AppointmentFormPage {
+  constructor(private readonly page: Page) {
+    super(page, 'Select all people with the same attendance outcome')
+  }
+
+  async selectPeople(peopleOnProbation: PersonOnProbation[]) {
+    /* eslint-disable no-plusplus, no-await-in-loop */
+    for (let i = 0; i < peopleOnProbation.length; i++) {
+      const label = peopleOnProbation[i].getNameAndCrnDisplay()
+
+      await this.page.getByLabel(label).check()
+    }
+    /* eslint-enable no-plusplus, no-await-in-loop */
+  }
+}

--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -6,6 +6,7 @@ import SummaryListComponent from '../components/summaryListComponent'
 import { AttendanceOutcome } from '../../contactOutcomes'
 import { ProjectAvailability } from '../../delius/project'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import PersonOnProbation from '../../delius/personOnProbation'
 
 export default class ConfirmPage extends AppointmentFormPage {
   override expect: ConfirmPageAssertions = new ConfirmPageAssertions(this)
@@ -54,6 +55,16 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
       const endTime = DateTimeFormats.stripTime(availability.endTime)
       await this.confirmPage.details.expect.toHaveItemWith('Start and end time', `${startTime} - ${endTime}`)
     }
+  }
+
+  async toShowSelectedPeople(peopleOnProbation: PersonOnProbation[]) {
+    const names = peopleOnProbation.map(person => person.getNameAndCrnDisplay())
+    const peopleSectionLocator = this.confirmPage.details.itemWithLabel('People')
+    /* eslint-disable no-await-in-loop */
+    for (const name of names) {
+      await expect(peopleSectionLocator.getByText(name)).toBeVisible()
+    }
+    /* eslint-enable no-await-in-loop */
   }
 
   async toShowPenaltyHoursAnswerWithHoursApplied() {

--- a/e2e-tests/pages/appointments/logHoursPage.ts
+++ b/e2e-tests/pages/appointments/logHoursPage.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test'
 import AppointmentFormPage from './appointmentFormPage'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
+import { ProjectAvailability } from '../../delius/project'
 
 export default class LogHoursPage extends AppointmentFormPage {
   startTimeFieldLocator: Locator
@@ -14,6 +15,11 @@ export default class LogHoursPage extends AppointmentFormPage {
     this.startTimeFieldLocator = page.getByLabel('Start time')
     this.endTimeFieldLocator = page.getByLabel('End time')
     this.hoursMinutesInput = new HoursMinutesInputComponent(page)
+  }
+
+  async enterStartAndEndTime(availability: Pick<ProjectAvailability, 'startTime' | 'endTime'>) {
+    await this.startTimeFieldLocator.fill(availability.startTime)
+    await this.endTimeFieldLocator.fill(availability.endTime)
   }
 
   async enterPenaltyHours(hours = '1', minutes = '00') {

--- a/e2e-tests/pages/sessionPage.ts
+++ b/e2e-tests/pages/sessionPage.ts
@@ -1,6 +1,6 @@
 /* eslint max-classes-per-file: "off" -- splitting out these classes would cause an import dependency loop */
 
-import { expect, Page } from '@playwright/test'
+import { expect, Locator, Page } from '@playwright/test'
 import BasePage from './basePage'
 import DataTableComponent from './components/dataTableComponent'
 
@@ -9,14 +9,21 @@ export default class SessionPage extends BasePage {
 
   readonly appointments: DataTableComponent
 
+  bulkUpdateButtonLocator: Locator
+
   constructor(page: Page, expectedTitle: string) {
     super(page)
     this.expect = new SessionPageAssertions(this, expectedTitle)
     this.appointments = new DataTableComponent(page)
+    this.bulkUpdateButtonLocator = page.getByRole('button', { name: 'Bulk update' })
   }
 
   async clickUpdateAnAppointment(crn: string) {
     await this.appointments.itemsLocator.filter({ hasText: crn }).getByRole('link', { name: 'Update' }).click()
+  }
+
+  async clickBulkUpdate() {
+    await this.bulkUpdateButtonLocator.click()
   }
 }
 

--- a/e2e-tests/steps/completeAttendanceOutcome.ts
+++ b/e2e-tests/steps/completeAttendanceOutcome.ts
@@ -2,18 +2,57 @@ import { Page } from '@playwright/test'
 import AttendanceOutcomePage from '../pages/appointments/attendanceOutcomePage'
 import LogHoursPage from '../pages/appointments/logHoursPage'
 
-export const completeAttendedCompliedOutcome = async (page: Page, attendanceOutcomePage: AttendanceOutcomePage) => {
-  return step(page, attendanceOutcomePage, () => attendanceOutcomePage.chooseAttendedCompliedOutcome())
+export const completeAttendedCompliedOutcome = async (
+  page: Page,
+  attendanceOutcomePage: AttendanceOutcomePage,
+  checkIsSensitive: boolean = false,
+) => {
+  return step(
+    page,
+    attendanceOutcomePage,
+    () => attendanceOutcomePage.chooseAttendedCompliedOutcome(),
+    checkIsSensitive,
+  )
 }
 
-export const completeAttendedEnforceableOutcome = async (page: Page, attendanceOutcomePage: AttendanceOutcomePage) => {
-  return step(page, attendanceOutcomePage, () => attendanceOutcomePage.chooseAttendedEnforceableOutcome())
+export const completeAttendedEnforceableOutcome = async (
+  page: Page,
+  attendanceOutcomePage: AttendanceOutcomePage,
+  checkIsSensitive: boolean = false,
+) => {
+  return step(
+    page,
+    attendanceOutcomePage,
+    () => attendanceOutcomePage.chooseAttendedEnforceableOutcome(),
+    checkIsSensitive,
+  )
 }
 
-const step = async (page: Page, attendanceOutcomePage: AttendanceOutcomePage, chooseOutcome: () => Promise<void>) => {
+export const completeNotAttendedOutcome = async (
+  page: Page,
+  attendanceOutcomePage: AttendanceOutcomePage,
+  checkIsSensitive: boolean = false,
+) =>
+  step(
+    page,
+    attendanceOutcomePage,
+    () => attendanceOutcomePage.chooseNotAttendedNotEnforcementOutcome(),
+    checkIsSensitive,
+  )
+
+const step = async (
+  page: Page,
+  attendanceOutcomePage: AttendanceOutcomePage,
+  chooseOutcome: () => Promise<void>,
+  checkIsSensitive: boolean,
+) => {
   const logHoursPage = new LogHoursPage(page)
 
   await chooseOutcome()
+
+  if (checkIsSensitive) {
+    await attendanceOutcomePage.isSensitiveOptionLocator.check()
+  }
 
   await attendanceOutcomePage.continue()
   await logHoursPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -30,7 +30,7 @@ test('Update a session appointment', async ({ page, deliusUser, team, project, p
 
   const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
 
-  const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
+  const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage, true)
   await logHoursPage.enterPenaltyHours()
   await logHoursPage.continue()
 

--- a/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test'
+import { login as deliusLogin } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
+import { checkAppointmentOnDelius } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/checkAppointmentDetails'
+import test from '../../fixtures/test'
+import signIn from '../../steps/signIn'
+import searchForASession from '../../steps/searchForASession'
+import selectASession from '../../steps/selectASession'
+import completeCompliance from '../../steps/completeCompliance'
+import ConfirmPage from '../../pages/appointments/confirmPage'
+import { completeAttendedCompliedOutcome } from '../../steps/completeAttendanceOutcome'
+import completeChooseSupervisor from '../../steps/completeChooseSupervisor'
+import BulkUpdatePeoplePage from '../../pages/appointments/bulkUpdatePeoplePage'
+import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
+
+test('Bulk update a group session => attended', async ({ page, deliusUser, team, project, groupSession: session }) => {
+  await page.goto('/sign-out')
+  await expect(page.locator('h1')).toContainText('Sign in')
+
+  const homePage = await signIn(page, deliusUser)
+  const groupSessionPage = await searchForASession(page, homePage, team, session.date)
+
+  await groupSessionPage.expect.toSeeResults()
+
+  const sessionPage = await selectASession(page, groupSessionPage, project.name)
+
+  await sessionPage.expect.toSeeAppointments()
+  await sessionPage.clickBulkUpdate()
+
+  const bulkUpdatePeoplePage = new BulkUpdatePeoplePage(page)
+  await bulkUpdatePeoplePage.expect.toBeOnThePage()
+  await bulkUpdatePeoplePage.selectPeople(session.peopleOnProbation)
+
+  await bulkUpdatePeoplePage.continue()
+
+  const chooseSupervisorPage = new ChooseSupervisorPage(page)
+  await chooseSupervisorPage.expect.toBeOnThePage()
+
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
+
+  const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
+  await logHoursPage.enterStartAndEndTime(project.availability)
+  await logHoursPage.continue()
+
+  await completeCompliance(page)
+
+  const confirmPage = new ConfirmPage(page)
+  await confirmPage.expect.toBeOnThePage()
+
+  await confirmPage.expect.toShowSelectedPeople(session.peopleOnProbation)
+  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
+  await confirmPage.expect.toShowAttendanceAnswer('Attended - Complied')
+  await confirmPage.expect.toShowComplianceAnswer()
+  await confirmPage.selectAlertPractitioner()
+
+  await confirmPage.confirmButtonLocator.click()
+
+  await sessionPage.expect.toBeOnThePage()
+
+  await deliusLogin(page)
+
+  /* eslint-disable no-plusplus, no-await-in-loop */
+  for (let i = 0; i < session.peopleOnProbation.length; i++) {
+    await page.getByRole('link', { name: 'UPW Project Diary' }).click()
+    await page.waitForSelector('span.float-start:has-text("UPW Project Diary")')
+    const person = session.peopleOnProbation[i]
+    await checkAppointmentOnDelius(page, {
+      teamProvider: team.provider,
+      teamName: team.name,
+      projectName: project.name,
+      popCrn: person.crn,
+      popName: person.getDisplayName(),
+      startTime: project.availability.startTime,
+      endTime: project.availability.endTime,
+      outcome: 'Attended - Complied',
+      hoursCredited: '4:00',
+    })
+  }
+  /* eslint-enable no-plusplus, no-await-in-loop */
+})

--- a/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test'
+import { login as deliusLogin } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
+import { checkAppointmentOnDelius } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/upw/checkAppointmentDetails'
+import test from '../../fixtures/test'
+import signIn from '../../steps/signIn'
+import searchForASession from '../../steps/searchForASession'
+import selectASession from '../../steps/selectASession'
+import ConfirmPage from '../../pages/appointments/confirmPage'
+import completeChooseSupervisor from '../../steps/completeChooseSupervisor'
+import BulkUpdatePeoplePage from '../../pages/appointments/bulkUpdatePeoplePage'
+import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
+
+test('Bulk update a group session => not attended', async ({ page, deliusUser, team, project, groupSession }) => {
+  await page.goto('/sign-out')
+  await expect(page.locator('h1')).toContainText('Sign in')
+
+  const homePage = await signIn(page, deliusUser)
+  const groupSessionPage = await searchForASession(page, homePage, team, groupSession.date)
+
+  await groupSessionPage.expect.toSeeResults()
+
+  const sessionPage = await selectASession(page, groupSessionPage, project.name)
+
+  await sessionPage.expect.toSeeAppointments()
+  await sessionPage.clickBulkUpdate()
+
+  const bulkUpdatePeoplePage = new BulkUpdatePeoplePage(page)
+  await bulkUpdatePeoplePage.expect.toBeOnThePage()
+  await bulkUpdatePeoplePage.selectPeople(groupSession.peopleOnProbation)
+
+  await bulkUpdatePeoplePage.continue()
+
+  const chooseSupervisorPage = new ChooseSupervisorPage(page)
+  await chooseSupervisorPage.expect.toBeOnThePage()
+
+  const attendanceOutcomePage = await completeChooseSupervisor(page, chooseSupervisorPage, team)
+  await attendanceOutcomePage.chooseNotAttendedNotEnforcementOutcome()
+  await attendanceOutcomePage.continue()
+
+  const confirmPage = new ConfirmPage(page)
+  await confirmPage.expect.toBeOnThePage()
+
+  await confirmPage.expect.toShowSelectedPeople(groupSession.peopleOnProbation)
+  await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
+  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled - Service Request')
+  await confirmPage.selectAlertPractitioner()
+
+  await confirmPage.confirmButtonLocator.click()
+
+  await sessionPage.expect.toBeOnThePage()
+
+  await deliusLogin(page)
+
+  /* eslint-disable no-plusplus, no-await-in-loop */
+  for (let i = 0; i < groupSession.peopleOnProbation.length; i++) {
+    await page.getByRole('link', { name: 'UPW Project Diary' }).click()
+    await page.waitForSelector('span.float-start:has-text("UPW Project Diary")')
+    const person = groupSession.peopleOnProbation[i]
+    await checkAppointmentOnDelius(page, {
+      teamProvider: team.provider,
+      teamName: team.name,
+      projectName: project.name,
+      popCrn: person.crn,
+      popName: person.getDisplayName(),
+      startTime: project.availability.startTime,
+      endTime: project.availability.endTime,
+      outcome: 'Rescheduled - Service Request',
+      hoursCredited: '',
+    })
+  }
+  /* eslint-enable no-plusplus, no-await-in-loop */
+})


### PR DESCRIPTION
## Context

Adds end to end tests for the bulk update functionality on group session appointments, including verifying outcomes in Delius.

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

## Changes in this PR

- Introduced a multi-person groupSession and groupSessionCount fixtures.
- Added new e2e tests for bulk updating a group session as Attended and Not attended, with Delius verification.
- Refactored attendance outcome completion to optionally tick the “sensitive information” checkbox.

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ