### PR TITLE
CPB-1109 Make sensitive info question a checkbox

### DIFF
--- a/e2e-tests/pages/appointments/attendanceOutcomePage.ts
+++ b/e2e-tests/pages/appointments/attendanceOutcomePage.ts
@@ -21,7 +21,9 @@ export default class AttendanceOutcomePage extends AppointmentFormPage {
     this.attendedEnforceableOutcomeLocator = page.getByLabel('Attended \u2013 failed to comply')
     this.notAttendedNotEnforcementOutcomeLocator = page.getByLabel('Rescheduled \u2013 service request')
     this.notesFieldLocator = page.getByLabel('Notes')
-    this.isSensitiveOptionLocator = page.getByLabel('Yes, they include sensitive information')
+    this.isSensitiveOptionLocator = page.getByLabel(
+      'This is information that you believe must be recorded but not shared with a person on probation.',
+    )
   }
 
   async chooseEnforcementOutcome() {

--- a/integration_tests/pages/components/notesQuestionComponent.ts
+++ b/integration_tests/pages/components/notesQuestionComponent.ts
@@ -1,4 +1,3 @@
-import { YesOrNo } from '../../../server/@types/user-defined'
 import RadioOrCheckboxGroupComponent from './radioOrCheckboxGroupComponent'
 
 export default class NotesQuestionComponent {
@@ -9,25 +8,28 @@ export default class NotesQuestionComponent {
   completeForm(expectIsSensitiveQuestion = true) {
     this.notesField().type('Attendance notes')
     if (expectIsSensitiveQuestion) {
-      this.selectIsSensitive('no')
+      this.checkIsSensitive()
     }
   }
 
-  selectIsSensitive(value: YesOrNo = 'yes') {
-    this.isSensitiveOptions.checkOptionWithValue(value)
+  checkIsSensitive() {
+    this.isSensitiveOptions.checkOptionWithValue('yes')
   }
 
   shouldShowNotes(text: string) {
     this.notesField().should('have.value', text)
   }
 
-  shouldShowIsSensitiveValue(value: YesOrNo = 'yes') {
-    this.isSensitiveOptions.shouldHaveSelectedValue(value)
+  shouldShowIsSensitiveValue() {
+    this.isSensitiveOptions.shouldHaveSelectedValue('yes')
   }
 
   shouldShowUncheckedSensitiveQuestion() {
     this.isSensitiveOptions.getOptionWithValue('yes').should('not.be.checked')
-    this.isSensitiveOptions.getOptionWithValue('no').should('not.be.checked')
+  }
+
+  shouldShowIsSensitiveQuestion() {
+    this.isSensitiveOptions.shouldBeVisible()
   }
 
   shouldNotShowIsSensitiveQuestion() {

--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -74,7 +74,7 @@ context('Attendance outcome', () => {
   beforeEach(function test() {
     cy.task('stubFindAppointment', { appointment: this.appointment })
     cy.task('stubGetContactOutcomes', { contactOutcomes: this.contactOutcomes })
-    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build())
+    cy.task('stubGetAppointmentForm', appointmentOutcomeFormFactory.build({ isSensitive: undefined }))
   })
 
   // Scenario: Validating the attendance outcome page
@@ -87,7 +87,7 @@ context('Attendance outcome', () => {
 
     // And I enter notes
     page.notesQuestions.notesField().type(notes)
-    page.notesQuestions.selectIsSensitive()
+    page.notesQuestions.checkIsSensitive()
 
     // When I submit the form
     page.clickSubmit()
@@ -234,17 +234,17 @@ context('Attendance outcome', () => {
       page.notesQuestions.shouldNotShowIsSensitiveQuestion()
     })
 
-    it('does show sensitivity options if appointment sensitive value is false', function test() {
+    it('does show sensitivity options if appointment sensitive value is undefined', function test() {
       const appointment = appointmentFactory.build({ sensitive: false })
       cy.task('stubFindAppointment', { appointment })
-      const form = appointmentOutcomeFormFactory.build({ isSensitive: 'no' })
+      const form = appointmentOutcomeFormFactory.build({ isSensitive: undefined })
       cy.task('stubGetAppointmentForm', form)
 
       // Given I am on the attendance outcome page for an appointment
       const page = AttendanceOutcomePage.visit(appointment)
 
-      // Then I should not see the is sensitive question
-      page.notesQuestions.shouldShowIsSensitiveValue('no')
+      // Then I should see the is sensitive question
+      page.notesQuestions.shouldShowIsSensitiveQuestion()
     })
   })
 })

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -349,7 +349,7 @@ context('Confirm details page', () => {
 
       // Then I can see the outcome page
       const outcomePage = Page.verifyOnPage(OutcomePage)
-      outcomePage.notesQuestions.shouldShowIsSensitiveValue(form.isSensitive)
+      outcomePage.notesQuestions.shouldShowIsSensitiveValue()
     })
 
     // Scenario: Changing the appointment

--- a/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/recordOutcome.cy.ts
@@ -141,7 +141,7 @@ context('Outcome Page', () => {
     //  When I submit an invalid form
     // And I enter notes
     page.notesQuestions.notesField().type(notes)
-    page.notesQuestions.selectIsSensitive()
+    page.notesQuestions.checkIsSensitive()
     page.clickSubmit()
 
     // Then I should see the page with errors
@@ -234,7 +234,7 @@ context('Outcome Page', () => {
       // Given I am on the attendance outcome page for an appointment
       const page = OutcomePage.visit(courseCompletion)
 
-      // Then I should not see the is sensitive question
+      // Then I should not see the is sensitive question is checked
       page.notesQuestions.shouldShowUncheckedSensitiveQuestion()
     })
   })

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -255,7 +255,7 @@ export interface SummaryCard {
 
 export type ViewDataWithNotes = {
   notes?: string
-  notesHint?: GovUKValue
+  sensitiveInfoContent?: string
   isSensitiveItems?: Array<GovUkRadioOrCheckboxOption>
 }
 

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -256,7 +256,7 @@ export interface SummaryCard {
 export type ViewDataWithNotes = {
   notes?: string
   sensitiveInfoContent?: string
-  isSensitiveItems?: Array<GovUkRadioOrCheckboxOption>
+  isSensitiveItem?: Array<GovUkRadioOrCheckboxOption>
 }
 
 export type ViewDataWithTimeToCredit = {
@@ -265,7 +265,7 @@ export type ViewDataWithTimeToCredit = {
 
 export type BodyWithNotes = {
   notes?: string
-  isSensitive?: YesOrNo
+  isSensitive?: 'yes'
 }
 
 export interface IFormPageController {

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -58,7 +58,7 @@ describe('OutcomeController', () => {
     )
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue({})
-    jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: undefined, isSensitiveItems: [] })
+    jest.spyOn(NotesUtils, 'questionItems').mockReturnValue({ notes: undefined, isSensitiveItem: [] })
     jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue([])
     jest.spyOn(CourseCompletionUtils, 'formattedCourseDetails').mockReturnValue(courseDetailsItems)
 
@@ -94,7 +94,7 @@ describe('OutcomeController', () => {
         timeToCredit: { hours: undefined, minutes: undefined },
         dateItems: [],
         notes: undefined,
-        isSensitiveItems: [],
+        isSensitiveItem: [],
         courseDetailsItems,
         requirementDetailsItems,
         courseCompletion,
@@ -117,8 +117,8 @@ describe('OutcomeController', () => {
         { name: 'month', classes: '', value: '02' },
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
-      const notesItems = { isSensitiveItems, notes: form.notes, showIsSensitiveQuestion: true }
+      const isSensitiveItem = [{ text: 'Yes', value: 'yes', checked: true }]
+      const notesItems = { isSensitiveItem, notes: form.notes, showIsSensitiveQuestion: true }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
       const viewData = {
@@ -243,7 +243,7 @@ describe('OutcomeController', () => {
         errorSummary,
         timeToCredit: { hours: undefined, minutes: undefined },
         dateItems: [],
-        isSensitiveItems: [],
+        isSensitiveItem: [],
         notes: undefined,
         courseDetailsItems,
         requirementDetailsItems,
@@ -289,10 +289,10 @@ describe('OutcomeController', () => {
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: false }]
+      const isSensitiveItem = [{ text: 'Yes', value: 'yes', checked: false }]
       const notesItems = {
         notes: 'some',
-        isSensitiveItems,
+        isSensitiveItem,
         showIsSensitiveQuestion: true,
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
@@ -356,10 +356,10 @@ describe('OutcomeController', () => {
       ]
       jest.spyOn(GovukFrontendDateInput, 'getDateItemsFromStructuredDate').mockReturnValue(dateItems)
 
-      const isSensitiveItems = [{ text: 'Yes', value: 'yes' as YesOrNo, checked: true }]
+      const isSensitiveItem = [{ text: 'Yes', value: 'yes', checked: true }]
       const notesItems = {
         notes,
-        isSensitiveItems,
+        isSensitiveItem,
         showIsSensitiveQuestion: true,
         isSensitiveValue: undefined as YesOrNo,
       }

--- a/server/pages/courseCompletions/process/confirmPage.test.ts
+++ b/server/pages/courseCompletions/process/confirmPage.test.ts
@@ -1137,38 +1137,6 @@ describe('ConfirmPage', () => {
         expect(result).toContainEqual(sensitivityItem)
       })
 
-      it('returns sensitivity item with "No" value', () => {
-        const form = courseCompletionFormFactory.build({
-          isSensitive: 'no',
-        })
-        const formId = '12'
-        const courseCompletionId = '23'
-
-        const result = page.appointmentItems({ courseCompletionId, form, formId, canChangeAppointment: false })
-
-        const sensitivityItem = {
-          key: {
-            text: 'Sensitive',
-          },
-          value: {
-            text: 'No',
-          },
-          actions: {
-            items: [
-              {
-                href: pathWithQuery(paths.courseCompletions.process({ page: 'outcome', id: courseCompletionId }), {
-                  form: formId,
-                }),
-                text: 'Change',
-                visuallyHiddenText: 'sensitivity',
-              },
-            ],
-          },
-        }
-
-        expect(result).toContainEqual(sensitivityItem)
-      })
-
       it('returns notes item with undefined value when notes is undefined', () => {
         const form = courseCompletionFormFactory.build({
           notes: undefined,

--- a/server/testutils/factories/appointmentOutcomeFormFactory.ts
+++ b/server/testutils/factories/appointmentOutcomeFormFactory.ts
@@ -19,7 +19,7 @@ export default Factory.define<AppointmentOutcomeForm>(
       attendanceData: attendanceDataFactory.build(),
       supervisor: supervisorSummaryFactory.build(),
       notes: undefined,
-      isSensitive: faker.helpers.arrayElement(['yes', 'no']),
+      isSensitive: 'yes',
       originalSearch: {
         provider: faker.string.alpha(8),
         team: faker.string.alpha(8),

--- a/server/testutils/factories/courseCompletionFormFactory.ts
+++ b/server/testutils/factories/courseCompletionFormFactory.ts
@@ -16,7 +16,7 @@ export default Factory.define<CourseCompletionForm>(() => ({
   team: faker.string.alpha(8),
   notes: faker.string.alpha(50),
   alertActive: faker.datatype.boolean(),
-  isSensitive: faker.helpers.arrayElement(['yes', 'no']),
+  isSensitive: 'yes',
   originalSearch: {
     provider: faker.string.alpha(8),
     pdu: faker.string.alpha(8),

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -99,13 +99,13 @@ describe('NotesUtils', () => {
     })
 
     describe('with appointment parameter', () => {
-      it('should return notes hint and no sensitive items when appointment is sensitive', () => {
+      it('should return sensitive info text and no sensitive items when appointment is sensitive', () => {
         const form = courseCompletionFormFactory.build()
         const appointment = appointmentFactory.build({ sensitive: true })
 
         const result = NotesUtils.questionItems({}, form, appointment)
 
-        expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveValueAutomatedHint)
+        expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveInfoContentMarkedAsSensitive)
         expect(result.isSensitiveItems).toBeUndefined()
       })
 
@@ -143,7 +143,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, appointment, false)
 
-          expect(result.sensitiveInfoContent).toBeUndefined()
+          expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveInfoContentDontInclude)
           expect(result.isSensitiveItems).toBeUndefined()
         })
 

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -1,10 +1,16 @@
-import { YesOrNo } from '../@types/user-defined'
 import appointmentFactory from '../testutils/factories/appointmentFactory'
 import courseCompletionFormFactory from '../testutils/factories/courseCompletionFormFactory'
 import NotesUtils from './notesUtils'
 
 describe('NotesUtils', () => {
   describe('questionItems', () => {
+    const isSensitiveItem = {
+      checked: true,
+      text: 'This is information that you believe must be recorded but not shared with a person on probation. If they make a request for their record, the Data Protection Team will decide whether the information can be shared.',
+      value: 'yes',
+      label: { classes: 'govuk-!-padding-top-0' },
+    }
+
     describe('notes', () => {
       it.each(['some note', ''])('should contain query value if any value', (notes: string) => {
         const form = courseCompletionFormFactory.build()
@@ -31,7 +37,7 @@ describe('NotesUtils', () => {
       })
     })
 
-    describe('isSensitiveItems', () => {
+    describe('isSensitiveItem', () => {
       it('Yes should be checked if form `sensitive` property is yes', () => {
         const form = courseCompletionFormFactory.build({
           isSensitive: 'yes',
@@ -39,44 +45,35 @@ describe('NotesUtils', () => {
 
         const result = NotesUtils.questionItems({}, form)
 
-        const expectedSensitiveItems = [
-          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: false, text: 'No, they are not sensitive', value: 'no' },
-        ]
+        const expectedSensitiveItems = [isSensitiveItem]
 
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+        expect(result.isSensitiveItem).toEqual(expectedSensitiveItems)
       })
 
-      it('No should be checked if form `sensitive` property is no', () => {
+      it('should be unchecked if form `sensitive` property is undefined', () => {
         const form = courseCompletionFormFactory.build({
-          isSensitive: 'no',
+          isSensitive: undefined,
         })
 
         const result = NotesUtils.questionItems({}, form)
 
-        const expectedSensitiveItems = [
-          { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: true, text: 'No, they are not sensitive', value: 'no' },
-        ]
+        const expectedSensitiveItems = [{ ...isSensitiveItem, checked: false }]
 
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+        expect(result.isSensitiveItem).toEqual(expectedSensitiveItems)
       })
 
       it.each([null, undefined])(
-        'Neither value should be checked if form `sensitive` property is null or undefined',
-        (isSensitive?: YesOrNo) => {
+        'should be unchecked if form `sensitive` property is null or undefined',
+        (isSensitive?: 'yes') => {
           const form = courseCompletionFormFactory.build({
             isSensitive,
           })
 
           const result = NotesUtils.questionItems({}, form)
 
-          const expectedSensitiveItems = [
-            { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-            { checked: false, text: 'No, they are not sensitive', value: 'no' },
-          ]
+          const expectedSensitiveItems = [{ ...isSensitiveItem, checked: false }]
 
-          expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+          expect(result.isSensitiveItem).toEqual(expectedSensitiveItems)
         },
       )
 
@@ -85,16 +82,13 @@ describe('NotesUtils', () => {
           isSensitive: undefined,
         })
 
-        const query = { isSensitive: 'yes' as YesOrNo }
+        const query = { isSensitive: 'yes' as const }
 
         const result = NotesUtils.questionItems(query, form)
 
-        const expectedSensitiveItems = [
-          { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: false, text: 'No, they are not sensitive', value: 'no' },
-        ]
+        const expectedSensitiveItems = [isSensitiveItem]
 
-        expect(result.isSensitiveItems).toEqual(expectedSensitiveItems)
+        expect(result.isSensitiveItem).toEqual(expectedSensitiveItems)
       })
     })
 
@@ -106,7 +100,7 @@ describe('NotesUtils', () => {
         const result = NotesUtils.questionItems({}, form, appointment)
 
         expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveInfoContentMarkedAsSensitive)
-        expect(result.isSensitiveItems).toBeUndefined()
+        expect(result.isSensitiveItem).toBeUndefined()
       })
 
       it('should return isSensitiveItems when appointment is not sensitive', () => {
@@ -117,10 +111,7 @@ describe('NotesUtils', () => {
         const result = NotesUtils.questionItems(query, form, appointment)
 
         expect(result.sensitiveInfoContent).toBeUndefined()
-        expect(result.isSensitiveItems).toEqual([
-          { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
-          { checked: true, text: 'No, they are not sensitive', value: 'no' },
-        ])
+        expect(result.isSensitiveItem).toEqual([{ ...isSensitiveItem, checked: false }])
       })
 
       describe('includeIsSensitiveQuestion', () => {
@@ -131,10 +122,7 @@ describe('NotesUtils', () => {
           const result = NotesUtils.questionItems({}, form, appointment, true)
 
           expect(result.sensitiveInfoContent).toBeUndefined()
-          expect(result.isSensitiveItems).toEqual([
-            { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-            { checked: false, text: 'No, they are not sensitive', value: 'no' },
-          ])
+          expect(result.isSensitiveItem).toEqual([isSensitiveItem])
         })
 
         it('does not show sensitive question when appointment is present and includeIsSensitiveQuestion is false', () => {
@@ -144,7 +132,7 @@ describe('NotesUtils', () => {
           const result = NotesUtils.questionItems({}, form, appointment, false)
 
           expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveInfoContentDontInclude)
-          expect(result.isSensitiveItems).toBeUndefined()
+          expect(result.isSensitiveItem).toBeUndefined()
         })
 
         it('shows sensitive question when appointment is undefined and includeIsSensitiveQuestion is true', () => {
@@ -153,10 +141,7 @@ describe('NotesUtils', () => {
           const result = NotesUtils.questionItems({}, form, undefined, true)
 
           expect(result.sensitiveInfoContent).toBeUndefined()
-          expect(result.isSensitiveItems).toEqual([
-            { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
-            { checked: false, text: 'No, they are not sensitive', value: 'no' },
-          ])
+          expect(result.isSensitiveItem).toEqual([isSensitiveItem])
         })
       })
     })
@@ -238,30 +223,6 @@ describe('NotesUtils', () => {
       })
     })
 
-    it("should return sensitive row displaying 'No' when isSensitive is 'no'", () => {
-      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
-
-      const result = NotesUtils.checkYourAnswersRows(form, changePath)
-
-      expect(result[1]).toEqual({
-        key: {
-          text: 'Sensitive',
-        },
-        value: {
-          text: 'No',
-        },
-        actions: {
-          items: [
-            {
-              href: changePath,
-              text: 'Change',
-              visuallyHiddenText: 'sensitivity',
-            },
-          ],
-        },
-      })
-    })
-
     it("should return sensitive row displaying 'Not entered' when isSensitive is undefined", () => {
       const form = courseCompletionFormFactory.build({ isSensitive: undefined })
 
@@ -306,7 +267,7 @@ describe('NotesUtils', () => {
     })
 
     it('should return sensitive row with action items when appointment is not sensitive', () => {
-      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+      const form = courseCompletionFormFactory.build({ isSensitive: undefined })
       const appointment = appointmentFactory.build({ sensitive: false })
 
       const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
@@ -316,7 +277,7 @@ describe('NotesUtils', () => {
           text: 'Sensitive',
         },
         value: {
-          text: 'No',
+          text: 'Not entered',
         },
         actions: {
           items: [
@@ -331,7 +292,7 @@ describe('NotesUtils', () => {
     })
 
     it("should return sensitive row displaying 'Yes' when appointment is sensitive true", () => {
-      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+      const form = courseCompletionFormFactory.build({ isSensitive: undefined })
       const appointment = appointmentFactory.build({ sensitive: true })
 
       const result = NotesUtils.checkYourAnswersRows(form, changePath, appointment)
@@ -383,7 +344,7 @@ describe('NotesUtils', () => {
 
   describe('formData', () => {
     it('should return isSensitive and notes values as yes when appointment is sensitive', () => {
-      const query = { notes: 'test notes', isSensitive: 'yes' as YesOrNo }
+      const query = { notes: 'test notes', isSensitive: 'yes' as const }
 
       const result = NotesUtils.formData(query)
 
@@ -413,11 +374,11 @@ describe('NotesUtils', () => {
     )
 
     it('should use form sensitive value when sensitive updates are explicitly allowed', () => {
-      const form = courseCompletionFormFactory.build({ isSensitive: 'no' })
+      const form = courseCompletionFormFactory.build({ isSensitive: undefined })
 
       const result = NotesUtils.requestBody(form, undefined, true)
 
-      expect(result.sensitive).toBe(false)
+      expect(result.sensitive).toBe(null)
     })
 
     it.each([false, undefined, null])(

--- a/server/utils/notesUtils.test.ts
+++ b/server/utils/notesUtils.test.ts
@@ -105,7 +105,7 @@ describe('NotesUtils', () => {
 
         const result = NotesUtils.questionItems({}, form, appointment)
 
-        expect(result.notesHint).toEqual({ text: NotesUtils.sensitiveValueAutomatedHint })
+        expect(result.sensitiveInfoContent).toEqual(NotesUtils.sensitiveValueAutomatedHint)
         expect(result.isSensitiveItems).toBeUndefined()
       })
 
@@ -116,7 +116,7 @@ describe('NotesUtils', () => {
 
         const result = NotesUtils.questionItems(query, form, appointment)
 
-        expect(result.notesHint).toBeUndefined()
+        expect(result.sensitiveInfoContent).toBeUndefined()
         expect(result.isSensitiveItems).toEqual([
           { checked: false, text: 'Yes, they include sensitive information', value: 'yes' },
           { checked: true, text: 'No, they are not sensitive', value: 'no' },
@@ -130,7 +130,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, appointment, true)
 
-          expect(result.notesHint).toBeUndefined()
+          expect(result.sensitiveInfoContent).toBeUndefined()
           expect(result.isSensitiveItems).toEqual([
             { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
             { checked: false, text: 'No, they are not sensitive', value: 'no' },
@@ -143,7 +143,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, appointment, false)
 
-          expect(result.notesHint).toBeUndefined()
+          expect(result.sensitiveInfoContent).toBeUndefined()
           expect(result.isSensitiveItems).toBeUndefined()
         })
 
@@ -152,7 +152,7 @@ describe('NotesUtils', () => {
 
           const result = NotesUtils.questionItems({}, form, undefined, true)
 
-          expect(result.notesHint).toBeUndefined()
+          expect(result.sensitiveInfoContent).toBeUndefined()
           expect(result.isSensitiveItems).toEqual([
             { checked: true, text: 'Yes, they include sensitive information', value: 'yes' },
             { checked: false, text: 'No, they are not sensitive', value: 'no' },

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -1,7 +1,6 @@
 import { AppointmentDto } from '../@types/shared'
 import { BodyWithNotes, GovUkSummaryListItem, ViewDataWithNotes, YesOrNo } from '../@types/user-defined'
 import GovUkRadioGroup from '../forms/GovUkRadioGroup'
-import { properCase } from './utils'
 
 export default class NotesUtils {
   static sensitiveInfoContentMarkedAsSensitive =
@@ -88,11 +87,11 @@ export default class NotesUtils {
   }
 
   private static getIsSensitiveAnswer(form: BodyWithNotes, appointment?: AppointmentDto): string {
-    if (appointment?.sensitive === true) {
+    if (appointment?.sensitive === true || form.isSensitive === 'yes') {
       return 'Yes'
     }
 
-    return form.isSensitive ? properCase(form.isSensitive) : 'Not entered'
+    return 'Not entered'
   }
 
   static questionItems(
@@ -117,7 +116,7 @@ export default class NotesUtils {
 
       return {
         notes,
-        isSensitiveItems: this.isSensitiveItems(sensitive),
+        isSensitiveItem: this.isSensitiveItem(sensitive),
       }
     }
 
@@ -127,17 +126,15 @@ export default class NotesUtils {
     }
   }
 
-  private static isSensitiveItems(isSensitive?: YesOrNo): { text: string; value: YesOrNo; checked: boolean }[] {
+  private static isSensitiveItem(
+    isSensitive?: YesOrNo,
+  ): { text: string; value: 'yes'; checked: boolean; label?: Record<string, unknown> }[] {
     return [
       {
-        text: 'Yes, they include sensitive information',
+        text: 'This is information that you believe must be recorded but not shared with a person on probation. If they make a request for their record, the Data Protection Team will decide whether the information can be shared.',
         value: 'yes',
         checked: isSensitive === 'yes',
-      },
-      {
-        text: 'No, they are not sensitive',
-        value: 'no',
-        checked: isSensitive === 'no',
+        label: { classes: 'govuk-!-padding-top-0' },
       },
     ]
   }

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -4,8 +4,10 @@ import GovUkRadioGroup from '../forms/GovUkRadioGroup'
 import { properCase } from './utils'
 
 export default class NotesUtils {
-  static sensitiveValueAutomatedHint =
+  static sensitiveInfoContentMarkedAsSensitive =
     'This note will be automatically marked sensitive as an earlier note was already flagged.'
+
+  static sensitiveInfoContentDontInclude = `Don't include sensitive or individual information.`
 
   static formData(query: BodyWithNotes): BodyWithNotes {
     return { notes: query.notes, isSensitive: query.isSensitive }
@@ -104,6 +106,7 @@ export default class NotesUtils {
     if (!includeIsSensitiveQuestion) {
       return {
         notes,
+        sensitiveInfoContent: NotesUtils.sensitiveInfoContentDontInclude,
       }
     }
     const showIsSensitiveQuestion = appointment?.sensitive !== true
@@ -120,7 +123,7 @@ export default class NotesUtils {
 
     return {
       notes,
-      sensitiveInfoContent: NotesUtils.sensitiveValueAutomatedHint,
+      sensitiveInfoContent: NotesUtils.sensitiveInfoContentMarkedAsSensitive,
     }
   }
 

--- a/server/utils/notesUtils.ts
+++ b/server/utils/notesUtils.ts
@@ -120,7 +120,7 @@ export default class NotesUtils {
 
     return {
       notes,
-      notesHint: { text: NotesUtils.sensitiveValueAutomatedHint },
+      sensitiveInfoContent: NotesUtils.sensitiveValueAutomatedHint,
     }
   }
 

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -27,4 +27,6 @@
     },
     items: isSensitiveItems
   }) }}
+{% else %}
+  <p class="govuk-body">{{ sensitiveInfoContent }}</p>
 {% endif %}

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {{ govukTextarea({
   name: "notes",
@@ -12,8 +12,8 @@
     isPageHeading: false
   }
 }) }}
-{% if isSensitiveItems | length %}
-  {{ govukRadios({
+{% if isSensitiveItem | length %}
+  {{ govukCheckboxes({
     name: 'isSensitive',
     fieldset: {
       legend: {
@@ -22,10 +22,7 @@
         isPageHeading: false
       }
     },
-    hint: {
-      text: 'This is information that you believe must be recorded but not shared with a person on probation. If they make a request for their record, the Data Protection Team will decide whether the information can be shared.'
-    },
-    items: isSensitiveItems
+    items: isSensitiveItem
   }) }}
 {% else %}
   <p class="govuk-body">{{ sensitiveInfoContent }}</p>

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -5,7 +5,6 @@
   name: "notes",
   id: "notes",
   value: notes,
-  hint: notesHint,
   errorMessage: errors.notes,
   label: {
     text: "Notes",


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1109)

## Changes in this PR
- Make sensitive info question a checkbox
- Remove hint from notes field
- Show a message in place of the sensitive info question when updating bulk appointments
- Show a message in place of the sensitive info question when the appointment has been previously flagged as sensitive

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
#### Record attendance page
When `isSensitive` is undefined or false
<img width="1258" height="328" alt="Screenshot 2026-06-29 at 14 55 51" src="https://github.com/user-attachments/assets/7a95c1f7-68c5-4b45-8b3e-de2d6ddb57e0" />

When `isSensitive` is true
<img width="1294" height="338" alt="Screenshot 2026-06-29 at 12 54 54" src="https://github.com/user-attachments/assets/af534eb3-4b74-45fe-a1f4-7e1a2f8d21a2" />

Bulk update
<img width="869" height="349" alt="Screenshot 2026-06-29 at 12 55 35" src="https://github.com/user-attachments/assets/63384f72-9550-4c4e-9d2c-c1666cef7ab3" />

#### Check your answers page

When the appointment was previously marked as sensitive
<img width="1184" height="94" alt="Screenshot 2026-06-29 at 18 00 00" src="https://github.com/user-attachments/assets/ab817fc6-d532-46a6-88d4-350d3028155d" />

When the current update checks the sensitive box
<img width="1190" height="95" alt="Screenshot 2026-06-29 at 17 58 50" src="https://github.com/user-attachments/assets/87edba99-5814-4b59-9504-a65fdcd8d402" />

When the current update does not check the sensitive box
<img width="1178" height="93" alt="Screenshot 2026-06-29 at 17 58 24" src="https://github.com/user-attachments/assets/ad27d3d6-e044-4392-82ad-46e6a142e887" />

When bulk updating appointments (does not show)
<img width="1193" height="134" alt="image" src="https://github.com/user-attachments/assets/2aa39916-df1a-4065-8a13-d0bac5bad44f" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
