### PR TITLE
CPB-976: Use single date search with a date picker

### DIFF
--- a/e2e-tests/pages/groupSessionPage.ts
+++ b/e2e-tests/pages/groupSessionPage.ts
@@ -14,12 +14,6 @@ export default class GroupSessionPage extends BasePage {
 
   readonly fromYearFieldLocator: Locator
 
-  readonly toDayFieldLocator: Locator
-
-  readonly toMonthFieldLocator: Locator
-
-  readonly toYearFieldLocator: Locator
-
   readonly results: DataTableComponent
 
   readonly teamFilter: TeamFilterComponent
@@ -28,12 +22,9 @@ export default class GroupSessionPage extends BasePage {
     super(page)
     this.expect = new GroupSessionPageAssertions(this)
     this.teamFilter = new TeamFilterComponent(page)
-    this.fromDayFieldLocator = page.getByLabel('day').nth(0)
-    this.fromMonthFieldLocator = page.getByLabel('month').nth(0)
-    this.fromYearFieldLocator = page.getByLabel('year').nth(0)
-    this.toDayFieldLocator = page.getByLabel('day').nth(1)
-    this.toMonthFieldLocator = page.getByLabel('month').nth(1)
-    this.toYearFieldLocator = page.getByLabel('year').nth(1)
+    this.fromDayFieldLocator = page.getByLabel('day')
+    this.fromMonthFieldLocator = page.getByLabel('month')
+    this.fromYearFieldLocator = page.getByLabel('year')
     this.results = new DataTableComponent(page)
   }
 
@@ -47,13 +38,10 @@ export default class GroupSessionPage extends BasePage {
     await row.getByRole('link', { name: projectName }).click()
   }
 
-  async completeSearchForm(fromDate: Date, toDate: Date) {
+  async completeSearchForm(fromDate: Date) {
     await this.fromDayFieldLocator.fill(fromDate.getDate().toString())
     await this.fromMonthFieldLocator.fill((fromDate.getMonth() + 1).toString().padStart(2, '0'))
     await this.fromYearFieldLocator.fill(fromDate.getFullYear().toString())
-    await this.toDayFieldLocator.fill(toDate.getDate().toString().padStart(2, '0'))
-    await this.toMonthFieldLocator.fill((toDate.getMonth() + 1).toString().padStart(2, '0'))
-    await this.toYearFieldLocator.fill(toDate.getFullYear().toString())
   }
 
   async submitForm() {

--- a/e2e-tests/pages/groupSessionPage.ts
+++ b/e2e-tests/pages/groupSessionPage.ts
@@ -8,11 +8,7 @@ import TeamFilterComponent from './components/teamFilterComponent'
 export default class GroupSessionPage extends BasePage {
   readonly expect: GroupSessionPageAssertions
 
-  readonly fromDayFieldLocator: Locator
-
-  readonly fromMonthFieldLocator: Locator
-
-  readonly fromYearFieldLocator: Locator
+  readonly dateFieldLocator: Locator
 
   readonly results: DataTableComponent
 
@@ -22,9 +18,7 @@ export default class GroupSessionPage extends BasePage {
     super(page)
     this.expect = new GroupSessionPageAssertions(this)
     this.teamFilter = new TeamFilterComponent(page)
-    this.fromDayFieldLocator = page.getByLabel('day')
-    this.fromMonthFieldLocator = page.getByLabel('month')
-    this.fromYearFieldLocator = page.getByLabel('year')
+    this.dateFieldLocator = page.getByLabel('Date')
     this.results = new DataTableComponent(page)
   }
 
@@ -39,9 +33,10 @@ export default class GroupSessionPage extends BasePage {
   }
 
   async completeSearchForm(fromDate: Date) {
-    await this.fromDayFieldLocator.fill(fromDate.getDate().toString())
-    await this.fromMonthFieldLocator.fill((fromDate.getMonth() + 1).toString().padStart(2, '0'))
-    await this.fromYearFieldLocator.fill(fromDate.getFullYear().toString())
+    const day = fromDate.getDate().toString()
+    const month = (fromDate.getMonth() + 1).toString()
+    const year = fromDate.getFullYear().toString()
+    await this.dateFieldLocator.fill(`${day}/${month}/${year}`)
   }
 
   async submitForm() {

--- a/e2e-tests/steps/searchForASession.ts
+++ b/e2e-tests/steps/searchForASession.ts
@@ -3,13 +3,7 @@ import GroupSessionPage from '../pages/groupSessionPage'
 import HomePage from '../pages/homePage'
 import { Team } from '../fixtures/testOptions'
 
-export default async (
-  page: Page,
-  homePage: HomePage,
-  team: Team,
-  startDate: Date = new Date(),
-  endDate: Date = new Date(),
-) => {
+export default async (page: Page, homePage: HomePage, team: Team, startDate: Date = new Date()) => {
   const groupSessionPage = new GroupSessionPage(page)
 
   await homePage.trackCommunityPaybackProgressLink.click()
@@ -17,7 +11,7 @@ export default async (
 
   await groupSessionPage.teamFilter.selectRegion(team)
   await groupSessionPage.teamFilter.selectTeam(team)
-  await groupSessionPage.completeSearchForm(startDate, endDate)
+  await groupSessionPage.completeSearchForm(startDate)
   await groupSessionPage.submitForm()
   return groupSessionPage
 }

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -52,13 +52,7 @@ test('Update a session appointment with an enforceable outcome', async ({
 
   await homePage.visit()
   const rescheduledAppointmentDate = DateTimeUtils.plusDays(new Date(), 7)
-  const rescheduledSessionsPage = await searchForASession(
-    page,
-    homePage,
-    team,
-    rescheduledAppointmentDate,
-    rescheduledAppointmentDate,
-  )
+  const rescheduledSessionsPage = await searchForASession(page, homePage, team, rescheduledAppointmentDate)
   await rescheduledSessionsPage.expect.toSeeResults()
 
   const rescheduledSessionPage = await selectASession(page, groupSessionPage, project.name)

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -54,13 +54,7 @@ test('Update a session appointment with a not attended but not enforceable outco
 
   await homePage.visit()
   const rescheduledAppointmentDate = DateTimeUtils.plusDays(new Date(), 7)
-  const rescheduledSessionsPage = await searchForASession(
-    page,
-    homePage,
-    team,
-    rescheduledAppointmentDate,
-    rescheduledAppointmentDate,
-  )
+  const rescheduledSessionsPage = await searchForASession(page, homePage, team, rescheduledAppointmentDate)
   await rescheduledSessionsPage.expect.toSeeResults()
 
   const rescheduledSessionPage = await selectASession(page, groupSessionPage, project.name)

--- a/e2e-tests/tests/javascript-fallbacks/01_search_for_sessions.spec.ts
+++ b/e2e-tests/tests/javascript-fallbacks/01_search_for_sessions.spec.ts
@@ -19,7 +19,7 @@ test.describe('Without javascript', () => {
     await groupSessionPage.teamFilter.selectRegion(team)
     await groupSessionPage.teamFilter.applyButtonLocator.click()
     await groupSessionPage.teamFilter.selectTeam(team)
-    await groupSessionPage.completeSearchForm(new Date(), new Date())
+    await groupSessionPage.completeSearchForm(new Date())
     await groupSessionPage.submitForm()
 
     await groupSessionPage.expect.toSeeResults()

--- a/integration_tests/pages/components/datatableComponent.ts
+++ b/integration_tests/pages/components/datatableComponent.ts
@@ -1,7 +1,16 @@
 export default class DataTableComponent {
+  private readonly locator = 'table'
+
+  constructor(private readonly identifier: string = undefined) {}
+
+  private component() {
+    return this.identifier ? cy.get(this.locator).filter(`:contains(${this.identifier})`) : cy.get(this.locator)
+  }
+
   shouldHaveRowsWithContent(rowData: Array<Array<string | number>>) {
     rowData.forEach((row: Array<string>, rowIndex: number) => {
-      cy.get('tr')
+      this.component()
+        .find('tr')
         .eq(rowIndex + 1)
         .within(() => {
           row.forEach((value: string, i: number) => {

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -3,11 +3,14 @@ import paths from '../../server/paths'
 import { ProviderSummaryDto, ProviderTeamSummaryDto, SessionSummaryDto } from '../../server/@types/shared'
 import SelectInput from './components/selectComponent'
 import DateTimeFormats from '../../server/utils/dateTimeUtils'
+import DataTableComponent from './components/datatableComponent'
 
 export default class FindASessionPage extends Page {
   regionSelect = new SelectInput('provider')
 
   teamSelect = new SelectInput('team')
+
+  resultsTable = new DataTableComponent('Project')
 
   constructor() {
     super('Find a group session')
@@ -55,12 +58,16 @@ export default class FindASessionPage extends Page {
   }
 
   shouldShowSearchResults(result: SessionSummaryDto) {
-    cy.get('td').eq(0).should('contain.text', result.projectName)
-    cy.get('td').eq(0).should('contain.text', result.projectCode)
-    cy.get('td').eq(1).should('have.text', DateTimeFormats.isoDateToUIDate(result.date))
-    cy.get('td').eq(2).should('have.text', result.numberOfOffendersAllocated)
-    cy.get('td').eq(3).should('have.text', result.numberOfOffendersWithOutcomes)
-    cy.get('td').eq(4).should('have.text', result.numberOfOffendersWithEA)
+    const expected = [
+      [
+        `${result.projectName}${result.projectCode}`,
+        DateTimeFormats.isoDateToUIDate(result.date),
+        result.numberOfOffendersAllocated,
+        result.numberOfOffendersWithOutcomes,
+        result.numberOfOffendersWithEA,
+      ],
+    ]
+    this.resultsTable.shouldHaveRowsWithContent(expected)
   }
 
   shouldShowPopulatedSearchForm() {

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -24,13 +24,11 @@ export default class FindASessionPage extends Page {
     cy.get('h2').contains('Filter group sessions')
     cy.get('label').contains('Region')
     cy.get('label').contains('Project team')
-    cy.get('legend').contains('Date')
+    cy.get('label').contains('Date')
   }
 
   enterDate() {
-    cy.get('#date-day').type('18')
-    cy.get('#date-month').type('09')
-    cy.get('#date-year').type('2025')
+    cy.get('#date').type('18/9/2025')
   }
 
   selectRegion(provider: ProviderSummaryDto) {
@@ -70,10 +68,8 @@ export default class FindASessionPage extends Page {
     this.resultsTable.shouldHaveRowsWithContent(expected)
   }
 
-  shouldShowPopulatedSearchForm() {
-    cy.get('#date-day').should('have.value', '18')
-    cy.get('#date-month').should('have.value', '09')
-    cy.get('#date-year').should('have.value', '2025')
+  shouldShowPopulatedDate(date: string = '18/9/2025') {
+    cy.get('#date').should('have.value', date)
   }
 
   shouldShowErrorSummary() {
@@ -82,12 +78,6 @@ export default class FindASessionPage extends Page {
 
   shouldShowNoResultsMessage() {
     cy.get('h2').should('contain.text', 'No results')
-  }
-
-  shouldHavePaddedStartDateValue() {
-    cy.get('#date-day').should('have.value', '18')
-    cy.get('#date-month').should('have.value', '09')
-    cy.get('#date-year').should('have.value', '2025')
   }
 
   shouldShowRegion(name: string) {

--- a/integration_tests/pages/findASessionPage.ts
+++ b/integration_tests/pages/findASessionPage.ts
@@ -21,23 +21,13 @@ export default class FindASessionPage extends Page {
     cy.get('h2').contains('Filter group sessions')
     cy.get('label').contains('Region')
     cy.get('label').contains('Project team')
-    cy.get('legend').contains('From')
-    cy.get('legend').contains('To')
+    cy.get('legend').contains('Date')
   }
 
-  completeSearchForm() {
-    cy.get('#startDate-day').type('18')
-    cy.get('#startDate-month').type('09')
-    cy.get('#startDate-year').type('2025')
-    cy.get('#endDate-day').type('20')
-    cy.get('#endDate-month').type('09')
-    cy.get('#endDate-year').type('2025')
-  }
-
-  completeStartDate() {
-    cy.get('#startDate-day').type('18')
-    cy.get('#startDate-month').type('9')
-    cy.get('#startDate-year').type('2025')
+  enterDate() {
+    cy.get('#date-day').type('18')
+    cy.get('#date-month').type('09')
+    cy.get('#date-year').type('2025')
   }
 
   selectRegion(provider: ProviderSummaryDto) {
@@ -74,18 +64,13 @@ export default class FindASessionPage extends Page {
   }
 
   shouldShowPopulatedSearchForm() {
-    cy.get('#startDate-day').should('have.value', '18')
-    cy.get('#startDate-month').should('have.value', '09')
-    cy.get('#startDate-year').should('have.value', '2025')
-    cy.get('#endDate-day').should('have.value', '20')
-    cy.get('#endDate-month').should('have.value', '09')
-    cy.get('#endDate-year').should('have.value', '2025')
+    cy.get('#date-day').should('have.value', '18')
+    cy.get('#date-month').should('have.value', '09')
+    cy.get('#date-year').should('have.value', '2025')
   }
 
   shouldShowErrorSummary() {
-    cy.get('.govuk-error-summary__list')
-      .find('a[href="#endDate-day"]')
-      .should('have.text', 'To date must include a day, month and year')
+    cy.get('.govuk-error-summary__list').find('a[href="#team"]').should('have.text', 'Choose a team')
   }
 
   shouldShowNoResultsMessage() {
@@ -93,9 +78,9 @@ export default class FindASessionPage extends Page {
   }
 
   shouldHavePaddedStartDateValue() {
-    cy.get('#startDate-day').should('have.value', '18')
-    cy.get('#startDate-month').should('have.value', '09')
-    cy.get('#startDate-year').should('have.value', '2025')
+    cy.get('#date-day').should('have.value', '18')
+    cy.get('#date-month').should('have.value', '09')
+    cy.get('#date-year').should('have.value', '2025')
   }
 
   shouldShowRegion(name: string) {

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -238,12 +238,9 @@ context('Session details', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'startDate-day': '18',
-        'startDate-month': '09',
-        'startDate-year': '2025',
-        'endDate-day': '20',
-        'endDate-month': '09',
-        'endDate-year': '2025',
+        'date-day': '18',
+        'date-month': '09',
+        'date-year': '2025',
       }
       // Given I am on an appointment 'check your details' page
       const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, originalSearch)
@@ -263,7 +260,7 @@ context('Session details', () => {
           providerCode: provider.code,
           teamCode: team.code,
           startDate: '2025-09-18',
-          endDate: '2025-09-20',
+          endDate: '2025-09-18',
           username: 'some-name',
         },
         sessions: {

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -238,9 +238,7 @@ context('Session details', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'date-day': '18',
-        'date-month': '09',
-        'date-year': '2025',
+        date: '18/09/2025',
       }
       // Given I am on an appointment 'check your details' page
       const page = CheckAppointmentDetailsPage.visit(this.appointment, this.project, originalSearch)

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -437,9 +437,7 @@ context('Confirm appointment details page', () => {
       const provider = providerSummaryFactory.build()
       const team = providerTeamSummaryFactory.build()
       const originalSearch = {
-        'date-day': '18',
-        'date-month': '09',
-        'date-year': '2025',
+        date: '18/09/2025',
         provider: provider.code,
         team: team.code,
       }

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -437,12 +437,9 @@ context('Confirm appointment details page', () => {
       const provider = providerSummaryFactory.build()
       const team = providerTeamSummaryFactory.build()
       const originalSearch = {
-        'startDate-day': '18',
-        'startDate-month': '09',
-        'startDate-year': '2025',
-        'endDate-day': '20',
-        'endDate-month': '09',
-        'endDate-year': '2025',
+        'date-day': '18',
+        'date-month': '09',
+        'date-year': '2025',
         provider: provider.code,
         team: team.code,
       }
@@ -493,7 +490,7 @@ context('Confirm appointment details page', () => {
           providerCode: provider.code,
           teamCode: team.code,
           startDate: '2025-09-18',
-          endDate: '2025-09-20',
+          endDate: '2025-09-18',
           username: 'some-name',
         },
         sessions: {

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -167,9 +167,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'date-day': '18',
-        'date-month': '09',
-        'date-year': '2025',
+        date: '18/09/2025',
       }
 
       const form = appointmentOutcomeFormFactory.build({

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -167,12 +167,9 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'startDate-day': '18',
-        'startDate-month': '09',
-        'startDate-year': '2025',
-        'endDate-day': '20',
-        'endDate-month': '09',
-        'endDate-year': '2025',
+        'date-day': '18',
+        'date-month': '09',
+        'date-year': '2025',
       }
 
       const form = appointmentOutcomeFormFactory.build({
@@ -203,7 +200,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
           providerCode: provider.code,
           teamCode: team.code,
           startDate: '2025-09-18',
-          endDate: '2025-09-20',
+          endDate: '2025-09-18',
           username: 'some-name',
         },
         sessions: {

--- a/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
@@ -74,12 +74,9 @@ context('Group Session Bulk Update - Bulk Update', () => {
         originalSearch: {
           provider: provider.code,
           team: team.code,
-          'startDate-day': '18',
-          'startDate-month': '09',
-          'startDate-year': '2025',
-          'endDate-day': '20',
-          'endDate-month': '09',
-          'endDate-year': '2025',
+          'date-day': '18',
+          'date-month': '09',
+          'date-year': '2025',
         },
       })
 
@@ -97,7 +94,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
           providerCode: provider.code,
           teamCode: team.code,
           startDate: '2025-09-18',
-          endDate: '2025-09-20',
+          endDate: '2025-09-18',
           username: 'some-name',
         },
         sessions: {
@@ -158,12 +155,9 @@ context('Group Session Bulk Update - Bulk Update', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'startDate-day': '18',
-        'startDate-month': '09',
-        'startDate-year': '2025',
-        'endDate-day': '20',
-        'endDate-month': '09',
-        'endDate-year': '2025',
+        'date-day': '18',
+        'date-month': '09',
+        'date-year': '2025',
       }
 
       const sessionSummary = sessionSummaryFactory.build({
@@ -179,7 +173,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
           providerCode: provider.code,
           teamCode: team.code,
           startDate: '2025-09-18',
-          endDate: '2025-09-20',
+          endDate: '2025-09-18',
           username: 'some-name',
         },
         sessions: {

--- a/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
@@ -74,9 +74,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
         originalSearch: {
           provider: provider.code,
           team: team.code,
-          'date-day': '18',
-          'date-month': '09',
-          'date-year': '2025',
+          date: '18/09/2025',
         },
       })
 
@@ -109,7 +107,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
       viewSessionPage.clickBack()
 
       const findASessionPage = Page.verifyOnPage(FindASessionPage)
-      findASessionPage.shouldShowPopulatedSearchForm()
+      findASessionPage.shouldShowPopulatedDate('18/09/2025')
       findASessionPage.shouldShowSearchResults(sessionSummary)
     })
   })
@@ -155,9 +153,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
       const originalSearch = {
         provider: provider.code,
         team: team.code,
-        'date-day': '18',
-        'date-month': '09',
-        'date-year': '2025',
+        date: '18/09/2025',
       }
 
       const sessionSummary = sessionSummaryFactory.build({
@@ -191,7 +187,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
       viewSessionPage.clickBack()
 
       const findASessionPage = Page.verifyOnPage(FindASessionPage)
-      findASessionPage.shouldShowPopulatedSearchForm()
+      findASessionPage.shouldShowPopulatedDate('18/09/2025')
       findASessionPage.shouldShowSearchResults(sessionSummary)
     })
   })

--- a/integration_tests/tests/group-sessions/findASession.cy.ts
+++ b/integration_tests/tests/group-sessions/findASession.cy.ts
@@ -115,7 +115,7 @@ context('Home', () => {
     // And I complete the search form
     page.selectRegion(provider)
     page.selectTeam(teams[0])
-    page.completeSearchForm()
+    page.enterDate()
     page.selectTeam(team)
 
     const sessionSummary = sessionSummaryFactory.build({ date })
@@ -126,7 +126,7 @@ context('Home', () => {
         providerCode: provider.code,
         teamCode: team.code,
         startDate: '2025-09-18',
-        endDate: '2025-09-20',
+        endDate: '2025-09-18',
         username: 'some-name',
       },
       sessions: {
@@ -153,7 +153,7 @@ context('Home', () => {
     // When I complete the search form
     page.selectRegion(provider)
     page.selectTeam(teams[0])
-    page.completeSearchForm()
+    page.enterDate()
     page.selectTeam(team)
 
     let summaries = sessionSummaryFactory.buildList(20)
@@ -164,7 +164,7 @@ context('Home', () => {
       providerCode: provider.code,
       teamCode: team.code,
       startDate: '2025-09-18',
-      endDate: '2025-09-20',
+      endDate: '2025-09-18',
       username: 'some-name',
     }
 
@@ -220,7 +220,7 @@ context('Home', () => {
     page.selectRegion(provider)
     page.selectTeam(team)
 
-    page.completeSearchForm()
+    page.enterDate()
 
     // And there are no results
     cy.task('stubGetSessions', {
@@ -228,7 +228,7 @@ context('Home', () => {
         providerCode: provider.code,
         teamCode: team.code,
         startDate: '2025-09-18',
-        endDate: '2025-09-20',
+        endDate: '2025-09-18',
         username: 'some-name',
       },
       sessions: {
@@ -265,11 +265,11 @@ context('Home', () => {
     const page = Page.verifyOnPage(FindASessionPage)
     page.selectRegion(provider)
     page.selectTeam(team)
-    page.completeSearchForm()
+    page.enterDate()
 
     //  When I search for a session
     cy.task('stubGetSessions', {
-      request: { providerCode, teamCode, startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
+      request: { providerCode, teamCode, startDate: '2025-09-18', endDate: '2025-09-18', username: 'some-name' },
       sessions: {
         content: [sessionSummary],
       },
@@ -292,8 +292,6 @@ context('Home', () => {
 
   //  Scenario: displaying error summary
   it('displays an error summary when form submission fails', () => {
-    const [team] = teams
-
     // Given I am logged in
     cy.signIn()
 
@@ -303,8 +301,7 @@ context('Home', () => {
 
     // And I only input the start date
     page.selectRegion(provider)
-    page.selectTeam(team)
-    page.completeStartDate()
+    page.enterDate()
 
     // And I search for sessions
     page.submitForm()
@@ -338,10 +335,10 @@ context('Home', () => {
     const page = Page.verifyOnPage(FindASessionPage)
     page.selectRegion(provider)
     page.selectTeam(team)
-    page.completeSearchForm()
+    page.enterDate()
 
     cy.task('stubGetSessions', {
-      request: { providerCode, teamCode, startDate: '2025-09-18', endDate: '2025-09-20', username: 'some-name' },
+      request: { providerCode, teamCode, startDate: '2025-09-18', endDate: '2025-09-18', username: 'some-name' },
       sessions: {
         content: [sessionSummary],
       },
@@ -379,7 +376,7 @@ context('Home', () => {
     page.shouldShowRegion(provider.name)
     page.selectTeam(team)
 
-    page.completeSearchForm()
+    page.enterDate()
 
     const sessionSummary = sessionSummaryFactory.build({ date })
 
@@ -389,7 +386,7 @@ context('Home', () => {
         providerCode: provider.code,
         teamCode: team.code,
         startDate: '2025-09-18',
-        endDate: '2025-09-20',
+        endDate: '2025-09-18',
         username: 'some-name',
       },
       sessions: {

--- a/integration_tests/tests/group-sessions/findASession.cy.ts
+++ b/integration_tests/tests/group-sessions/findASession.cy.ts
@@ -137,7 +137,7 @@ context('Home', () => {
 
     //  Then I see the search results
     page.shouldShowSearchResults(sessionSummary)
-    page.shouldShowPopulatedSearchForm()
+    page.shouldShowPopulatedDate()
   })
 
   // Scenario: navigating through paginated results
@@ -205,7 +205,7 @@ context('Home', () => {
 
     // Then I see the next page of results
     page.shouldShowSearchResults(sessionSummary)
-    page.shouldShowPopulatedSearchForm()
+    page.shouldShowPopulatedDate()
   })
 
   // Scenario: search returns no results
@@ -308,7 +308,7 @@ context('Home', () => {
 
     // Then I see the error summary
     page.shouldShowErrorSummary()
-    page.shouldHavePaddedStartDateValue()
+    page.shouldShowPopulatedDate()
   })
 
   // Scenario: returning to search from a session
@@ -358,7 +358,7 @@ context('Home', () => {
     sessionDetailsPage.clickBack()
 
     // Then I see the session list
-    page.shouldShowPopulatedSearchForm()
+    page.shouldShowPopulatedDate()
     page.shouldShowSearchResults(sessionSummary)
   })
 
@@ -398,7 +398,7 @@ context('Home', () => {
     //  Then I see the search results
     page.shouldShowRegion(provider.name)
     page.shouldShowSearchResults(sessionSummary)
-    page.shouldShowPopulatedSearchForm()
+    page.shouldShowPopulatedDate()
   })
 
   // Scenario: Refreshing teams when the session has expired

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -64,7 +64,7 @@ describe('SessionsController', () => {
       return {
         validationErrors: () => ({}),
         items: () => ({
-          dateItems: [] as GovUkFrontendDateInputItem[],
+          date: [] as GovUkFrontendDateInputItem[],
         }),
         searchValues: () => ({
           startDate: '2025-12-27',
@@ -106,7 +106,7 @@ describe('SessionsController', () => {
       pageMock.mockImplementation(() => ({
         validationErrors: () => errors,
         items: () => ({
-          dateItems: [] as GovUkFrontendDateInputItem[],
+          date: [] as GovUkFrontendDateInputItem[],
         }),
       }))
       const requestHandler = sessionsController.search()
@@ -121,7 +121,7 @@ describe('SessionsController', () => {
       await requestHandler(req, response, next)
 
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
-        form: { ...providersAndTeams, dateItems: [] },
+        form: { ...providersAndTeams, date: [] },
         errors,
         errorSummary: [
           expect.objectContaining({
@@ -156,7 +156,7 @@ describe('SessionsController', () => {
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
         form: {
           ...providersAndTeams,
-          dateItems: [],
+          date: [],
         },
         sessionRows: formattedSessionRows,
         showNoResultsMessage: false,
@@ -182,9 +182,7 @@ describe('SessionsController', () => {
       const req: DeepMocked<Request> = createMock<Request>({
         query: {
           team: 'XR123',
-          'date-day': '07',
-          'date-month': '07',
-          'date-year': '2024',
+          date: '07/07/2024',
         },
       })
 

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -64,8 +64,7 @@ describe('SessionsController', () => {
       return {
         validationErrors: () => ({}),
         items: () => ({
-          startDateItems: [] as GovUkFrontendDateInputItem[],
-          endDateItems: [] as GovUkFrontendDateInputItem[],
+          dateItems: [] as GovUkFrontendDateInputItem[],
         }),
         searchValues: () => ({
           startDate: '2025-12-27',
@@ -107,8 +106,7 @@ describe('SessionsController', () => {
       pageMock.mockImplementation(() => ({
         validationErrors: () => errors,
         items: () => ({
-          startDateItems: [] as GovUkFrontendDateInputItem[],
-          endDateItems: [] as GovUkFrontendDateInputItem[],
+          dateItems: [] as GovUkFrontendDateInputItem[],
         }),
       }))
       const requestHandler = sessionsController.search()
@@ -123,7 +121,7 @@ describe('SessionsController', () => {
       await requestHandler(req, response, next)
 
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
-        form: { ...providersAndTeams, startDateItems: [], endDateItems: [] },
+        form: { ...providersAndTeams, dateItems: [] },
         errors,
         errorSummary: [
           expect.objectContaining({
@@ -158,8 +156,7 @@ describe('SessionsController', () => {
       expect(response.render).toHaveBeenCalledWith('sessions/index', {
         form: {
           ...providersAndTeams,
-          startDateItems: [],
-          endDateItems: [],
+          dateItems: [],
         },
         sessionRows: formattedSessionRows,
         showNoResultsMessage: false,
@@ -185,12 +182,9 @@ describe('SessionsController', () => {
       const req: DeepMocked<Request> = createMock<Request>({
         query: {
           team: 'XR123',
-          'startDate-day': '07',
-          'startDate-month': '07',
-          'startDate-year': '2024',
-          'endDate-day': '08',
-          'endDate-month': '08',
-          'endDate-year': '2025',
+          'date-day': '07',
+          'date-month': '07',
+          'date-year': '2024',
         },
       })
 

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -60,7 +60,7 @@ export default class SessionsController {
         return res.render('sessions/index', {
           errorSummary,
           errors: validationErrors,
-          form: { teamItems, providerItems, ...indexPage.items(validationErrors), provider },
+          form: { teamItems, providerItems, ...indexPage.items(), provider },
           sessionRows: [],
         })
       }

--- a/server/forms/mojDateInput.test.ts
+++ b/server/forms/mojDateInput.test.ts
@@ -1,0 +1,63 @@
+import InvalidDateStringError from '../errors/invalidDateStringError'
+import MojDateInput from './mojDateInput'
+
+describe('MojDateInput', () => {
+  describe('validate', () => {
+    it('returns required message when blank', () => {
+      const result = MojDateInput.validate('')
+
+      expect(result).toEqual({ text: 'Enter or select a date' })
+    })
+
+    it('returns invalid message when value cannot be parsed as a date', () => {
+      const result = MojDateInput.validate('31/6/2026')
+
+      expect(result).toEqual({
+        text: `Enter a real date in the correct format. For example, 17/5/2024`,
+      })
+    })
+
+    it('returns undefined for a valid date', () => {
+      const result = MojDateInput.validate('7/5/2026')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('supports a custom label', () => {
+      const result = MojDateInput.validate('', 'Session date')
+
+      expect(result).toEqual({ text: 'Enter or select a Session date' })
+    })
+  })
+
+  describe('isValid', () => {
+    it.each(['7/5/2026', '07/05/2026', '29/2/2024'])('returns true for valid input %s', value => {
+      expect(MojDateInput.isValid(value)).toBe(true)
+    })
+
+    it.each(['', undefined, '2026-05-07', '7-5-2026', '7/5/26', '31/02/2026', '29/2/2025'])(
+      'returns false for invalid input %s',
+      value => {
+        expect(MojDateInput.isValid(value)).toBe(false)
+      },
+    )
+  })
+
+  describe('toIsoDate', () => {
+    it('converts dd/MM/yyyy input to ISO format', () => {
+      const result = MojDateInput.toIsoDate('07/05/2026')
+
+      expect(result).toEqual('2026-05-07')
+    })
+
+    it('converts d/M/yyyy input to ISO format', () => {
+      const result = MojDateInput.toIsoDate('7/5/2026')
+
+      expect(result).toEqual('2026-05-07')
+    })
+
+    it('throws for invalid values', () => {
+      expect(() => MojDateInput.toIsoDate('31/02/2026')).toThrow(InvalidDateStringError)
+    })
+  })
+})

--- a/server/forms/mojDateInput.ts
+++ b/server/forms/mojDateInput.ts
@@ -1,0 +1,43 @@
+import { format, isValid, parse } from 'date-fns'
+import InvalidDateStringError from '../errors/invalidDateStringError'
+
+export default class MojDateInput {
+  static validate(dateInput: string | undefined, label: string = 'date'): Record<'text', string> | undefined {
+    const trimmedDateInput = dateInput?.trim()
+    if (!trimmedDateInput) {
+      return { text: `Enter or select a ${label}` }
+    }
+
+    if (!MojDateInput.isValid(trimmedDateInput)) {
+      return { text: `Enter a real ${label} in the correct format. For example, 17/5/2024` }
+    }
+
+    return undefined
+  }
+
+  static isValid(trimmedDateInput: string | undefined): boolean {
+    if (!trimmedDateInput) {
+      return false
+    }
+
+    if (!/^\d{1,2}\/\d{1,2}\/\d{4}$/.test(trimmedDateInput)) {
+      return false
+    }
+
+    const parsedDate = parse(trimmedDateInput, 'd/M/yyyy', new Date())
+    if (!isValid(parsedDate)) {
+      return false
+    }
+
+    return true
+  }
+
+  static toIsoDate(dateInput: string): string {
+    if (!MojDateInput.isValid(dateInput)) {
+      throw new InvalidDateStringError(`Invalid Date: ${dateInput}`)
+    }
+
+    const parsedDate = parse(dateInput.trim(), 'd/M/yyyy', new Date())
+    return format(parsedDate, 'yyyy-MM-dd')
+  }
+}

--- a/server/pages/groupSessionIndexPage.test.ts
+++ b/server/pages/groupSessionIndexPage.test.ts
@@ -1,88 +1,41 @@
+import MojDateInput from '../forms/mojDateInput'
 import GroupSessionIndexPage, { GroupSessionIndexPageInput } from './groupSessionIndexPage'
 
 describe('GroupSessionIndexPage', () => {
   describe('validationErrors', () => {
     it('returns errors when fields are empty', () => {
       const page = new GroupSessionIndexPage({} as GroupSessionIndexPageInput)
+      jest.spyOn(MojDateInput, 'validate').mockReturnValue(undefined)
 
       expect(page.validationErrors()).toEqual({
         team: { text: 'Choose a team' },
         provider: { text: 'Choose a region' },
-        'date-day': { text: 'Date must include a day, month and year' },
       })
     })
 
-    it('returns errors when date is invalid', () => {
+    it('returns date error', () => {
+      const dateError = { text: 'Date error' }
+      jest.spyOn(MojDateInput, 'validate').mockReturnValue(dateError)
       const page = new GroupSessionIndexPage({
-        'date-day': '11',
-        'date-month': '13',
-        'date-year': '2025',
+        date: '11/13/2025',
         provider: 'x',
+        team: 'y',
       } as GroupSessionIndexPageInput)
 
       expect(page.validationErrors()).toEqual({
-        team: { text: 'Choose a team' },
-        'date-day': { text: 'Date must be a valid date' },
+        date: dateError,
       })
     })
   })
 
   describe('items', () => {
-    it('returns date input items', () => {
+    it('returns date value for template', () => {
       const page = new GroupSessionIndexPage({
-        'date-day': '11',
-        'date-month': '03',
-        'date-year': '2025',
+        date: '11/03/2025',
       } as GroupSessionIndexPageInput)
 
       expect(page.items()).toEqual({
-        dateItems: [
-          {
-            classes: 'govuk-input--width-2',
-            name: 'day',
-            value: '11',
-          },
-          {
-            classes: 'govuk-input--width-2',
-            name: 'month',
-            value: '03',
-          },
-          {
-            classes: 'govuk-input--width-4',
-            name: 'year',
-            value: '2025',
-          },
-        ],
-      })
-    })
-
-    it('returns date input items with error classes', () => {
-      const page = new GroupSessionIndexPage({
-        'date-day': '11',
-        'date-month': '03',
-        'date-year': '2025',
-      } as GroupSessionIndexPageInput)
-
-      const errors = { 'date-day': { text: 'some error' } }
-
-      expect(page.items(errors)).toEqual({
-        dateItems: [
-          {
-            classes: 'govuk-input--width-2 govuk-input--error',
-            name: 'day',
-            value: '11',
-          },
-          {
-            classes: 'govuk-input--width-2 govuk-input--error',
-            name: 'month',
-            value: '03',
-          },
-          {
-            classes: 'govuk-input--width-4 govuk-input--error',
-            name: 'year',
-            value: '2025',
-          },
-        ],
+        date: '11/03/2025',
       })
     })
   })
@@ -91,9 +44,7 @@ describe('GroupSessionIndexPage', () => {
     it('returns query items formatted for API request with same date for startDate and endDate', () => {
       const page = new GroupSessionIndexPage({
         team: 'XR123',
-        'date-day': '07',
-        'date-month': '07',
-        'date-year': '2024',
+        date: '7/7/2024',
       })
 
       const result = page.searchValues()
@@ -111,21 +62,10 @@ describe('GroupSessionIndexPage', () => {
       it.each([
         [{ team: 'TEAM1' }],
         [{ provider: 'PROVIDER1' }],
-        [{ 'date-day': '01' }],
-        [{ 'date-month': '01' }],
-        [{ 'date-year': '2024' }],
-        [{ team: 'TEAM1', provider: 'PROVIDER1', 'date-day': '01' }],
-        [
-          {
-            team: 'TEAM1',
-            provider: 'PROVIDER1',
-            'date-day': '01',
-            'date-month': '01',
-            'date-year': '2024',
-          },
-        ],
+        [{ date: '01/01/2024' }],
+        [{ team: 'TEAM1', provider: 'PROVIDER1', date: '01/01/2024' }],
         [{ team: '' }],
-        [{ 'date-day': '31' }],
+        [{ date: '31/12/2024' }],
       ])('should return true given %s', queryObject => {
         const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
         expect(result).toBe(true)
@@ -138,7 +78,7 @@ describe('GroupSessionIndexPage', () => {
         [{ other: 'value' }],
         [{ notASearchProperty: 'value', anotherOne: 'test' }],
         [{ team: undefined }],
-        [{ provider: undefined, 'date-day': undefined }],
+        [{ provider: undefined, date: undefined }],
       ])('should return false given %s', queryObject => {
         const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
         expect(result).toBe(false)

--- a/server/pages/groupSessionIndexPage.test.ts
+++ b/server/pages/groupSessionIndexPage.test.ts
@@ -8,42 +8,21 @@ describe('GroupSessionIndexPage', () => {
       expect(page.validationErrors()).toEqual({
         team: { text: 'Choose a team' },
         provider: { text: 'Choose a region' },
-        'startDate-day': { text: 'From date must include a day, month and year' },
-        'endDate-day': { text: 'To date must include a day, month and year' },
+        'date-day': { text: 'Date must include a day, month and year' },
       })
     })
 
     it('returns errors when date is invalid', () => {
       const page = new GroupSessionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '13',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
+        'date-day': '11',
+        'date-month': '13',
+        'date-year': '2025',
         provider: 'x',
       } as GroupSessionIndexPageInput)
 
       expect(page.validationErrors()).toEqual({
         team: { text: 'Choose a team' },
-        'startDate-day': { text: 'From date must be a valid date' },
-      })
-    })
-
-    it('returns an error when date range is greater than 7 days', () => {
-      const page = new GroupSessionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '12',
-        'startDate-year': '2025',
-        'endDate-day': '20',
-        'endDate-month': '12',
-        'endDate-year': '2025',
-        provider: 'x',
-      } as GroupSessionIndexPageInput)
-
-      expect(page.validationErrors()).toEqual({
-        team: { text: 'Choose a team' },
-        'endDate-day': { text: 'Time period entered must be 7 days or less' },
+        'date-day': { text: 'Date must be a valid date' },
       })
     })
   })
@@ -51,33 +30,13 @@ describe('GroupSessionIndexPage', () => {
   describe('items', () => {
     it('returns date input items', () => {
       const page = new GroupSessionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
-        'endDate-day': '13',
-        'endDate-month': '03',
-        'endDate-year': '2025',
+        'date-day': '11',
+        'date-month': '03',
+        'date-year': '2025',
       } as GroupSessionIndexPageInput)
 
       expect(page.items()).toEqual({
-        endDateItems: [
-          {
-            classes: 'govuk-input--width-2',
-            name: 'day',
-            value: '13',
-          },
-          {
-            classes: 'govuk-input--width-2',
-            name: 'month',
-            value: '03',
-          },
-          {
-            classes: 'govuk-input--width-4',
-            name: 'year',
-            value: '2025',
-          },
-        ],
-        startDateItems: [
+        dateItems: [
           {
             classes: 'govuk-input--width-2',
             name: 'day',
@@ -99,44 +58,27 @@ describe('GroupSessionIndexPage', () => {
 
     it('returns date input items with error classes', () => {
       const page = new GroupSessionIndexPage({
-        'startDate-day': '11',
-        'startDate-month': '03',
-        'startDate-year': '2025',
+        'date-day': '11',
+        'date-month': '03',
+        'date-year': '2025',
       } as GroupSessionIndexPageInput)
 
-      const errors = { 'endDate-day': { text: 'some error' } }
+      const errors = { 'date-day': { text: 'some error' } }
 
       expect(page.items(errors)).toEqual({
-        endDateItems: [
+        dateItems: [
           {
             classes: 'govuk-input--width-2 govuk-input--error',
-            name: 'day',
-            value: '',
-          },
-          {
-            classes: 'govuk-input--width-2 govuk-input--error',
-            name: 'month',
-            value: '',
-          },
-          {
-            classes: 'govuk-input--width-4 govuk-input--error',
-            name: 'year',
-            value: '',
-          },
-        ],
-        startDateItems: [
-          {
-            classes: 'govuk-input--width-2',
             name: 'day',
             value: '11',
           },
           {
-            classes: 'govuk-input--width-2',
+            classes: 'govuk-input--width-2 govuk-input--error',
             name: 'month',
             value: '03',
           },
           {
-            classes: 'govuk-input--width-4',
+            classes: 'govuk-input--width-4 govuk-input--error',
             name: 'year',
             value: '2025',
           },
@@ -146,22 +88,19 @@ describe('GroupSessionIndexPage', () => {
   })
 
   describe('searchValues', () => {
-    it('returns query items formatted for API request', () => {
+    it('returns query items formatted for API request with same date for startDate and endDate', () => {
       const page = new GroupSessionIndexPage({
         team: 'XR123',
-        'startDate-day': '07',
-        'startDate-month': '07',
-        'startDate-year': '2024',
-        'endDate-day': '08',
-        'endDate-month': '08',
-        'endDate-year': '2025',
+        'date-day': '07',
+        'date-month': '07',
+        'date-year': '2024',
       })
 
       const result = page.searchValues()
 
       expect(result).toEqual({
         startDate: '2024-07-07',
-        endDate: '2025-08-08',
+        endDate: '2024-07-07',
         teamCode: 'XR123',
       })
     })
@@ -172,27 +111,21 @@ describe('GroupSessionIndexPage', () => {
       it.each([
         [{ team: 'TEAM1' }],
         [{ provider: 'PROVIDER1' }],
-        [{ 'startDate-day': '01' }],
-        [{ 'startDate-month': '01' }],
-        [{ 'startDate-year': '2024' }],
-        [{ 'endDate-day': '31' }],
-        [{ 'endDate-month': '12' }],
-        [{ 'endDate-year': '2024' }],
-        [{ team: 'TEAM1', provider: 'PROVIDER1', 'startDate-day': '01' }],
+        [{ 'date-day': '01' }],
+        [{ 'date-month': '01' }],
+        [{ 'date-year': '2024' }],
+        [{ team: 'TEAM1', provider: 'PROVIDER1', 'date-day': '01' }],
         [
           {
             team: 'TEAM1',
             provider: 'PROVIDER1',
-            'startDate-day': '01',
-            'startDate-month': '01',
-            'startDate-year': '2024',
-            'endDate-day': '31',
-            'endDate-month': '12',
-            'endDate-year': '2024',
+            'date-day': '01',
+            'date-month': '01',
+            'date-year': '2024',
           },
         ],
         [{ team: '' }],
-        [{ 'startDate-day': '31' }],
+        [{ 'date-day': '31' }],
       ])('should return true given %s', queryObject => {
         const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
         expect(result).toBe(true)
@@ -205,7 +138,7 @@ describe('GroupSessionIndexPage', () => {
         [{ other: 'value' }],
         [{ notASearchProperty: 'value', anotherOne: 'test' }],
         [{ team: undefined }],
-        [{ provider: undefined, 'startDate-day': undefined }],
+        [{ provider: undefined, 'date-day': undefined }],
       ])('should return false given %s', queryObject => {
         const result = GroupSessionIndexPage.objectContainsSearchProperty(queryObject)
         expect(result).toBe(false)

--- a/server/pages/groupSessionIndexPage.ts
+++ b/server/pages/groupSessionIndexPage.ts
@@ -1,21 +1,9 @@
 import { ParsedQs } from 'qs'
 import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
 import { SessionsSortField, SortDirection, TableCell, ValidationErrors } from '../@types/user-defined'
-import DateTimeFormats from '../utils/dateTimeUtils'
 import sortHeader from '../utils/sortHeader'
 
-type DateFields = 'startDate' | 'endDate'
-
-const groupSessionIndexPageInputProperties = [
-  'team',
-  'provider',
-  'startDate-day',
-  'startDate-month',
-  'startDate-year',
-  'endDate-day',
-  'endDate-month',
-  'endDate-year',
-]
+const groupSessionIndexPageInputProperties = ['team', 'provider', 'date-day', 'date-month', 'date-year']
 
 export type GroupSessionIndexPageInput = { [key in (typeof groupSessionIndexPageInputProperties)[number]]?: string }
 
@@ -26,7 +14,7 @@ interface SearchValues {
 }
 
 interface InputDate {
-  key: DateFields
+  key: 'date'
   text: string
 }
 
@@ -50,23 +38,21 @@ export default class GroupSessionIndexPage {
 
     return {
       ...validationErrors,
-      ...this.checkDateIsAcceptable({ key: 'startDate', text: 'From date' }),
-      ...this.checkDateIsAcceptable({ key: 'endDate', text: 'To date' }),
-      ...this.checkEndDateIsWithin7DaysOfStartDate(),
+      ...this.checkDateIsAcceptable({ key: 'date', text: 'Date' }),
     }
   }
 
   items(errors: ValidationErrors<GroupSessionIndexPageInput> = {}) {
     return {
-      startDateItems: GovukFrontendDateInput.getDateItems(this.query, 'startDate', Boolean(errors?.['startDate-day'])),
-      endDateItems: GovukFrontendDateInput.getDateItems(this.query, 'endDate', Boolean(errors?.['endDate-day'])),
+      dateItems: GovukFrontendDateInput.getDateItems(this.query, 'date', Boolean(errors?.['date-day'])),
     }
   }
 
   searchValues(): SearchValues {
+    const date = `${this.query['date-year']}-${this.query['date-month']}-${this.query['date-day']}`
     return {
-      startDate: `${this.query['startDate-year']}-${this.query['startDate-month']}-${this.query['startDate-day']}`,
-      endDate: `${this.query['endDate-year']}-${this.query['endDate-month']}-${this.query['endDate-day']}`,
+      startDate: date,
+      endDate: date,
       teamCode: this.query.team,
     }
   }
@@ -103,23 +89,6 @@ export default class GroupSessionIndexPage {
       }
       if (!GovukFrontendDateInput.dateIsValid(this.query, date.key)) {
         errors[`${date.key}-day`] = { text: `${date.text} must be a valid date` }
-      }
-    }
-    return errors
-  }
-
-  private checkEndDateIsWithin7DaysOfStartDate() {
-    const errors: ValidationErrors<GroupSessionIndexPageInput> = {}
-
-    if (
-      GovukFrontendDateInput.dateIsValid(this.query, 'startDate') &&
-      GovukFrontendDateInput.dateIsValid(this.query, 'endDate')
-    ) {
-      const startDateFromInputs = DateTimeFormats.dateAndTimeInputsToIsoString(this.query, 'startDate')
-      const endDateFromInputs = DateTimeFormats.dateAndTimeInputsToIsoString(this.query, 'endDate')
-
-      if (!DateTimeFormats.datesAreWithinNDays(startDateFromInputs.startDate, endDateFromInputs.endDate, 7)) {
-        errors['endDate-day'] = { text: 'Time period entered must be 7 days or less' }
       }
     }
     return errors

--- a/server/pages/groupSessionIndexPage.ts
+++ b/server/pages/groupSessionIndexPage.ts
@@ -1,9 +1,9 @@
 import { ParsedQs } from 'qs'
-import GovukFrontendDateInput from '../forms/GovukFrontendDateInput'
+import MojDateInput from '../forms/mojDateInput'
 import { SessionsSortField, SortDirection, TableCell, ValidationErrors } from '../@types/user-defined'
 import sortHeader from '../utils/sortHeader'
 
-const groupSessionIndexPageInputProperties = ['team', 'provider', 'date-day', 'date-month', 'date-year']
+const groupSessionIndexPageInputProperties = ['team', 'provider', 'date']
 
 export type GroupSessionIndexPageInput = { [key in (typeof groupSessionIndexPageInputProperties)[number]]?: string }
 
@@ -11,11 +11,6 @@ interface SearchValues {
   teamCode: string
   startDate: string
   endDate: string
-}
-
-interface InputDate {
-  key: 'date'
-  text: string
 }
 
 export default class GroupSessionIndexPage {
@@ -36,20 +31,23 @@ export default class GroupSessionIndexPage {
       validationErrors.team = { text: 'Choose a team' }
     }
 
-    return {
-      ...validationErrors,
-      ...this.checkDateIsAcceptable({ key: 'date', text: 'Date' }),
+    const dateError = MojDateInput.validate(this.query.date)
+
+    if (dateError) {
+      validationErrors.date = dateError
     }
+
+    return validationErrors
   }
 
-  items(errors: ValidationErrors<GroupSessionIndexPageInput> = {}) {
+  items() {
     return {
-      dateItems: GovukFrontendDateInput.getDateItems(this.query, 'date', Boolean(errors?.['date-day'])),
+      date: this.query.date,
     }
   }
 
   searchValues(): SearchValues {
-    const date = `${this.query['date-year']}-${this.query['date-month']}-${this.query['date-day']}`
+    const date = MojDateInput.toIsoDate(this.query.date)
     return {
       startDate: date,
       endDate: date,
@@ -73,24 +71,5 @@ export default class GroupSessionIndexPage {
 
   static objectContainsSearchProperty(queryObject: ParsedQs): boolean {
     return groupSessionIndexPageInputProperties.some(property => queryObject[property] !== undefined)
-  }
-
-  private checkDateIsAcceptable(date: InputDate) {
-    const errors: ValidationErrors<GroupSessionIndexPageInput> = {}
-
-    if (!GovukFrontendDateInput.dateIsComplete(this.query, date.key)) {
-      errors[`${date.key}-day`] = { text: `${date.text} must include a day, month and year` }
-    } else {
-      const dateItems = GovukFrontendDateInput.getStructuredDate(this.query, date.key)
-      this.query = {
-        ...this.query,
-        [`${date.key}-day`]: dateItems.day,
-        [`${date.key}-month`]: dateItems.month,
-      }
-      if (!GovukFrontendDateInput.dateIsValid(this.query, date.key)) {
-        errors[`${date.key}-day`] = { text: `${date.text} must be a valid date` }
-      }
-    }
-    return errors
   }
 }

--- a/server/views/sessions/index.njk
+++ b/server/views/sessions/index.njk
@@ -1,6 +1,5 @@
 {% extends "../partials/layout.njk" %}
 
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% from "../showErrorSummary.njk" import showErrorSummary %}
@@ -8,6 +7,7 @@
 
 {% from "../components/sortableTable/macro.njk" import sortableTable %}
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
+{% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 
 {% set pageTitle = applicationName + " - Find a group session" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -29,17 +29,18 @@
 
       {% call teamFilter(form, errors, paths.sessions.search(), paths.sessions.index(), "Filter group sessions") %}
         <div class="search-and-filter__row">
-          {{ govukDateInput({
+          {{ mojDatePicker({
             id: "date",
-            namePrefix: "date",
-            fieldset: {
-              legend: {
-                text: "Date",
-                classes: "govuk-!-font-weight-bold"
-              }
+            name: "date",
+            label: {
+              text: "Date",
+              classes: "govuk-!-font-weight-bold"
             },
-            items: form.dateItems,
-            errorMessage: errors['date-day']
+            hint: {
+              text: "For example, 17/5/2024"
+            },
+            value: form.date,
+            errorMessage: errors.date
           }) }}
         </div>
       {% endcall %}

--- a/server/views/sessions/index.njk
+++ b/server/views/sessions/index.njk
@@ -7,7 +7,7 @@
 {% from "../partials/teamFilter/index.njk" import teamFilter %}
 
 {% from "../components/sortableTable/macro.njk" import sortableTable %}
-{%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+{% from "moj/components/pagination/macro.njk" import mojPagination %}
 
 {% set pageTitle = applicationName + " - Find a group session" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -30,28 +30,16 @@
       {% call teamFilter(form, errors, paths.sessions.search(), paths.sessions.index(), "Filter group sessions") %}
         <div class="search-and-filter__row">
           {{ govukDateInput({
-            id: "startDate",
-            namePrefix: "startDate",
+            id: "date",
+            namePrefix: "date",
             fieldset: {
               legend: {
-                text: "From",
+                text: "Date",
                 classes: "govuk-!-font-weight-bold"
               }
             },
-            items: form.startDateItems,
-            errorMessage: errors['startDate-day']
-          }) }}
-          {{ govukDateInput({
-            id: "endDate",
-            namePrefix: "endDate",
-            fieldset: {
-              legend: {
-                text: "To",
-                classes: "govuk-!-font-weight-bold"
-              }
-            },
-            items: form.endDateItems,
-            errorMessage: errors['endDate-day']
+            items: form.dateItems,
+            errorMessage: errors['date-day']
           }) }}
         </div>
       {% endcall %}


### PR DESCRIPTION
## Context

- Use the [MOJ Date picker](https://design-patterns.service.justice.gov.uk/components/date-picker) for session search
- Search for single dates only

Have update error messages to fit new format, using examples from the [component documentation](https://design-patterns.service.justice.gov.uk/components/date-picker/#how-to-use-tab).

[CPB-976](https://dsdmoj.atlassian.net/browse/CPB-976)

### Screenshots of UI changes

<img width="1615" height="958" alt="Group session search for 29/6/2026" src="https://github.com/user-attachments/assets/6dc7a7ea-0b17-4c36-83af-bc7c4dc064a8" />

<img width="1546" height="955" alt="Group session search with error message 'Enter a date'" src="https://github.com/user-attachments/assets/24e61be4-3f44-4b0b-85bd-c138ddbb4e7e" />

<img width="1556" height="959" alt="Group session search with error message 'Enter a real date in the correct format" src="https://github.com/user-attachments/assets/d34c0b1d-243b-41b9-b4f2-c88316634f95" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

Note: e2es are currently failing, but I have verified that the tests pass up until updating an appointment (so during session search)

<!-- ```
$ ./script/test
``` -->


[CPB-976]: https://dsdmoj.atlassian.net/browse/CPB-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ