### PR TITLE
CPB-1106: Tidy up appointment update confirm page

### DIFF
--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -67,8 +67,8 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
     /* eslint-enable no-await-in-loop */
   }
 
-  async toShowAttendanceAnswer(answer: AttendanceOutcome) {
-    await this.confirmPage.details.expect.toHaveItemWith('Attendance', answer)
+  async toShowOutcome(answer: AttendanceOutcome) {
+    await this.confirmPage.details.expect.toHaveItemWith('Outcome', answer)
   }
 
   async toShowComplianceAnswer() {

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -38,7 +38,7 @@ test('Update a session appointment', async ({ page, deliusUser, team, project, p
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
+  await confirmPage.expect.toShowOutcome('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
   await confirmPage.selectAlertPractitioner()
 

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -35,7 +35,7 @@ test('Update a session appointment with an enforceable outcome', async ({
 
   const confirmPage = new ConfirmPage(page)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Unacceptable absence')
+  await confirmPage.expect.toShowOutcome('Unacceptable absence')
   await confirmPage.expect.toShowMessageThatOutcomeWillAlert()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -41,7 +41,7 @@ test('Update a session appointment with an attended but enforceable outcome', as
   const confirmPage = new ConfirmPage(page)
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 failed to comply')
+  await confirmPage.expect.toShowOutcome('Attended \u2013 failed to comply')
   await confirmPage.expect.toShowComplianceAnswer()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -38,7 +38,7 @@ test('Update a session appointment with a not attended but not enforceable outco
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled \u2013 service request')
+  await confirmPage.expect.toShowOutcome('Rescheduled \u2013 service request')
 
   await confirmPage.confirmButtonLocator.click()
 

--- a/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
@@ -50,7 +50,7 @@ test('Bulk update a group session => attended', async ({ page, deliusUser, team,
 
   await confirmPage.expect.toShowSelectedPeople(session.peopleOnProbation)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
+  await confirmPage.expect.toShowOutcome('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
   await confirmPage.selectAlertPractitioner()
 

--- a/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
@@ -44,7 +44,7 @@ test('Bulk update a group session => not attended', async ({ page, deliusUser, t
 
   await confirmPage.expect.toShowSelectedPeople(groupSession.peopleOnProbation)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled \u2013 service request')
+  await confirmPage.expect.toShowOutcome('Rescheduled \u2013 service request')
   await confirmPage.selectAlertPractitioner()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -42,7 +42,7 @@ test('Update an individual placement appointment with attended complied', async 
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
+  await confirmPage.expect.toShowOutcome('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
 
   await confirmPage.confirmButtonLocator.click()

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -24,7 +24,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
 
   shouldShowCompletedDetails(): void {
     this.formDetails.getValueWithLabel('Supervising officer').should('contain.text', this.form.supervisor.fullName)
-    this.formDetails.getValueWithLabel('Attendance').should('contain.text', this.form.contactOutcome.name)
+    this.formDetails.getValueWithLabel('Outcome').should('contain.text', this.form.contactOutcome.name)
   }
 
   shouldShowAttendanceDetails(expectIsSensitiveAnswer: boolean): void {

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -28,7 +28,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
   }
 
   shouldShowAttendanceDetails(expectIsSensitiveAnswer: boolean): void {
-    this.formDetails.getValueWithLabel('Start and end time').should('contain.text', this.form.startTime)
+    this.formDetails
+      .getValueWithLabel('Start and end time')
+      .should('contain.text', this.form.startTime)
+      .should('contain.text', this.form.endTime)
 
     this.formDetails
       .getValueWithLabel('Compliance')
@@ -41,6 +44,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     if (expectIsSensitiveAnswer) {
       this.formDetails.getValueWithLabel('Sensitive').should('contain.text', 'Not entered')
     }
+  }
+
+  shouldShowHoursCreditedText(text: string) {
+    cy.get('p').contains('Hours credited').should('contain.text', text)
   }
 
   shouldShowAlertPractitionerMessage() {

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -25,10 +25,11 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
   shouldShowCompletedDetails(): void {
     this.formDetails.getValueWithLabel('Supervising officer').should('contain.text', this.form.supervisor.fullName)
     this.formDetails.getValueWithLabel('Attendance').should('contain.text', this.form.contactOutcome.name)
-    this.formDetails.getValueWithLabel('Start and end time').should('contain.text', this.form.startTime)
   }
 
   shouldShowAttendanceDetails(expectIsSensitiveAnswer: boolean): void {
+    this.formDetails.getValueWithLabel('Start and end time').should('contain.text', this.form.startTime)
+
     this.formDetails
       .getValueWithLabel('Compliance')
       .should(
@@ -59,6 +60,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
   }
 
   shouldNotShowAttendanceDetails(): void {
+    this.formDetails.shouldNotContainRowWithLabel('Start and end time')
     this.formDetails.shouldNotContainValueWithLabel('Compliance')
   }
 

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -128,6 +128,7 @@ context('Confirm appointment details page', () => {
     // Then I can see my submitted answers
     page.shouldShowCompletedDetails()
     page.shouldShowAttendanceDetails(true)
+    page.shouldShowHoursCreditedText('7 hours')
   })
 
   // Scenario: Confirming an appointment update - not attended

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -347,7 +347,7 @@ context('Confirm appointment details page', () => {
       cy.task('stubGetContactOutcomes', { contactOutcomes })
 
       // And I click change
-      page.clickChange('Attendance')
+      page.clickChange('Outcome')
 
       // Then I can see the log attendance page
       const attendanceOutcomePage = Page.verifyOnPage(AttendanceOutcomePage, this.appointment)

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -155,6 +155,7 @@ context('Confirm appointment details page', () => {
     // Then I can see my completed answers without attendance
     page.shouldShowCompletedDetails()
     page.shouldNotShowAttendanceDetails()
+    page.shouldShowHoursCreditedText('0')
   })
 
   // Scenario: alerting the probation practitioner

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -93,6 +93,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       page.shouldNotShowSensitiveQuestion()
       page.shouldShowSelectedPeople(this.appointments)
       page.shouldNotShowSelectedPeople([this.unselectedAppointment])
+      page.shouldShowHoursCreditedText('7 hours')
     })
 
     describe('navigating back via change links', () => {

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -115,7 +115,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
 
         const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
 
-        page.clickChange('Attendance')
+        page.clickChange('Outcome')
 
         Page.verifyOnPage(AttendanceOutcomePage, this.session)
       })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -254,21 +254,10 @@ describe('ConfirmPage', () => {
               ],
             },
           },
-          {
-            key: {
-              text: 'Start and end time',
-            },
-            value: {
-              html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
-            },
-            actions: {
-              items: [],
-            },
-          },
         ])
       })
 
-      it('should record logged hours for attendance outcomes', async () => {
+      it('should display start and end time with logged hours for attendance outcomes', async () => {
         const hours = '8 hours'
         jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
 
@@ -293,30 +282,6 @@ describe('ConfirmPage', () => {
                   visuallyHiddenText: 'start and end time',
                 },
               ],
-            },
-          }),
-        )
-      })
-
-      it('should record no logged hours for non-attendance outcomes', async () => {
-        const hours = '0'
-        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
-
-        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-        })
-        const result = page.viewData(appointment, submitted)
-        expect(result.submittedItems).toContainEqual(
-          expect.objectContaining({
-            key: {
-              text: 'Start and end time',
-            },
-            value: {
-              html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
-            },
-            actions: {
-              items: [],
             },
           }),
         )
@@ -592,36 +557,6 @@ describe('ConfirmPage', () => {
             value: { html: '' },
           }),
         )
-      })
-
-      it('should contain start and end time item when appointmentOrSession is a session and contact outcome is attended', () => {
-        const session = sessionFactory.build()
-        const hours = '8 hours'
-        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
-
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: true, enforceable: false }),
-        })
-
-        const result = page.viewData(session, submitted)
-
-        expect(result.submittedItems).toContainEqual({
-          key: {
-            text: 'Start and end time',
-          },
-          value: {
-            html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
-          },
-          actions: {
-            items: [
-              {
-                href: pathWithQuery,
-                text: 'Change',
-                visuallyHiddenText: 'start and end time',
-              },
-            ],
-          },
-        })
       })
     })
   })

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -205,7 +205,7 @@ describe('ConfirmPage', () => {
           },
           {
             key: {
-              text: 'Attendance',
+              text: 'Outcome',
             },
             value: {
               html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
@@ -287,7 +287,7 @@ describe('ConfirmPage', () => {
         )
       })
 
-      it('should contain attendance item with contact outcome name when outcome is attended', () => {
+      it('should contain "Outcome" item with contact outcome name when outcome is attended', () => {
         const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const submitted = appointmentOutcomeFormFactory.build({
           contactOutcome,
@@ -298,7 +298,7 @@ describe('ConfirmPage', () => {
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
             key: {
-              text: 'Attendance',
+              text: 'Outcome',
             },
             value: {
               text: submitted.contactOutcome.name,
@@ -520,7 +520,7 @@ describe('ConfirmPage', () => {
           },
           {
             key: {
-              text: 'Attendance',
+              text: 'Outcome',
             },
             value: {
               html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -272,7 +272,7 @@ describe('ConfirmPage', () => {
               text: 'Start and end time',
             },
             value: {
-              html: `09:00 - 17:00<br>Total hours worked: ${hours}`,
+              html: `<p>09:00 - 17:00</p><p>Hours credited: ${hours}</p>`,
             },
             actions: {
               items: [

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -172,7 +172,7 @@ describe('ConfirmPage', () => {
         jest.restoreAllMocks()
       })
 
-      it('should return an object containing summary list items', async () => {
+      it('should return an object containing summary list items for non attended outcome', async () => {
         const hours = '0'
         jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
         jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Not entered')
@@ -208,7 +208,7 @@ describe('ConfirmPage', () => {
               text: 'Attendance',
             },
             value: {
-              text: submitted.contactOutcome.name,
+              html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
             },
             actions: {
               items: [
@@ -280,6 +280,35 @@ describe('ConfirmPage', () => {
                   href: pathWithQuery,
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
+                },
+              ],
+            },
+          }),
+        )
+      })
+
+      it('should contain attendance item with contact outcome name when outcome is attended', () => {
+        const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
+        const submitted = appointmentOutcomeFormFactory.build({
+          contactOutcome,
+        })
+
+        const result = page.viewData(appointment, submitted)
+
+        expect(result.submittedItems).toContainEqual(
+          expect.objectContaining({
+            key: {
+              text: 'Attendance',
+            },
+            value: {
+              text: submitted.contactOutcome.name,
+            },
+            actions: {
+              items: [
+                {
+                  href: pathWithQuery,
+                  text: 'Change',
+                  visuallyHiddenText: 'attendance outcome',
                 },
               ],
             },
@@ -425,7 +454,7 @@ describe('ConfirmPage', () => {
         })
       })
 
-      it('should return submittedItems with session change links when appointmentOrSession is a session', () => {
+      it('should return submittedItems with session change links when appointmentOrSession is a session and outcome is not attended', () => {
         const summaryOne = appointmentSummaryFactory.build({
           offender: offenderFullFactory.build({ forename: 'Alex', surname: 'Smith', crn: 'CRN001' }),
         })
@@ -494,7 +523,7 @@ describe('ConfirmPage', () => {
               text: 'Attendance',
             },
             value: {
-              text: submitted.contactOutcome.name,
+              html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
             },
             actions: {
               items: [

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -118,7 +118,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       },
       {
         key: {
-          text: 'Attendance',
+          text: 'Outcome',
         },
         value: this.outcomeValue(form.contactOutcome),
         actions: {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -82,7 +82,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
 
   private getStartAndEndTime(form: AppointmentOutcomeForm) {
     const { startTime, endTime } = form
-    const hours = !form.contactOutcome.attended ? 0 : DateTimeFormats.timeBetween(startTime, endTime)
+    const hours = DateTimeFormats.timeBetween(startTime, endTime)
 
     return `${DateTimeFormats.stripTime(startTime)} - ${DateTimeFormats.stripTime(endTime)}<br>Total hours worked: ${hours}`
   }
@@ -133,46 +133,45 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
       ),
     ]
 
-    if (form.contactOutcome.attended || this.isSingleAppointment(appointment)) {
-      items.push({
-        key: {
-          text: 'Start and end time',
-        },
-        value: {
-          html: this.getStartAndEndTime(form),
-        },
-        actions: {
-          items: form.contactOutcome.attended
-            ? [
+    if (form.contactOutcome?.attended) {
+      items.push(
+        ...[
+          {
+            key: {
+              text: 'Start and end time',
+            },
+            value: {
+              html: this.getStartAndEndTime(form),
+            },
+            actions: {
+              items: [
                 {
                   href: this.changePath(appointment, 'log-hours'),
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
                 },
-              ]
-            : [],
-        },
-      })
-    }
-
-    if (form.contactOutcome.attended) {
-      items.push({
-        key: {
-          text: 'Compliance',
-        },
-        value: {
-          html: this.getComplianceAnswers(form),
-        },
-        actions: {
-          items: [
-            {
-              href: this.changePath(appointment, 'log-compliance'),
-              text: 'Change',
-              visuallyHiddenText: 'compliance',
+              ],
             },
-          ],
-        },
-      })
+          },
+          {
+            key: {
+              text: 'Compliance',
+            },
+            value: {
+              html: this.getComplianceAnswers(form),
+            },
+            actions: {
+              items: [
+                {
+                  href: this.changePath(appointment, 'log-compliance'),
+                  text: 'Change',
+                  visuallyHiddenText: 'compliance',
+                },
+              ],
+            },
+          },
+        ],
+      )
     }
 
     return items

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -131,12 +131,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           ],
         },
       },
-      ...NotesUtils.checkYourAnswersRows(
-        form,
-        this.changePath(appointment, 'attendance-outcome'),
-        isSingleAppointment ? appointment : undefined,
-        isSingleAppointment,
-      ),
     ]
 
     if (form.contactOutcome?.attended) {
@@ -179,6 +173,15 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         ],
       )
     }
+
+    items.push(
+      ...NotesUtils.checkYourAnswersRows(
+        form,
+        this.changePath(appointment, 'attendance-outcome'),
+        isSingleAppointment ? appointment : undefined,
+        isSingleAppointment,
+      ),
+    )
 
     return items
   }

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
@@ -120,9 +120,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         key: {
           text: 'Attendance',
         },
-        value: {
-          text: form.contactOutcome?.name,
-        },
+        value: this.outcomeValue(form.contactOutcome),
         actions: {
           items: [
             {
@@ -183,6 +181,16 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     }
 
     return items
+  }
+
+  private outcomeValue(contactOutcome?: ContactOutcomeDto) {
+    if (contactOutcome?.attended) {
+      return { text: contactOutcome?.name }
+    }
+
+    return {
+      html: HtmlUtils.getElementsWithContent([contactOutcome?.name, this.hoursCreditedText('0')], 'p'),
+    }
   }
 
   buildOffenderItem(

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -13,6 +13,7 @@ import Offender from '../../models/offender'
 import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+import HtmlUtils from '../../utils/htmlUtils'
 import NotesUtils from '../../utils/notesUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
@@ -84,7 +85,14 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     const { startTime, endTime } = form
     const hours = DateTimeFormats.timeBetween(startTime, endTime)
 
-    return `${DateTimeFormats.stripTime(startTime)} - ${DateTimeFormats.stripTime(endTime)}<br>Total hours worked: ${hours}`
+    return HtmlUtils.getElementsWithContent(
+      [DateTimeFormats.timePeriod(startTime, endTime), this.hoursCreditedText(hours)],
+      'p',
+    )
+  }
+
+  private hoursCreditedText(hours: string) {
+    return `Hours credited: ${hours}`
   }
 
   private formItems(form: AppointmentOutcomeForm, appointment: AppointmentOrSession): GovUkSummaryListItem[] {

--- a/server/utils/htmlUtils.test.ts
+++ b/server/utils/htmlUtils.test.ts
@@ -22,6 +22,20 @@ describe('HTMLUtils', () => {
     })
   })
 
+  describe('getElementsWithContent', () => {
+    it('wraps all items in the specified element when element is p', () => {
+      const result = HtmlUtils.getElementsWithContent(['First item', 'Second item'], 'p')
+
+      expect(result).toEqual('<p>First item</p><p>Second item</p>')
+    })
+
+    it('wraps all items in div elements when no element parameter is provided', () => {
+      const result = HtmlUtils.getElementsWithContent(['First item', 'Second item'])
+
+      expect(result).toEqual('<div>First item</div><div>Second item</div>')
+    })
+  })
+
   describe('getHiddenText', () => {
     it('returns an element with the govuk hidden class containing given content', () => {
       const result = HtmlUtils.getHiddenText('Some content')

--- a/server/utils/htmlUtils.ts
+++ b/server/utils/htmlUtils.ts
@@ -9,6 +9,10 @@ export default class HtmlUtils {
     return `<${element}>${text}</${element}>`
   }
 
+  static getElementsWithContent(items: Array<string>, element: string = 'div'): string {
+    return items.map(item => HtmlUtils.getElementWithContent(item, element)).join('')
+  }
+
   static getHiddenText = (text: string): string => {
     return `<span class="govuk-visually-hidden">${text}</span>`
   }


### PR DESCRIPTION
## Context

When we removed the 'Penalty hours' question, we lost the concept of 'Hours credited' on the confirm page. This reintroduces that by rewording 'hours worked' to 'credited' as this will now always be the credited time.

Also, hiding start and end time in the case of non-attendance, as this question is not shown, and this row is already hidden for bulk updates. In this case, we move 'Hours credited' to the 'Outcome' row, as 0 hours credited is a direct result of selecting a non-attendance outcome. 

[CPB-1106](https://dsdmoj.atlassian.net/browse/CPB-1106)

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

For an attended outcome, show credited hours next to start and end time:
<img width="1554" height="960" alt="Appointment confirm page with 4 hours credited" src="https://github.com/user-attachments/assets/69d54a4a-b9eb-4cf5-9581-d437aad1c272" />

For a non-attended outcome, show credited hours next to outcome:
<img width="1512" height="958" alt="Appointment confirm page with 0 hours credited" src="https://github.com/user-attachments/assets/25d16a2d-59d2-4142-a405-867682672b89" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1106]: https://dsdmoj.atlassian.net/browse/CPB-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ