### PR TITLE
CPB-1059: Display hint text on contact outcome options

### DIFF
--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -423,6 +423,26 @@ describe('AttendanceOutcomePage', () => {
         expect(result.items).toEqual(expectedItems)
       })
 
+      it('should include hint text when a contact outcome defines it', () => {
+        const hintedOutcome = contactOutcomeFactory.build({
+          hintText: 'Use this when the person gave advance notice',
+        })
+        const page = new AttendanceOutcomePage({
+          query: {},
+          appointmentOrSession: appointment,
+          contactOutcomes: [hintedOutcome],
+        })
+
+        const result = page.viewData(appointmentOutcomeFormFactory.build())
+
+        expect(result.items[0]).toEqual({
+          text: hintedOutcome.name,
+          value: hintedOutcome.code,
+          hint: { text: hintedOutcome.hintText },
+          checked: false,
+        })
+      })
+
       it('should return query values if there are errors', () => {
         const notesItems = { notes: 'Test', showIsSensitiveQuestion: true }
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -115,6 +115,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return this.contactOutcomes.map(outcome => ({
       text: outcome.name,
       value: outcome.code,
+      hint: outcome.hintText ? { text: outcome.hintText } : undefined,
       checked: outcome.code === code,
     }))
   }

--- a/server/testutils/factories/contactOutcomeFactory.ts
+++ b/server/testutils/factories/contactOutcomeFactory.ts
@@ -10,6 +10,8 @@ export const contactOutcomeFactory = Factory.define<ContactOutcomeDto>(() => ({
   attended: faker.datatype.boolean(),
   availableToSupervisors: faker.datatype.boolean(),
   willAlertEnforcementDiary: faker.datatype.boolean(),
+  // hintText is not required for most test cases
+  hintText: undefined,
 }))
 
 export const contactOutcomesFactory = Factory.define<ContactOutcomesDto>(() => ({


### PR DESCRIPTION
This displays a new hintText property on contact outcomes, if defined.

[CPB-1059](https://dsdmoj.atlassian.net/browse/CPB-1059)

### Screenshots of UI changes

<img width="1053" height="572" alt="A list of radio options with and without hint text" src="https://github.com/user-attachments/assets/fe14c5ed-7134-4810-8821-690ecfe93de6" />


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1059]: https://dsdmoj.atlassian.net/browse/CPB-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ