### PR TITLE
CPB-394 - Remove hi-vis and worked intensively questions from compliance page

### DIFF
--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -72,10 +72,7 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
   }
 
   async toShowComplianceAnswer() {
-    await this.confirmPage.details.expect.toHaveItemWith(
-      'Compliance',
-      'Wore hi-vis - YesWorking intensively - YesWork quality - GoodBehaviour - Poor',
-    )
+    await this.confirmPage.details.expect.toHaveItemWith('Compliance', 'Work quality - GoodBehaviour - Poor')
 
     await this.confirmPage.details.expect.toHaveItemWith('Notes', 'There were some issues')
   }

--- a/e2e-tests/pages/appointments/logCompliancePage.ts
+++ b/e2e-tests/pages/appointments/logCompliancePage.ts
@@ -2,26 +2,18 @@ import { Locator, Page } from '@playwright/test'
 import AppointmentFormPage from './appointmentFormPage'
 
 export default class LogCompliancePage extends AppointmentFormPage {
-  hiVisFieldLocator: Locator
-
-  workedIntensivelyFieldLocator: Locator
-
-  workedQualityFieldLocator: Locator
+  workQualityFieldLocator: Locator
 
   behaviourFieldLocator: Locator
 
   constructor(page: Page) {
     super(page, 'Log compliance')
-    this.hiVisFieldLocator = page.getByRole('group', { name: 'Did they wear hi-vis?' })
-    this.workedIntensivelyFieldLocator = page.getByRole('group', { name: 'Are they working intensively' })
-    this.workedQualityFieldLocator = page.getByRole('group', { name: 'How was their work quality?' })
+    this.workQualityFieldLocator = page.getByRole('group', { name: 'How was their work quality?' })
     this.behaviourFieldLocator = page.getByRole('group', { name: 'How was their behaviour?' })
   }
 
   async enterComplianceDetails() {
-    await this.hiVisFieldLocator.getByRole('radio', { name: 'Yes' }).check()
-    await this.workedIntensivelyFieldLocator.getByRole('radio', { name: 'Yes' }).check()
-    await this.workedQualityFieldLocator.getByRole('radio', { name: 'Good' }).check()
+    await this.workQualityFieldLocator.getByRole('radio', { name: 'Good' }).check()
     await this.behaviourFieldLocator.getByRole('radio', { name: 'Poor' }).check()
   }
 }

--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -102,14 +102,6 @@ export default class CheckAppointmentDetailsPage extends Page {
 
   shouldContainComplianceDetails(): void {
     this.complianceDetails
-      .getValueWithLabel('Wore hi-vis')
-      .should('contain.text', yesNoDisplayValue(this.appointment.attendanceData.hiVisWorn))
-
-    this.complianceDetails
-      .getValueWithLabel('Working intensively')
-      .should('contain.text', yesNoDisplayValue(this.appointment.attendanceData.workedIntensively))
-
-    this.complianceDetails
       .getValueWithLabel('Work quality')
       .should('contain.text', AppointmentUtils.formatComplianceRatings(this.appointment.attendanceData.workQuality))
 

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -35,10 +35,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
 
     this.formDetails
       .getValueWithLabel('Compliance')
-      .should(
-        'contain.html',
-        'Wore hi-vis - No<br>Working intensively - No<br>Work quality - Good<br>Behaviour - Not applicable',
-      )
+      .should('contain.html', 'Work quality - Good<br>Behaviour - Not applicable')
     this.formDetails.getValueWithLabel('Notes').should('contain.text', 'Test')
 
     if (expectIsSensitiveAnswer) {

--- a/integration_tests/pages/appointments/logCompliancePage.ts
+++ b/integration_tests/pages/appointments/logCompliancePage.ts
@@ -7,10 +7,6 @@ import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 export default class LogCompliancePage extends BaseAppointmentFormPage {
   protected override page: AppointmentFormPage = 'log-compliance'
 
-  private readonly hiVisOptions = new RadioOrCheckboxGroupComponent('hiVis')
-
-  private readonly workedIntensivelyOptions = new RadioOrCheckboxGroupComponent('workedIntensively')
-
   private readonly workQualityOptions = new RadioOrCheckboxGroupComponent('workQuality')
 
   private readonly behaviourOptions = new RadioOrCheckboxGroupComponent('behaviour')
@@ -20,15 +16,11 @@ export default class LogCompliancePage extends BaseAppointmentFormPage {
   }
 
   completeForm(): void {
-    this.hiVisOptions.checkOptionWithValue('yes')
-    this.workedIntensivelyOptions.checkOptionWithValue('no')
     this.workQualityOptions.checkOptionWithValue('GOOD')
     this.behaviourOptions.checkOptionWithValue('UNSATISFACTORY')
   }
 
   shouldShowEnteredAnswers(attendanceData: AttendanceDataDto) {
-    this.hiVisOptions.shouldHaveSelectedValue(attendanceData.hiVisWorn ? 'yes' : 'no')
-    this.workedIntensivelyOptions.shouldHaveSelectedValue(attendanceData.workedIntensively ? 'yes' : 'no')
     this.workQualityOptions.shouldHaveSelectedValue(attendanceData.workQuality)
     this.behaviourOptions.shouldHaveSelectedValue(attendanceData.behaviour)
   }

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -106,8 +106,6 @@ context('Confirm appointment details page', () => {
       startTime: '09:00',
       endTime: '16:00',
       attendanceData: attendanceDataFactory.build({
-        hiVisWorn: false,
-        workedIntensively: false,
         workQuality: 'GOOD',
         behaviour: 'NOT_APPLICABLE',
       }),

--- a/integration_tests/tests/appointments/logCompliance.cy.ts
+++ b/integration_tests/tests/appointments/logCompliance.cy.ts
@@ -43,8 +43,6 @@ context('Log compliance', () => {
   it('validates form data', function test() {
     const form = appointmentOutcomeFormFactory.build({
       attendanceData: {
-        hiVisWorn: null,
-        workedIntensively: null,
         workQuality: null,
         behaviour: null,
       },
@@ -61,8 +59,6 @@ context('Log compliance', () => {
     page.clickSubmit()
 
     // Then I see the log compliance page with errors
-    page.shouldShowErrorSummary('hiVis', 'Select whether a Hi-Vis was worn')
-    page.shouldShowErrorSummary('workedIntensively', 'Select whether they worked intensively')
     page.shouldShowErrorSummary('workQuality', 'Select their work quality')
     page.shouldShowErrorSummary('behaviour', 'Select their behaviour')
     page.shouldNotHaveAnySelectedValues()

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -70,9 +70,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
         endTime: '16:00',
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
         attendanceData: attendanceDataFactory.build({
-          hiVisWorn: false,
           penaltyMinutes: 60,
-          workedIntensively: false,
           workQuality: 'GOOD',
           behaviour: 'NOT_APPLICABLE',
         }),

--- a/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/logCompliance.cy.ts
@@ -11,8 +11,6 @@ import appointmentFactory from '../../../../server/testutils/factories/appointme
 
 context('Group Session Bulk Update - Log Compliance', () => {
   const attendanceData = {
-    hiVisWorn: null,
-    workedIntensively: null,
     workQuality: null,
     behaviour: null,
   }
@@ -50,8 +48,6 @@ context('Group Session Bulk Update - Log Compliance', () => {
     const page = LogCompliancePage.visitForSession(this.session)
     page.clickSubmit()
 
-    page.shouldShowErrorSummary('hiVis', 'Select whether a Hi-Vis was worn')
-    page.shouldShowErrorSummary('workedIntensively', 'Select whether they worked intensively')
     page.shouldShowErrorSummary('workQuality', 'Select their work quality')
     page.shouldShowErrorSummary('behaviour', 'Select their behaviour')
     page.shouldNotHaveAnySelectedValues()

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -317,46 +317,6 @@ describe('ConfirmPage', () => {
       })
 
       describe('compliance answers', () => {
-        describe('when hiVisWorn is true', () => {
-          it('returns `Yes`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { hiVisWorn: true } })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Wore hi-vis - Yes')
-          })
-        })
-
-        describe('when hiVisWorn is false', () => {
-          it('returns `No`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { hiVisWorn: false } })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Wore hi-vis - No')
-          })
-        })
-
-        describe('when workedIntensively is false', () => {
-          it('returns `No`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({
-              attendanceData: { workedIntensively: false },
-            })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Working intensively - No')
-          })
-        })
-
-        describe('when workedIntensively is true', () => {
-          it('returns `Yes`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({
-              attendanceData: { workedIntensively: true },
-            })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Working intensively - Yes')
-          })
-        })
-
         describe('when workQuality is NOT_APPLICABLE', () => {
           it('returns `Not applicable`', () => {
             const formComplianceAnswers = appointmentOutcomeFormFactory.build({
@@ -404,7 +364,7 @@ describe('ConfirmPage', () => {
         const contactOutcome = contactOutcomeFactory.build({ attended: true })
         const submitted = appointmentOutcomeFormFactory.build({
           contactOutcome,
-          attendanceData: { hiVisWorn: true, workedIntensively: true },
+          attendanceData: { workQuality: 'GOOD', behaviour: 'NOT_APPLICABLE' },
         })
         const result = page.viewData(appointment, submitted).submittedItems
 
@@ -413,7 +373,7 @@ describe('ConfirmPage', () => {
             text: 'Compliance',
           },
           value: {
-            html: 'Wore hi-vis - Yes<br>Working intensively - Yes<br>Work quality - Good<br>Behaviour - Not applicable',
+            html: 'Work quality - Good<br>Behaviour - Not applicable',
           },
           actions: {
             items: [

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -262,14 +262,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   getComplianceAnswers(form: AppointmentOutcomeForm): string {
     let answers = ''
 
-    if (typeof form.attendanceData?.hiVisWorn === 'boolean') {
-      answers += `Wore hi-vis - ${form.attendanceData.hiVisWorn ? 'Yes' : 'No'}<br>`
-    }
-
-    if (typeof form.attendanceData?.workedIntensively === 'boolean') {
-      answers += `Working intensively - ${form.attendanceData.workedIntensively ? 'Yes' : 'No'}<br>`
-    }
-
     if (form.attendanceData?.workQuality) {
       answers += `Work quality - ${AppointmentUtils.formatComplianceRatings(form.attendanceData.workQuality)}<br>`
     }

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -1,5 +1,5 @@
 import { AppointmentDto } from '../../@types/shared'
-import { AppointmentOutcomeForm, GovUkRadioOrCheckboxOption } from '../../@types/user-defined'
+import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
@@ -79,22 +79,6 @@ describe('LogCompliancePage', () => {
     })
 
     describe('items', () => {
-      it('should return items for hiVis', async () => {
-        const items = ['items'] as unknown as GovUkRadioOrCheckboxOption[]
-        jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-
-        const result = page.viewData(appointment, form)
-        expect(result.hiVisItems).toEqual(items)
-      })
-
-      it('should return items for workedIntensively', async () => {
-        const items = ['items'] as unknown as GovUkRadioOrCheckboxOption[]
-        jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-
-        const result = page.viewData(appointment, form)
-        expect(result.workedIntensivelyItems).toEqual(items)
-      })
-
       describe('workQuality', () => {
         it('should return items for workQuality without checked answer from form', async () => {
           form = appointmentOutcomeFormFactory.build({
@@ -157,30 +141,26 @@ describe('LogCompliancePage', () => {
         })
       })
 
-      it('should return items from query if page has errors', () => {
+      it('should return items from form if page has errors', () => {
+        const formData = appointmentOutcomeFormFactory.build({
+          attendanceData: {
+            workQuality: 'POOR',
+            behaviour: 'GOOD',
+          },
+        })
         page = new LogCompliancePage({
-          hiVis: null,
-          workedIntensively: 'no',
-          behaviour: 'GOOD',
-          workQuality: 'POOR',
+          behaviour: null,
+          workQuality: 'EXCELLENT',
         })
         page.validate()
 
-        const result = page.viewData(appointment, form)
+        const result = page.viewData(appointment, formData)
 
         expect(result).toEqual(
           expect.objectContaining({
             workQualityItems: [
-              { text: 'Excellent', value: 'EXCELLENT', checked: false },
+              { text: 'Excellent', value: 'EXCELLENT', checked: true },
               { text: 'Good', value: 'GOOD', checked: false },
-              { text: 'Satisfactory', value: 'SATISFACTORY', checked: false },
-              { text: 'Unsatisfactory', value: 'UNSATISFACTORY', checked: false },
-              { text: 'Poor', value: 'POOR', checked: true },
-              { text: 'Not applicable', value: 'NOT_APPLICABLE', checked: false },
-            ],
-            behaviourItems: [
-              { text: 'Excellent', value: 'EXCELLENT', checked: false },
-              { text: 'Good', value: 'GOOD', checked: true },
               { text: 'Satisfactory', value: 'SATISFACTORY', checked: false },
               { text: 'Unsatisfactory', value: 'UNSATISFACTORY', checked: false },
               { text: 'Poor', value: 'POOR', checked: false },
@@ -193,30 +173,6 @@ describe('LogCompliancePage', () => {
   })
 
   describe('validate', () => {
-    describe('when hiVis is not present', () => {
-      it('should return the correct error', () => {
-        page = new LogCompliancePage({ hiVis: null })
-        page.validate()
-
-        expect(page.validationErrors.hiVis).toEqual({
-          text: 'Select whether a Hi-Vis was worn',
-        })
-        expect(page.hasError).toBe(true)
-      })
-    })
-
-    describe('when workedIntensively is not present', () => {
-      it('should return the correct error', () => {
-        page = new LogCompliancePage({ workedIntensively: null })
-        page.validate()
-
-        expect(page.validationErrors.workedIntensively).toEqual({
-          text: 'Select whether they worked intensively',
-        })
-        expect(page.hasError).toBe(true)
-      })
-    })
-
     describe('when workQuality is not present', () => {
       it('should return the correct error', () => {
         page = new LogCompliancePage({ workQuality: null })
@@ -279,8 +235,6 @@ describe('LogCompliancePage', () => {
     it('updates and returns data from query given object with existing data', () => {
       const form = appointmentOutcomeFormFactory.build({ startTime: '10:00', attendanceData: { penaltyMinutes: 60 } })
       const query: LogComplianceQuery = {
-        hiVis: 'no',
-        workedIntensively: 'no',
         workQuality: 'EXCELLENT',
         behaviour: 'GOOD',
       }
@@ -294,8 +248,6 @@ describe('LogCompliancePage', () => {
         startTime: '10:00',
         attendanceData: {
           penaltyMinutes: 60,
-          hiVisWorn: false,
-          workedIntensively: false,
           workQuality: 'EXCELLENT',
           behaviour: 'GOOD',
         },

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -6,29 +6,21 @@ import {
   AppointmentUpdateQuery,
   GovUkRadioOrCheckboxOption,
   ValidationErrors,
-  YesOrNo,
 } from '../../@types/user-defined'
-import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
-  hiVisItems: GovUkRadioOrCheckboxOption[]
-  workedIntensivelyItems: GovUkRadioOrCheckboxOption[]
   workQualityItems: GovUkRadioOrCheckboxOption[]
   behaviourItems: GovUkRadioOrCheckboxOption[]
 }
 
 interface Body {
-  hiVis: YesOrNo
-  workedIntensively: YesOrNo
   workQuality: NonNullable<AttendanceDataDto['workQuality']>
   behaviour: NonNullable<AttendanceDataDto['behaviour']>
 }
 
 export interface LogComplianceQuery extends AppointmentUpdateQuery {
-  hiVis?: YesOrNo
-  workedIntensively?: YesOrNo
   workQuality?: AttendanceDataDto['workQuality']
   behaviour?: AttendanceDataDto['behaviour']
 }
@@ -50,8 +42,6 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
 
       attendanceData: {
         ...data.attendanceData,
-        hiVisWorn: GovUkRadioGroup.valueFromYesOrNoItem(this.query.hiVis),
-        workedIntensively: GovUkRadioGroup.valueFromYesOrNoItem(this.query.workedIntensively),
         workQuality: this.query.workQuality,
         behaviour: this.query.behaviour,
       },
@@ -62,26 +52,12 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     const formValues = this.getFormDisplayValues(form)
     return {
       ...this.commonViewData({ appointmentOrSession, form }),
-      hiVisItems: GovUkRadioGroup.yesNoItems({
-        checkedValue: formValues.hiVis,
-      }),
-      workedIntensivelyItems: GovUkRadioGroup.yesNoItems({
-        checkedValue: formValues.workedIntensively,
-      }),
       workQualityItems: this.getItems(formValues.workQuality),
       behaviourItems: this.getItems(formValues.behaviour),
     }
   }
 
   validate() {
-    if (!this.query.hiVis) {
-      this.validationErrors.hiVis = { text: 'Select whether a Hi-Vis was worn' }
-    }
-
-    if (!this.query.workedIntensively) {
-      this.validationErrors.workedIntensively = { text: 'Select whether they worked intensively' }
-    }
-
     if (!this.query.workQuality) {
       this.validationErrors.workQuality = { text: 'Select their work quality' }
     }
@@ -123,8 +99,6 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }
 
     return {
-      hiVis: GovUkRadioGroup.determineCheckedValue(form.attendanceData?.hiVisWorn),
-      workedIntensively: GovUkRadioGroup.determineCheckedValue(form.attendanceData?.workedIntensively),
       workQuality: form.attendanceData?.workQuality,
       behaviour: form.attendanceData?.behaviour,
     }

--- a/server/testutils/factories/attendanceDataFactory.ts
+++ b/server/testutils/factories/attendanceDataFactory.ts
@@ -1,10 +1,7 @@
 import { Factory } from 'fishery'
-import { faker } from '@faker-js/faker'
 import { AttendanceDataDto } from '../../@types/shared'
 
 export default Factory.define<AttendanceDataDto>(() => ({
-  hiVisWorn: faker.datatype.boolean(),
-  workedIntensively: faker.datatype.boolean(),
   penaltyMinutes: 60,
   workQuality: 'GOOD',
   behaviour: 'NOT_APPLICABLE',

--- a/server/views/appointments/update/logCompliance.njk
+++ b/server/views/appointments/update/logCompliance.njk
@@ -6,28 +6,6 @@
 
 {% block formContent %}
       {{ govukRadios({
-        name: "hiVis",
-        fieldset: {
-          legend: {
-            text: "Did they wear hi-vis?",
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: hiVisItems,
-        errorMessage: errors.hiVis
-      }) }}
-      {{ govukRadios({
-        name: "workedIntensively",
-        fieldset: {
-          legend: {
-            text: "Are they working intensively (28 hours of unpaid work over a 4-day week)?",
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: workedIntensivelyItems,
-        errorMessage: errors.workedIntensively
-      }) }}
-      {{ govukRadios({
         name: "workQuality",
         fieldset: {
           legend: {


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-394?atlOrigin=eyJpIjoiZDMxMzAyOTgxNWE1NDgxZTg2MmI1YmRhMDJiZTVkYWYiLCJwIjoiaiJ9)

## Context
Remove hi-vis and worked intensively questions from appearing on compliance, confirm and check appointment details pages.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR


<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes
<img width="1310" height="877" alt="Screenshot 2026-07-01 at 14 40 40" src="https://github.com/user-attachments/assets/5b6052b1-0405-4c2a-9652-a4096b05bce8" />
<img width="1313" height="1096" alt="Screenshot 2026-07-01 at 14 40 19" src="https://github.com/user-attachments/assets/87f0e1c6-b294-42dc-bf5a-16fdc3d42469" />
<img width="1009" height="1252" alt="Screenshot 2026-07-01 at 14 29 16" src="https://github.com/user-attachments/assets/72445e56-67e4-464f-9335-5a73224a7ae8" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
