### PR TITLE
CPB-1020: Remove any attended related logic on log hours page

### DIFF
--- a/integration_tests/tests/appointments/logHours.cy.ts
+++ b/integration_tests/tests/appointments/logHours.cy.ts
@@ -3,21 +3,11 @@
 //    I want to update the log hours on for an offender
 //    So that I can track progress for an unpaid work order
 
-//  Scenario: Validating the log hours page - attended
+//  Scenario: Validating the log hours page
 //    Given I am on the log hours page for an appointment with an attended outcome
 //    And I do not enter a valid start, end or penalty time
 //    When I submit the form
 //    Then I see the log hours page with errors
-
-//  Scenario: Validating the log hours page - not attended
-//    Given I am on the log hours page for an appointment with a not attended outcome
-//    And I do not enter a valid start or end time
-//    When I submit the form
-//    Then I see the log hours page with errors
-
-//  Scenario: viewing the log hours page after entering 'Acceptable absence - stood down' contact outcome
-//    Given I am on the log hours page for an appointment with a contact outcome of 'Acceptable absence - stood down'
-//    Then I see the start and end times as read-only
 
 //  Scenario: Scenario: Completing the log hours page - attended
 //    Given I am on the log hours page for an appointment with an attended outcome
@@ -68,77 +58,32 @@ context('Log hours', () => {
   })
 
   describe('Validation', function type() {
-    describe('attended', function describe() {
-      // Scenario: Validating the log hours page
-      it('validates form data', function test() {
-        const form = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: true }),
-        })
-
-        cy.task('stubGetAppointmentForm', form)
-
-        // Given I am on the log hours page for an appointment with an attended outcome
-        const page = LogHoursPage.visit(this.appointment)
-
-        // And I do not enter a valid start, end or penalty time
-        page.enterStartTime('0')
-        page.enterEndTime('1')
-        page.enterPenaltyTime('-1', '400')
-
-        // When I submit the form
-        page.clickSubmit()
-
-        // Then I see the log hours page with errors
-        page.shouldShowErrorSummary('startTime', 'Enter a valid start time, for example 09:00')
-        page.shouldShowErrorSummary('endTime', 'Enter a valid end time, for example 17:00')
-        page.shouldShowErrorSummary('penaltyTimeHours', 'Enter valid hours for penalty hours, for example 2')
-        page.shouldShowErrorSummary('penaltyTimeMinutes', 'Enter valid minutes for penalty hours, for example 30')
-
-        page.shouldShowEnteredTimes({ startTime: '0', endTime: '1', penaltyHours: '-1', penaltyMinutes: '400' })
-      })
-    })
-
-    describe('not attended', function describe() {
-      // Scenario: Validating the log hours page
-      it('validates form data', function test() {
-        const form = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: false }),
-        })
-
-        cy.task('stubGetAppointmentForm', form)
-
-        // Given I am on the log hours page for an appointment with a not attended outcome
-        const page = LogHoursPage.visit(this.appointment)
-
-        // And I do not enter a valid start or end time
-        page.enterStartTime('0')
-        page.enterEndTime('1')
-        page.shouldNotShowPenaltyHours()
-
-        // When I submit the form
-        page.clickSubmit()
-
-        // Then I see the log hours page with errors
-        page.shouldShowErrorSummary('startTime', 'Enter a valid start time, for example 09:00')
-        page.shouldShowErrorSummary('endTime', 'Enter a valid end time, for example 17:00')
-      })
-    })
-  })
-
-  describe('Acceptable absence - stood down (AASD)', function describe() {
-    //  Scenario: viewing the log hours page after entering 'Acceptable absence - stood down' contact outcome
-    it('renders start/end times as read-only', function test() {
-      //  Given I am on the log hours page for an appointment with a contact outcome of 'Acceptable absence - stood down'
+    // Scenario: Validating the log hours page
+    it('validates form data', function test() {
       const form = appointmentOutcomeFormFactory.build({
-        contactOutcome: contactOutcomeFactory.build({ attended: false, code: 'AASD' }),
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
 
       cy.task('stubGetAppointmentForm', form)
 
+      // Given I am on the log hours page for an appointment with an attended outcome
       const page = LogHoursPage.visit(this.appointment)
 
-      //  Then I see the start and end times as read-only
-      page.shouldShowReadOnlyStartAndEndTimes(form.startTime, form.endTime)
+      // And I do not enter a valid start, end or penalty time
+      page.enterStartTime('0')
+      page.enterEndTime('1')
+      page.enterPenaltyTime('-1', '400')
+
+      // When I submit the form
+      page.clickSubmit()
+
+      // Then I see the log hours page with errors
+      page.shouldShowErrorSummary('startTime', 'Enter a valid start time, for example 09:00')
+      page.shouldShowErrorSummary('endTime', 'Enter a valid end time, for example 17:00')
+      page.shouldShowErrorSummary('penaltyTimeHours', 'Enter valid hours for penalty hours, for example 2')
+      page.shouldShowErrorSummary('penaltyTimeMinutes', 'Enter valid minutes for penalty hours, for example 30')
+
+      page.shouldShowEnteredTimes({ startTime: '0', endTime: '1', penaltyHours: '-1', penaltyMinutes: '400' })
     })
   })
 

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -279,69 +279,7 @@ describe('LogHoursPage', () => {
       )
     })
 
-    describe('showPenaltyHours', () => {
-      describe('when contact outcome is attended', () => {
-        it('should return true', () => {
-          const result = page.viewData(appointment, form)
-          expect(result).toEqual(
-            expect.objectContaining({
-              showPenaltyHours: true,
-            }),
-          )
-        })
-      })
-
-      describe('when contact outcome is not attended', () => {
-        it('should return false', () => {
-          form = appointmentOutcomeFormFactory.build({
-            contactOutcome: contactOutcomeFactory.build({ attended: false }),
-          })
-          const result = page.viewData(appointment, form)
-          expect(result).toEqual(
-            expect.objectContaining({
-              showPenaltyHours: false,
-            }),
-          )
-        })
-      })
-    })
-
-    describe('isOutcomeAcceptableAbsenceStoodDown', () => {
-      it("should be true when contactOutcome.code is 'AASD'", () => {
-        form = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: true, code: 'AASD' }),
-        })
-
-        const result = page.viewData(appointment, form)
-
-        expect(result.isOutcomeAcceptableAbsenceStoodDown).toBe(true)
-      })
-
-      it("should be false when contactOutcome.code is not 'AASD'", () => {
-        form = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: true, code: 'SOME_OTHER_CODE' }),
-        })
-
-        const result = page.viewData(appointment, form)
-
-        expect(result.isOutcomeAcceptableAbsenceStoodDown).toBe(false)
-      })
-    })
-
     describe('penaltyHours', () => {
-      describe('when contact outcome is not attended', () => {
-        it('should not define penalty hours', () => {
-          const contactOutcome = contactOutcomeFactory.build({ attended: false })
-          form = appointmentOutcomeFormFactory.build({ contactOutcome })
-
-          appointment = appointmentFactory.build()
-
-          const result = page.viewData(appointment, form)
-          expect(result.penaltyTimeHours).toBeUndefined()
-          expect(result.penaltyTimeMinutes).toBeUndefined()
-        })
-      })
-
       describe('when form inputted penalty hours differ from appointment penalty hours', () => {
         it('should return the form penalty hours', () => {
           appointment = appointmentFactory.build({

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -14,7 +14,6 @@ interface ViewData extends AppointmentUpdatePageViewData {
   endTime: string
   penaltyTimeHours?: string
   penaltyTimeMinutes?: string
-  isOutcomeAcceptableAbsenceStoodDown?: boolean
 }
 
 interface LogHoursBody {
@@ -133,15 +132,10 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
   }
 
   viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
-    const isAttended = Boolean(form.contactOutcome?.attended)
-    const isOutcomeAcceptableAbsenceStoodDown = form.contactOutcome?.code === 'AASD'
-
     const viewData = {
       ...this.commonViewData({ appointmentOrSession, form }),
       startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
       endTime: form.endTime ? DateTimeFormats.stripTime(form.endTime) : '',
-      showPenaltyHours: isAttended,
-      isOutcomeAcceptableAbsenceStoodDown,
     }
 
     if (this.hasErrors) {
@@ -151,22 +145,18 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
       }
     }
 
-    if (isAttended) {
-      const penaltyMinutes = form.attendanceData?.penaltyMinutes
-      const hasPenaltyMinutes = typeof penaltyMinutes === 'number' && penaltyMinutes >= 0
+    const penaltyMinutes = form.attendanceData?.penaltyMinutes
+    const hasPenaltyMinutes = typeof penaltyMinutes === 'number' && penaltyMinutes >= 0
 
-      const penaltyTimeParts = hasPenaltyMinutes
-        ? DateTimeFormats.totalMinutesToHoursAndMinutesParts(penaltyMinutes)
-        : null
+    const penaltyTimeParts = hasPenaltyMinutes
+      ? DateTimeFormats.totalMinutesToHoursAndMinutesParts(penaltyMinutes)
+      : null
 
-      return {
-        ...viewData,
-        penaltyTimeHours: penaltyTimeParts?.hours ?? null,
-        penaltyTimeMinutes: penaltyTimeParts?.minutes ?? null,
-      }
+    return {
+      ...viewData,
+      penaltyTimeHours: penaltyTimeParts?.hours ?? null,
+      penaltyTimeMinutes: penaltyTimeParts?.minutes ?? null,
     }
-
-    return viewData
   }
 
   protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {

--- a/server/views/appointments/update/logHours.njk
+++ b/server/views/appointments/update/logHours.njk
@@ -8,94 +8,73 @@
 {% block formHeader %}{% endblock %}
 
 {% block formContent %}
-      <h2 class="govuk-heading-m">Log start and end time</h2>
-    {% if isOutcomeAcceptableAbsenceStoodDown %}
-      <div class="govuk-form-group">
-        <span class="govuk-label govuk-label--s">
-          Start time
-        </span>
-        <p class="govuk-body">{{ startTime }}</p>
-        <input type="hidden" name="startTime" value="{{ startTime }}">
-      </div>
-    {% else %}
-      {{ govukInput({
-        name: "startTime",
-        id: "startTime",
-        value: startTime,
-        label: {
-          text: "Start time",
-          classes: "govuk-label--s"
-        },
-        classes: "govuk-input--width-3",
-        errorMessage: errors.startTime
-      }) }}
-    {% endif %}
+  <h2 class="govuk-heading-m">Log start and end time</h2>
 
-    {% if isOutcomeAcceptableAbsenceStoodDown %}
-      <div class="govuk-form-group">
-        <span class="govuk-label govuk-label--s">
-          End time
-        </span>
-        <p class="govuk-body">{{ endTime }}</p>
-        <input type="hidden" name="endTime" value="{{ endTime }}">
-      </div>
-    {% else %}
-      {{ govukInput({
-        name: "endTime",
-        id: "endTime",
-        value: endTime,
-        label: {
-          text: "End time",
-          classes: "govuk-label--s"
-        },
-        classes: "govuk-input--width-3",
-        errorMessage: errors.endTime
-      }) }}
-    {% endif %}
+  {{ govukInput({
+    name: "startTime",
+    id: "startTime",
+    value: startTime,
+    label: {
+      text: "Start time",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-3",
+    errorMessage: errors.startTime
+  }) }}
 
-  {% if showPenaltyHours %}
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="penalty-time-hint">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h2 class="govuk-fieldset__heading">
-                Log penalty hours
-              </h2>
-            </legend>
-            <div id="penalty-time-hint" class="govuk-hint">
-              Enter hours and minutes, for example 1 30
-            </div>
-            <div class="govuk-date-input">
-              <div class="govuk-date-input__item">
-                {{ govukInput({
-                  label: {
-                    text: "Hours",
-                    classes: "govuk-label--s"
-                  },
-                  classes: "govuk-input--width-2",
-                  id: "penaltyTimeHours",
-                  name: "penaltyTimeHours",
-                  value: penaltyTimeHours,
-                  attributes: { readonly: "readonly", inputmode: "numeric" } if readOnlyLogHours else { inputmode: "numeric" },
-                  errorMessage: errors.penaltyTimeHours
-                }) }}
-              </div>
-              <div class="govuk-date-input__item">
-                 {{ govukInput({
-                  label: {
-                    text: "Minutes",
-                    classes: "govuk-label--s"
-                  },
-                  classes: "govuk-input--width-2",
-                  id: "penaltyTimeMinutes",
-                  name: "penaltyTimeMinutes",
-                  value: penaltyTimeMinutes,
-                  attributes: { readonly: "readonly", inputmode: "numeric" } if readOnlyLogHours else { inputmode: "numeric" },
-                  errorMessage: errors.penaltyTimeMinutes
-                }) }}
-              </div>
-            </div>
-          </fieldset>
+  {{ govukInput({
+    name: "endTime",
+    id: "endTime",
+    value: endTime,
+    label: {
+      text: "End time",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-3",
+    errorMessage: errors.endTime
+  }) }}
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" role="group" aria-describedby="penalty-time-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h2 class="govuk-fieldset__heading">
+          Log penalty hours
+        </h2>
+      </legend>
+      <div id="penalty-time-hint" class="govuk-hint">
+        Enter hours and minutes, for example 1 30
+      </div>
+      <div class="govuk-date-input">
+        <div class="govuk-date-input__item">
+          {{ govukInput({
+            label: {
+              text: "Hours",
+              classes: "govuk-label--s"
+            },
+            classes: "govuk-input--width-2",
+            id: "penaltyTimeHours",
+            name: "penaltyTimeHours",
+            value: penaltyTimeHours,
+            attributes: { readonly: "readonly", inputmode: "numeric" } if readOnlyLogHours else { inputmode: "numeric" },
+            errorMessage: errors.penaltyTimeHours
+          }) }}
         </div>
+        <div class="govuk-date-input__item">
+          {{ govukInput({
+            label: {
+              text: "Minutes",
+              classes: "govuk-label--s"
+            },
+            classes: "govuk-input--width-2",
+            id: "penaltyTimeMinutes",
+            name: "penaltyTimeMinutes",
+            value: penaltyTimeMinutes,
+            attributes: { readonly: "readonly", inputmode: "numeric" } if readOnlyLogHours else { inputmode: "numeric" },
+            errorMessage: errors.penaltyTimeMinutes
+          }) }}
+        </div>
+      </div>
+    </fieldset>
+  </div>
 
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
This page will not be shown if an outcome was not attended (or later if there is no outcome to be updated), so the logic is redundant.

[CPB-1020](https://dsdmoj.atlassian.net/browse/CPB-1020)

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1020]: https://dsdmoj.atlassian.net/browse/CPB-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ