### PR TITLE
CPB-1057: Update e2e tests to use new contact outcome display names

### DIFF
--- a/e2e-tests/contactOutcomes.ts
+++ b/e2e-tests/contactOutcomes.ts
@@ -1,5 +1,5 @@
 export type AttendanceOutcome =
-  | 'Unacceptable Absence'
-  | 'Attended - Complied'
-  | 'Attended - Failed to Comply'
-  | 'Rescheduled - Service Request'
+  | 'Unacceptable absence'
+  | 'Attended \u2013 complied'
+  | 'Attended \u2013 failed to comply'
+  | 'Rescheduled \u2013 service request'

--- a/e2e-tests/pages/appointments/attendanceOutcomePage.ts
+++ b/e2e-tests/pages/appointments/attendanceOutcomePage.ts
@@ -16,10 +16,10 @@ export default class AttendanceOutcomePage extends AppointmentFormPage {
 
   constructor(page: Page) {
     super(page, 'Log attendance')
-    this.outcomeWithEnforcementLocator = page.getByLabel('Unacceptable Absence')
-    this.attendedCompliedOutcomeLocator = page.getByLabel('Attended - complied')
-    this.attendedEnforceableOutcomeLocator = page.getByLabel('Attended - failed to comply')
-    this.notAttendedNotEnforcementOutcomeLocator = page.getByLabel('Rescheduled - Service request')
+    this.outcomeWithEnforcementLocator = page.getByLabel('Unacceptable absence')
+    this.attendedCompliedOutcomeLocator = page.getByLabel('Attended \u2013 complied')
+    this.attendedEnforceableOutcomeLocator = page.getByLabel('Attended \u2013 failed to comply')
+    this.notAttendedNotEnforcementOutcomeLocator = page.getByLabel('Rescheduled \u2013 service request')
     this.notesFieldLocator = page.getByLabel('Notes')
     this.isSensitiveOptionLocator = page.getByLabel('Yes, they include sensitive information')
   }

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -38,7 +38,7 @@ test('Update a session appointment', async ({ page, deliusUser, team, project, p
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended - Complied')
+  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
   await confirmPage.selectAlertPractitioner()
 

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -35,7 +35,7 @@ test('Update a session appointment with an enforceable outcome', async ({
 
   const confirmPage = new ConfirmPage(page)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Unacceptable Absence')
+  await confirmPage.expect.toShowAttendanceAnswer('Unacceptable absence')
   await confirmPage.expect.toShowMessageThatOutcomeWillAlert()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -41,7 +41,7 @@ test('Update a session appointment with an attended but enforceable outcome', as
   const confirmPage = new ConfirmPage(page)
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended - Failed to Comply')
+  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 failed to comply')
   await confirmPage.expect.toShowComplianceAnswer()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -38,7 +38,7 @@ test('Update a session appointment with a not attended but not enforceable outco
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled - Service Request')
+  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled \u2013 service request')
 
   await confirmPage.confirmButtonLocator.click()
 

--- a/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
@@ -50,7 +50,7 @@ test('Bulk update a group session => attended', async ({ page, deliusUser, team,
 
   await confirmPage.expect.toShowSelectedPeople(session.peopleOnProbation)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended - Complied')
+  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
   await confirmPage.selectAlertPractitioner()
 

--- a/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
@@ -44,7 +44,7 @@ test('Bulk update a group session => not attended', async ({ page, deliusUser, t
 
   await confirmPage.expect.toShowSelectedPeople(groupSession.peopleOnProbation)
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
-  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled - Service Request')
+  await confirmPage.expect.toShowAttendanceAnswer('Rescheduled \u2013 service request')
   await confirmPage.selectAlertPractitioner()
 
   await confirmPage.confirmButtonLocator.click()

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -42,7 +42,7 @@ test('Update an individual placement appointment with attended complied', async 
   await confirmPage.expect.toBeOnThePage()
 
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability)
-  await confirmPage.expect.toShowAttendanceAnswer('Attended - Complied')
+  await confirmPage.expect.toShowAttendanceAnswer('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
 
   await confirmPage.confirmButtonLocator.click()


### PR DESCRIPTION
## Context

In https://github.com/ministryofjustice/hmpps-community-payback-api/pull/720 the behaviour of the API was changed to return display names for contact outcomes where available instead of the names as they appear in Delius. This has caused the e2e tests to fail in situations where it attempts to get page elements using the old names.

This updates the tests to use the new display names, allowing them to pass.

## Changes in this PR

- The `AttendanceOutcome` type and its usages have been updated to reflect the new observed values in the UI.

### Screenshots of UI changes

No visual changes have been introduced.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
