### PR TITLE
CPB-1026: Bulk update header styling and content updates

### DIFF
--- a/assets/scss/components/_page-header.scss
+++ b/assets/scss/components/_page-header.scss
@@ -1,4 +1,4 @@
-.cpb-offender-details {
+.cpb-page-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -10,7 +10,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/header-bar';
 @import './components/search-and-filter';
 @import './components/sortable-table';
-@import './components/offender-details';
+@import './components/page-header';
 @import './pages/dashboard-index';
 
 @import './overrides/local';

--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -5,7 +5,6 @@ import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
 import { AppointmentDto, SessionDto } from '../../../server/@types/shared'
-import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import SelectedPeopleCardComponent from './selectedPeopleCardComponent'
 
 export default abstract class BaseAppointmentFormPage extends Page {
@@ -17,9 +16,7 @@ export default abstract class BaseAppointmentFormPage extends Page {
 
   constructor(appointment: AppointmentOrSession) {
     const isSingleAppointment = 'offender' in appointment
-    const title = isSingleAppointment
-      ? new Offender(appointment.offender).name
-      : `${appointment.projectName} (${DateTimeFormats.isoDateToUIDate(appointment.date)})`
+    const title = isSingleAppointment ? new Offender(appointment.offender).name : appointment.projectName
     super(title)
     this.isSingleAppointment = isSingleAppointment
   }

--- a/integration_tests/pages/appointments/bulkUpdatePage.ts
+++ b/integration_tests/pages/appointments/bulkUpdatePage.ts
@@ -1,5 +1,4 @@
 import { AppointmentDto, SessionDto } from '../../../server/@types/shared'
-import DateTimeFormats from '../../../server/utils/dateTimeUtils'
 import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
 import RadioOrCheckboxGroupComponent from '../components/radioOrCheckboxGroupComponent'
@@ -9,7 +8,7 @@ export default class BulkUpdatePage extends Page {
   private readonly checkBoxes: RadioOrCheckboxGroupComponent
 
   constructor(session: SessionDto) {
-    super(`${session.projectName} (${DateTimeFormats.isoDateToUIDate(session.date)})`)
+    super(session.projectName)
     this.checkBoxes = new RadioOrCheckboxGroupComponent('appointments')
   }
 

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -12,7 +12,7 @@ import ReferenceDataService from '../../services/referenceDataService'
 
 export type AppointmentUpdatePageViewData = {
   selectedPeopleCard?: GovUkSummaryList
-  heading: { title: string; caption: string }
+  heading: { title: string; caption: string; description?: string }
   backLink: string
   updatePath: string
   form?: string

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -10,9 +10,11 @@ import {
 } from '../shared'
 import ReferenceDataService from '../../services/referenceDataService'
 
+type PageHeader = { title: string; caption: string; description?: string }
+
 export type AppointmentUpdatePageViewData = {
   selectedPeopleCard?: GovUkSummaryList
-  heading: { title: string; caption: string; description?: string }
+  heading: PageHeader
   backLink: string
   updatePath: string
   form?: string

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -74,8 +74,9 @@ describe('BaseAppointmentUpdatePage', () => {
         })
 
         expect(result.heading).toEqual({
-          title: `${session.projectName} (${formattedDate})`,
+          title: session.projectName,
           caption: 'Bulk update',
+          description: `Date: ${formattedDate}`,
         })
         expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith(session.date)
       })

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -134,8 +134,9 @@ export default abstract class BaseAppointmentUpdatePage {
       }
     }
     return {
-      title: `${appointmentOrSession.projectName} (${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)})`,
+      title: appointmentOrSession.projectName,
       caption: 'Bulk update',
+      description: `Date: ${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)}`,
     }
   }
 

--- a/server/pages/appointments/bulkUpdatePage.test.ts
+++ b/server/pages/appointments/bulkUpdatePage.test.ts
@@ -56,8 +56,9 @@ describe('BulkUpdatePage', () => {
       const result = page.viewData({ formData: appointmentOutcomeFormFactory.build(), session, formId: 'form-id-1' })
 
       expect(result.heading).toEqual({
-        title: `Project A (${formattedDate})`,
+        title: 'Project A',
         caption: 'Bulk update',
+        description: `Date: ${formattedDate}`,
       })
     })
 

--- a/server/pages/appointments/bulkUpdatePage.ts
+++ b/server/pages/appointments/bulkUpdatePage.ts
@@ -1,5 +1,10 @@
 import { AppointmentDto, SessionDto } from '../../@types/shared'
-import { AppointmentOutcomeForm, GovUkRadioOrCheckboxOption, ValidationErrors } from '../../@types/user-defined'
+import {
+  AppointmentOutcomeForm,
+  GovUkRadioOrCheckboxOption,
+  PageHeader,
+  ValidationErrors,
+} from '../../@types/user-defined'
 import GovUkCheckboxes from '../../forms/GovUkCheckboxes'
 import Offender from '../../models/offender'
 import paths from '../../paths'
@@ -16,15 +21,16 @@ export default class BulkUpdatePage extends PageWithValidation<Body> {
     backLink: string
     updatePath: string
     options: Array<GovUkRadioOrCheckboxOption>
-    heading: { title: string; caption: string }
+    heading: PageHeader
   } {
     return {
       backLink: this.backPath(session, formData.originalSearch),
       updatePath: this.updatePath(formId, session),
       options: this.items(session, formData),
       heading: {
-        title: `${session.projectName} (${DateTimeFormats.isoDateToUIDate(session.date)})`,
+        title: session.projectName,
         caption: 'Bulk update',
+        description: `Date: ${DateTimeFormats.isoDateToUIDate(session.date)}`,
       },
     }
   }

--- a/server/views/appointments/_appointmentHeader.njk
+++ b/server/views/appointments/_appointmentHeader.njk
@@ -4,6 +4,9 @@
       <div>
         <span class="govuk-caption-l">{{ heading.caption }}</span>
         <h1 class="govuk-heading-l">{{ heading.title }}</h1>
+        {% if (heading.description) %}
+          <p class="govuk-body govuk-!-font-weight-bold">{{ heading.description }}</p>
+        {% endif %}
       </div>
       {{ caller() }}
     </div>

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "../_appointmentHeader.njk" import appointmentHeader %}
+{% from "../../partials/pageHeader.njk" import pageHeader %}
 
 
 {% from "../../showErrorSummary.njk" import showErrorSummary %}
@@ -45,7 +45,7 @@
   {% endif %}
 
 
-  {% call appointmentHeader(heading) %}
+  {% call pageHeader(heading) %}
     {% block headerCallToAction %}
     {% endblock %}
   {% endcall %}

--- a/server/views/courseCompletions/show.njk
+++ b/server/views/courseCompletions/show.njk
@@ -18,7 +18,7 @@
 {% block content %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full cpb-offender-details">
+  <div class="govuk-grid-column-full cpb-page-header">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ courseCompletion.firstName }} {{ courseCompletion.lastName }}</h1>
 
     {{ govukButton({

--- a/server/views/partials/pageHeader.njk
+++ b/server/views/partials/pageHeader.njk
@@ -1,6 +1,6 @@
 {% macro pageHeader(heading) %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full cpb-offender-details">
+    <div class="govuk-grid-column-full cpb-page-header">
       <div>
         <span class="govuk-caption-l">{{ heading.caption }}</span>
         <h1 class="govuk-heading-l">{{ heading.title }}</h1>

--- a/server/views/partials/pageHeader.njk
+++ b/server/views/partials/pageHeader.njk
@@ -1,4 +1,4 @@
-{% macro appointmentHeader(heading) %}
+{% macro pageHeader(heading) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full cpb-offender-details">
       <div>

--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% from "../partials/pageHeader.njk" import pageHeader %}
+
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = project.projectName %}
@@ -38,18 +40,14 @@
   {% endfor %}
 {% endif %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <span class="govuk-caption-l">{{ session.projectCode }}</span>
-    <h1 class="govuk-heading-l">{{ session.projectName }}</h1>
-    {% if bulkUpdatePath %}
-      {{ govukButton({
-        text: "Bulk update",
-        href: bulkUpdatePath
-      }) }}
-    {% endif %}
-  </div>
-</div>
+{% call pageHeader({ title: session.projectName, caption: session.projectCode }) %}
+  {% if bulkUpdatePath %}
+    {{ govukButton({
+      text: "Bulk update",
+      href: bulkUpdatePath
+    }) }}
+  {% endif %}
+{% endcall %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
## Context

Updates content and styling of group session and bulk update page headings:
- Style bulk update button to sit top right in header
- Move date out of page h1 for bulk update form pages

[CPB-1026](https://dsdmoj.atlassian.net/browse/CPB-1026)

### Screenshots of UI changes

#### Before

<img width="1616" height="956" alt="Group session page with appointment list" src="https://github.com/user-attachments/assets/048659f5-cd84-4007-979b-d6ac3ee1ec9f" />
<img width="1564" height="929" alt="Bulk update select people page" src="https://github.com/user-attachments/assets/1c8069f2-a34a-47a9-af03-ae0ed28dc728" />

#### After

<img width="1525" height="955" alt="Group session page with appointment list with bulk update button in header" src="https://github.com/user-attachments/assets/3be76ce0-6511-454d-9954-5adedffabb44" />
<img width="1363" height="954" alt="Bulk update select people page with session date underneath heading" src="https://github.com/user-attachments/assets/02c989b4-c36c-42fb-b522-c350a2b9fb18" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1026]: https://dsdmoj.atlassian.net/browse/CPB-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ