### PR TITLE
CPB-1110: Populate supervising team on form object

### DIFF
--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -64,6 +64,9 @@ describe('AppointmentFormService', () => {
         },
         sensitive: appointment.sensitive,
         originalSearch: search,
+        team: {
+          code: appointment.supervisingTeamCode,
+        },
       }
 
       expect(formClient.save).toHaveBeenCalledWith(

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import { AppointmentDto, ContactOutcomeDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, ProviderTeamSummaryDto, SupervisorSummaryDto } from '../../@types/shared'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import FormClient, { FormKey } from '../../data/formClient'
 import BaseFormService from './baseFormService'
@@ -40,6 +40,9 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
           code: appointment.contactOutcomeCode,
         } as ContactOutcomeDto,
         attendanceData: appointment.attendanceData,
+        team: {
+          code: appointment.supervisingTeamCode,
+        } as ProviderTeamSummaryDto,
         supervisor: {
           code: appointment.supervisorOfficerCode,
         } as SupervisorSummaryDto,


### PR DESCRIPTION
## Context

Ensure the supervising team and officer are populated on a single appointment form.

[CPB-1110](https://dsdmoj.atlassian.net/browse/CPB-1110)

## Changes in this PR

- Add the supervising team code to the form object when creating a new form object, as the officer field is always dependent on team code having a value.

### Screenshots of UI changes


https://github.com/user-attachments/assets/6d5c80a9-194f-4472-b710-62124ce1a556


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1110]: https://dsdmoj.atlassian.net/browse/CPB-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ