### PR TITLE
CPB-1071: Style status tags

### DIFF
--- a/server/utils/htmlUtils.test.ts
+++ b/server/utils/htmlUtils.test.ts
@@ -36,6 +36,18 @@ describe('HTMLUtils', () => {
       const result = HtmlUtils.getStatusTag('Label', colour as GovUkStatusTagColour)
       expect(result).toEqual(`<strong class="govuk-tag govuk-tag--${colour}">Label</strong>`)
     })
+
+    it('includes cpb-unset-max-width class when unsetMaxWidth is true', () => {
+      const result = HtmlUtils.getStatusTag('Label', 'grey', true)
+
+      expect(result).toEqual('<strong class="govuk-tag govuk-tag--grey cpb-unset-max-width">Label</strong>')
+    })
+
+    it('does not include cpb-unset-max-width class when unsetMaxWidth is false', () => {
+      const result = HtmlUtils.getStatusTag('Label', 'grey', false)
+
+      expect(result).toEqual('<strong class="govuk-tag govuk-tag--grey">Label</strong>')
+    })
   })
 
   describe('getStatusTagClass', () => {

--- a/server/utils/htmlUtils.ts
+++ b/server/utils/htmlUtils.ts
@@ -13,8 +13,13 @@ export default class HtmlUtils {
     return `<span class="govuk-visually-hidden">${text}</span>`
   }
 
-  static getStatusTag = (statusLabel: string, colour: GovUkStatusTagColour): string => {
-    return `<strong class="govuk-tag ${this.getStatusTagClass(colour)}">${statusLabel}</strong>`
+  static getStatusTag = (statusLabel: string, colour: GovUkStatusTagColour, unsetMaxWidth: boolean = false): string => {
+    let classes = `govuk-tag ${this.getStatusTagClass(colour)}`
+
+    if (unsetMaxWidth) {
+      classes += ' cpb-unset-max-width'
+    }
+    return `<strong class="${classes}">${statusLabel}</strong>`
   }
 
   static getStatusTagClass(colour: GovUkStatusTagColour): string {

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -140,7 +140,7 @@ describe('SessionUtils', () => {
       const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
       expect(sessionRow[sessionRow.length - 2]).toEqual({ html: mockTag })
-      expect(HtmlUtils.getStatusTag).toHaveBeenCalledWith(contactOutcome.name, statusColour)
+      expect(HtmlUtils.getStatusTag).toHaveBeenCalledWith(contactOutcome.name, statusColour, true)
       expect(AppointmentUtils.getStatusColour).toHaveBeenCalledWith(contactOutcome)
     })
 
@@ -163,7 +163,7 @@ describe('SessionUtils', () => {
 
       const result = SessionUtils.sessionListTableRows(session, search)
       const sessionRow = result[0]
-      expect(HtmlUtils.getStatusTag).toHaveBeenCalledWith('Not entered', 'grey')
+      expect(HtmlUtils.getStatusTag).toHaveBeenCalledWith('Not entered', 'grey', true)
       expect(sessionRow[sessionRow.length - 2]).toEqual({ html: statusTagHtml })
     })
 

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -132,6 +132,6 @@ export default class SessionUtils {
 
   private static getStatusTag(contactOutcome?: ContactOutcomeDto) {
     const text = contactOutcome?.name || 'Not entered'
-    return HtmlUtils.getStatusTag(text, AppointmentUtils.getStatusColour(contactOutcome))
+    return HtmlUtils.getStatusTag(text, AppointmentUtils.getStatusColour(contactOutcome), true)
   }
 }


### PR DESCRIPTION
## Context

This applies the same styling to unset GOV.UK tag max widths as on the appointment details page, to allow longer tags to sit on one line where there is more space.

### Screenshots of UI changes

Desktop:
<img width="1903" height="1370" alt="Group session page with a list of appointments with status: Attended - Sent Home (service issues)" src="https://github.com/user-attachments/assets/0e785dd0-929c-472f-87e6-ca0363dc9599" />

Zoomed in:
<img width="1903" height="4392" alt="Group session page with a list of appointments with status: Attended - Sent Home (service issues)" src="https://github.com/user-attachments/assets/3f9cd638-283b-4f87-b2eb-1bc9579c421c" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
