### PR TITLE
Hide is sensitive item for bulk updates

### DIFF
--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -28,7 +28,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     this.formDetails.getValueWithLabel('Start and end time').should('contain.text', this.form.startTime)
   }
 
-  shouldShowAttendanceDetails(): void {
+  shouldShowAttendanceDetails(expectIsSensitiveAnswer: boolean): void {
     this.formDetails.getValueWithLabel('Penalty hours').should('contain.text', '1 hourTotal hours credited: 6 hours')
     this.formDetails
       .getValueWithLabel('Compliance')
@@ -37,7 +37,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
         'Wore hi-vis - No<br>Working intensively - No<br>Work quality - Good<br>Behaviour - Not applicable',
       )
     this.formDetails.getValueWithLabel('Notes').should('contain.text', 'Test')
-    this.formDetails.getValueWithLabel('Sensitive').should('contain.text', 'Not entered')
+
+    if (expectIsSensitiveAnswer) {
+      this.formDetails.getValueWithLabel('Sensitive').should('contain.text', 'Not entered')
+    }
   }
 
   shouldShowAlertPractitionerMessage() {
@@ -50,6 +53,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     cy.get('div')
       .contains('This outcome will be shared with the practitioner as it requires enforcement action.')
       .should('not.exist')
+  }
+
+  shouldNotShowSensitiveQuestion() {
+    this.formDetails.shouldNotContainValueWithLabel('Sensitive')
   }
 
   shouldNotShowAttendanceDetails(): void {

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -128,7 +128,7 @@ context('Confirm appointment details page', () => {
 
     // Then I can see my submitted answers
     page.shouldShowCompletedDetails()
-    page.shouldShowAttendanceDetails()
+    page.shouldShowAttendanceDetails(true)
   })
 
   // Scenario: Confirming an appointment update - not attended

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -89,7 +89,8 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       const page = ConfirmDetailsPage.visitForSession(this.session, form)
 
       page.shouldShowCompletedDetails()
-      page.shouldShowAttendanceDetails()
+      page.shouldShowAttendanceDetails(false)
+      page.shouldNotShowSensitiveQuestion()
       page.shouldShowSelectedPeople(this.appointments)
       page.shouldNotShowSelectedPeople([this.unselectedAppointment])
     })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -634,23 +634,6 @@ describe('ConfirmPage', () => {
               ],
             },
           },
-          {
-            key: {
-              text: 'Sensitive',
-            },
-            value: {
-              text: 'Not entered',
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'sensitivity',
-                },
-              ],
-            },
-          },
         ])
 
         expect(paths.sessions.update).toHaveBeenCalledWith({

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -113,6 +113,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   }
 
   private formItems(form: AppointmentOutcomeForm, appointment: AppointmentOrSession): GovUkSummaryListItem[] {
+    const isSingleAppointment = this.isSingleAppointment(appointment)
     const items = [
       ...this.buildOffenderItem(form, appointment),
       {
@@ -152,7 +153,8 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       ...NotesUtils.checkYourAnswersRows(
         form,
         this.changePath(appointment, 'attendance-outcome'),
-        this.isSingleAppointment(appointment) ? appointment : undefined,
+        isSingleAppointment ? appointment : undefined,
+        isSingleAppointment,
       ),
     ]
 

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -351,6 +351,34 @@ describe('NotesUtils', () => {
         text: 'Yes',
       })
     })
+
+    describe('includeIsSensitiveQuestion', () => {
+      it('includes sensitive row when includeIsSensitiveQuestion is true', () => {
+        const form = courseCompletionFormFactory.build({ notes: 'Some important notes', isSensitive: 'yes' })
+
+        const result = NotesUtils.checkYourAnswersRows(form, changePath, undefined, true)
+
+        expect(result).toHaveLength(2)
+        expect(result[1]).toEqual(
+          expect.objectContaining({
+            key: { text: 'Sensitive' },
+          }),
+        )
+      })
+
+      it('does not include sensitive row when includeIsSensitiveQuestion is false', () => {
+        const form = courseCompletionFormFactory.build({ notes: 'Some important notes', isSensitive: 'yes' })
+
+        const result = NotesUtils.checkYourAnswersRows(form, changePath, undefined, false)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual(
+          expect.objectContaining({
+            key: { text: 'Notes' },
+          }),
+        )
+      })
+    })
   })
 
   describe('formData', () => {

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -38,6 +38,7 @@ export default class NotesUtils {
     form: BodyWithNotes,
     changePath: string,
     appointment?: AppointmentDto,
+    includeIsSensitiveQuestion = true,
   ): Array<GovUkSummaryListItem> {
     const isSensitiveActions =
       appointment?.sensitive === true
@@ -49,7 +50,7 @@ export default class NotesUtils {
               visuallyHiddenText: 'sensitivity',
             },
           ]
-    return [
+    const rows = [
       {
         key: {
           text: 'Notes',
@@ -67,7 +68,9 @@ export default class NotesUtils {
           ],
         },
       },
-      {
+    ]
+    if (includeIsSensitiveQuestion) {
+      rows.push({
         key: {
           text: 'Sensitive',
         },
@@ -77,8 +80,9 @@ export default class NotesUtils {
         actions: {
           items: isSensitiveActions,
         },
-      },
-    ]
+      })
+    }
+    return rows
   }
 
   private static getIsSensitiveAnswer(form: BodyWithNotes, appointment?: AppointmentDto): string {


### PR DESCRIPTION
If completing a bulk update, users won't be shown the sensitivity question, so hiding the answer.

We will always send the original appointment value.

### Screenshots of UI changes

<img width="1506" height="960" alt="Confirm details page for bulk update with no 'Sensitive' answer" src="https://github.com/user-attachments/assets/44270a89-4d6d-43e2-a438-30a282221f81" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
