### PR TITLE
CPB-1070: Create project components

### DIFF
--- a/e2e-tests/pages/components/projectQuestionsComponent.ts
+++ b/e2e-tests/pages/components/projectQuestionsComponent.ts
@@ -1,0 +1,22 @@
+import { Locator, Page } from '@playwright/test'
+import { Team } from '../../fixtures/testOptions'
+
+export default class ProjectQuestionsComponent {
+  private readonly teamFieldLocator: Locator
+
+  private readonly applyTeamButtonLocator: Locator
+
+  private readonly projectFieldLocator: Locator
+
+  constructor(page: Page) {
+    this.teamFieldLocator = page.getByLabel('Project team')
+    this.applyTeamButtonLocator = page.getByRole('button', { name: 'Select team' })
+    this.projectFieldLocator = page.getByLabel('Choose project', { exact: true })
+  }
+
+  async selectProject(team: Team, projectName: string) {
+    await this.teamFieldLocator.selectOption({ label: team.name })
+    await this.applyTeamButtonLocator.click()
+    await this.projectFieldLocator.selectOption({ label: projectName })
+  }
+}

--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -5,8 +5,8 @@ import BasePage from '../basePage'
 import { CourseCompletionPage } from '../../../server/pages/courseCompletions/process/pathMap'
 import HoursMinutesInputComponent from '../components/hoursMinutesInputComponent'
 import DateInputComponent from '../components/dateInputComponent'
-import { Team } from '../../fixtures/testOptions'
 import DateTimeFormats from '../../../server/utils/dateTimeUtils'
+import ProjectQuestionsComponent from '../components/projectQuestionsComponent'
 
 export default class CourseCompletionFormPage extends BasePage {
   readonly expect: CourseCompletionFormPageAssertions
@@ -14,12 +14,6 @@ export default class CourseCompletionFormPage extends BasePage {
   private readonly crnFieldLocator: Locator
 
   private readonly requirementRadioGroupLocator: Locator
-
-  private readonly teamFieldLocator: Locator
-
-  private readonly applyTeamButtonLocator: Locator
-
-  private readonly projectFieldLocator: Locator
 
   private readonly hoursMinutesInput: HoursMinutesInputComponent
 
@@ -37,6 +31,8 @@ export default class CourseCompletionFormPage extends BasePage {
 
   private readonly unableToCreditTimeLink: Locator
 
+  readonly projectQuestions: ProjectQuestionsComponent
+
   constructor(
     page: Page,
     readonly hasExistingAppointments: boolean = false,
@@ -48,9 +44,7 @@ export default class CourseCompletionFormPage extends BasePage {
     this.continueButtonLocator = page.getByRole('button', { name: 'Continue' })
     this.crnFieldLocator = page.getByLabel('Add a CRN')
     this.requirementRadioGroupLocator = page.getByRole('group', { name: 'Existing requirements' })
-    this.teamFieldLocator = page.getByLabel('Project team')
-    this.applyTeamButtonLocator = page.getByRole('button', { name: 'Select team' })
-    this.projectFieldLocator = page.getByLabel('Choose project', { exact: true })
+    this.projectQuestions = new ProjectQuestionsComponent(page)
     this.existingAppointmentsRadioGroupLocator = page.getByRole('group', { name: 'Existing appointments' })
     this.submitButtonLocator = page.getByRole('button', { name: 'Submit' })
     this.createNewAppointmentButton = page.getByRole('button', { name: 'Create an appointment' })
@@ -76,12 +70,6 @@ export default class CourseCompletionFormPage extends BasePage {
         name: DateTimeFormats.dateObjtoUIDate(appointment.date),
       })
       .check()
-  }
-
-  async selectProject(team: Team, projectName: string) {
-    await this.teamFieldLocator.selectOption({ label: team.name })
-    await this.applyTeamButtonLocator.click()
-    await this.projectFieldLocator.selectOption({ label: projectName })
   }
 
   async completeOutcomeForm(

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -52,7 +52,7 @@ test('Process course completion - credit time on existing appointment', async ({
 
   await courseCompletionFormPage.expect.toBeOnThePage('project')
   const [projectName] = e2eProjects
-  await courseCompletionFormPage.selectProject(team, projectName)
+  await courseCompletionFormPage.projectQuestions.selectProject(team, projectName)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -51,7 +51,7 @@ test('Process course completion - create new appointment', async ({
 
   const [projectName] = e2eProjects
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, projectName)
+  await courseCompletionFormPage.projectQuestions.selectProject(team, projectName)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')

--- a/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
+++ b/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
@@ -52,7 +52,7 @@ test('Process course completion - use recommended CRN', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, firstProject)
+  await courseCompletionFormPage.projectQuestions.selectProject(team, firstProject)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')
@@ -96,7 +96,7 @@ test('Process course completion - use recommended CRN', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, secondProject)
+  await courseCompletionFormPage.projectQuestions.selectProject(team, secondProject)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')

--- a/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
+++ b/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
@@ -51,7 +51,7 @@ test('Process course completion failure', async ({
 
   const [projectName] = e2eProjects
   await courseCompletionFormPage.expect.toBeOnThePage('project')
-  await courseCompletionFormPage.selectProject(team, projectName)
+  await courseCompletionFormPage.projectQuestions.selectProject(team, projectName)
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('appointments')

--- a/integration_tests/pages/components/errorSummaryComponent.ts
+++ b/integration_tests/pages/components/errorSummaryComponent.ts
@@ -1,0 +1,5 @@
+export default class ErrorSummaryComponent {
+  shouldShowErrorSummary(field: string, errorMessage: string) {
+    cy.get(`[data-cy-error-${field}]`).should('contain', errorMessage)
+  }
+}

--- a/integration_tests/pages/components/projectQuestionsComponent.ts
+++ b/integration_tests/pages/components/projectQuestionsComponent.ts
@@ -1,0 +1,26 @@
+import { ProjectOutcomeSummaryDto, ProviderTeamSummaryDto } from '../../../server/@types/shared'
+import ErrorSummaryComponent from './errorSummaryComponent'
+import SelectInput from './selectComponent'
+
+export default class ProjectQuestionsComponent extends ErrorSummaryComponent {
+  readonly teamInput = new SelectInput('team')
+
+  readonly projectInput = new SelectInput('project')
+
+  selectTeam(team: ProviderTeamSummaryDto) {
+    this.teamInput.select(team.code)
+    cy.get('button').contains('Select team').click()
+  }
+
+  selectProject(project: ProjectOutcomeSummaryDto) {
+    this.projectInput.select(project.projectCode)
+  }
+
+  shouldShowTeamError() {
+    this.shouldShowErrorSummary('team', 'Choose a team')
+  }
+
+  shouldShowProjectError() {
+    this.shouldShowErrorSummary('project', 'Choose a project')
+  }
+}

--- a/integration_tests/pages/courseCompletions/process/projectPage.ts
+++ b/integration_tests/pages/courseCompletions/process/projectPage.ts
@@ -1,20 +1,15 @@
-import {
-  EteCourseCompletionEventDto,
-  ProjectOutcomeSummaryDto,
-  ProviderTeamSummaryDto,
-} from '../../../../server/@types/shared'
+import { EteCourseCompletionEventDto } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths'
 import { pathWithQuery } from '../../../../server/utils/utils'
-import SelectInput from '../../components/selectComponent'
+import ProjectQuestionsComponent from '../../components/projectQuestionsComponent'
 import BaseCourseCompletionsPage from './baseCourseCompletionsPage'
 
 export default class ProjectPage extends BaseCourseCompletionsPage {
-  readonly teamInput = new SelectInput('team')
-
-  readonly projectInput = new SelectInput('project')
+  readonly form: ProjectQuestionsComponent
 
   constructor() {
     super('Match with a project')
+    this.form = new ProjectQuestionsComponent()
   }
 
   static visit(courseCompletion: EteCourseCompletionEventDto) {
@@ -22,22 +17,5 @@ export default class ProjectPage extends BaseCourseCompletionsPage {
       form: '12',
     })
     return this.visitAndCheck(path)
-  }
-
-  selectTeam(team: ProviderTeamSummaryDto) {
-    this.teamInput.select(team.code)
-    cy.get('button').contains('Select team').click()
-  }
-
-  selectProject(project: ProjectOutcomeSummaryDto) {
-    this.projectInput.select(project.projectCode)
-  }
-
-  shouldShowTeamError() {
-    this.shouldShowErrorSummary('team', 'Choose a team')
-  }
-
-  shouldShowProjectError() {
-    this.shouldShowErrorSummary('project', 'Choose a project')
   }
 }

--- a/integration_tests/tests/appointments/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/appointments/chooseSupervisor.cy.ts
@@ -131,7 +131,7 @@ context('Choose supervisor', () => {
         'stubGetAppointmentForm',
         appointmentOutcomeFormFactory.build({
           supervisor: supervisors[1],
-          team: providerTeamSummaryFactory.build({ code: appointment.supervisingTeamCode }),
+          supervisingTeam: providerTeamSummaryFactory.build({ code: appointment.supervisingTeamCode }),
         }),
       )
 

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -267,7 +267,7 @@ context('Confirm details page', () => {
 
       // Then I can see the project page
       const projectPage = Page.verifyOnPage(ProjectPage)
-      projectPage.teamInput.shouldHaveValue(team.code)
+      projectPage.form.teamInput.shouldHaveValue(team.code)
     })
 
     // Scenario: Changing the Project
@@ -280,7 +280,7 @@ context('Confirm details page', () => {
 
       // Then I can see the project page
       const projectPage = Page.verifyOnPage(ProjectPage)
-      projectPage.projectInput.shouldHaveValue(project.projectCode)
+      projectPage.form.projectInput.shouldHaveValue(project.projectCode)
     })
 
     // Scenario: Changing the requirement

--- a/integration_tests/tests/courseCompletions/process/matchProject.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/matchProject.cy.ts
@@ -62,11 +62,11 @@ context('Project Page', () => {
     const page = ProjectPage.visit(courseCompletion)
 
     // When I select a project team
-    page.selectTeam(team)
-    page.teamInput.shouldHaveValue(team.code)
+    page.form.selectTeam(team)
+    page.form.teamInput.shouldHaveValue(team.code)
 
     // And I select a project and click continue
-    page.selectProject(project)
+    page.form.selectProject(project)
     page.clickSubmit()
 
     // Then I see the next page
@@ -84,8 +84,8 @@ context('Project Page', () => {
     const page = ProjectPage.visit(courseCompletion)
 
     // Then I see the previously entered answers
-    page.teamInput.shouldHaveValue(team.code)
-    page.projectInput.shouldHaveValue(project.projectCode)
+    page.form.teamInput.shouldHaveValue(team.code)
+    page.form.projectInput.shouldHaveValue(project.projectCode)
   })
 
   describe('validation', () => {
@@ -99,7 +99,7 @@ context('Project Page', () => {
 
       // Then I see errors
       Page.verifyOnPage(ProjectPage)
-      page.shouldShowTeamError()
+      page.form.shouldShowTeamError()
     })
 
     // Scenario: displays project error
@@ -110,15 +110,15 @@ context('Project Page', () => {
       const page = ProjectPage.visit(courseCompletion)
 
       // When I select a project team
-      page.selectTeam(team)
-      page.teamInput.shouldHaveValue(team.code)
+      page.form.selectTeam(team)
+      page.form.teamInput.shouldHaveValue(team.code)
 
       // And I click continue
       page.clickSubmit()
 
       // Then I see errors
       Page.verifyOnPage(ProjectPage)
-      page.shouldShowProjectError()
+      page.form.shouldShowProjectError()
     })
   })
 

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -39,7 +39,7 @@ export type AppointmentOutcomeForm = {
   endTime?: string
   contactOutcome?: ContactOutcomeDto
   supervisor?: SupervisorSummaryDto
-  team?: ProviderTeamSummaryDto
+  supervisingTeam?: ProviderTeamSummaryDto
   attendanceData?: AttendanceDataDto
   enforcement?: EnforcementOutcomeForm
   originalSearch: Record<string, string>

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -39,7 +39,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
 
-      const team = _req.query.team?.toString() || form?.team?.code
+      const team = _req.query.team?.toString() || form?.supervisingTeam?.code
 
       const supervisors = team
         ? await this.providerService.getSupervisors({

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -6,7 +6,7 @@ import { AppointmentDto, UpdateAppointmentDto } from '../../@types/shared'
 import { AppointmentOrSessionParams, AppointmentOutcomeForm, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
-import NotesUtils from '../../utils/notesUtils'
+import NotesUtils from '../../utils/components/notesUtils'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import SessionService from '../../services/sessionService'
 

--- a/server/controllers/courseCompletions/process/outcomeController.test.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.test.ts
@@ -12,7 +12,7 @@ import OffenderService from '../../../services/offenderService'
 import unpaidWorkDetailsFactory from '../../../testutils/factories/unpaidWorkDetailsFactory'
 import offenderFullFactory from '../../../testutils/factories/offenderFullFactory'
 import appointmentFactory from '../../../testutils/factories/appointmentFactory'
-import NotesUtils from '../../../utils/notesUtils'
+import NotesUtils from '../../../utils/components/notesUtils'
 import { GovUkSummaryListItem, YesOrNo } from '../../../@types/user-defined'
 import AppointmentService from '../../../services/appointmentService'
 

--- a/server/controllers/courseCompletions/process/outcomeController.ts
+++ b/server/controllers/courseCompletions/process/outcomeController.ts
@@ -12,7 +12,7 @@ import {
 import CourseCompletionUtils, { CourseDetails } from '../../../utils/courseCompletionUtils'
 import { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import OffenderService from '../../../services/offenderService'
-import NotesUtils from '../../../utils/notesUtils'
+import NotesUtils from '../../../utils/components/notesUtils'
 import AppointmentService from '../../../services/appointmentService'
 import { EteCourseCompletionEventDto } from '../../../@types/shared'
 

--- a/server/controllers/courseCompletions/process/projectController.test.ts
+++ b/server/controllers/courseCompletions/process/projectController.test.ts
@@ -7,14 +7,11 @@ import courseCompletionFactory from '../../../testutils/factories/courseCompleti
 import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
 import ProviderService from '../../../services/providerService'
-import { GovUkSelectOption } from '../../../@types/user-defined'
-import getTeams from '../../shared/getTeams'
 import ProjectService from '../../../services/projectService'
-import pagedModelProjectOutcomeSummaryFactory from '../../../testutils/factories/pagedModelProjectOutcomeSummaryFactory'
-import GovUkSelectInput from '../../../forms/GovUkSelectInput'
 import AuditService from '../../../services/auditService'
+import getProjectsAndTeams from '../../shared/getProjectsAndTeams'
 
-jest.mock('../../shared/getTeams')
+jest.mock('../../shared/getProjectsAndTeams')
 
 describe('ProjectController', () => {
   const response = createMock<Response>()
@@ -39,7 +36,7 @@ describe('ProjectController', () => {
     { text: 'Team 2', value: '2' },
   ]
 
-  const getTeamsMock: jest.Mock = getTeams as unknown as jest.Mock<Promise<Array<GovUkSelectOption>>>
+  const getProjectsAndTeamsMock: jest.Mock = getProjectsAndTeams as unknown as jest.Mock
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -53,7 +50,7 @@ describe('ProjectController', () => {
     )
     courseCompletionService.getCourseCompletion.mockResolvedValue(courseCompletion)
     formService.getForm.mockResolvedValue(form)
-    getTeamsMock.mockResolvedValue(teamItems)
+    getProjectsAndTeamsMock.mockResolvedValue({ teamItems, projectItems: undefined })
   })
 
   describe('show', () => {
@@ -80,6 +77,15 @@ describe('ProjectController', () => {
         teamCode: undefined,
         projectItems: undefined,
       })
+      expect(getProjectsAndTeamsMock).toHaveBeenCalledWith({
+        projectService,
+        providerService,
+        projectTypeGroup: 'ETE',
+        providerCode,
+        teamCode: undefined,
+        projectCode: undefined,
+        response,
+      })
       expect(formService.getForm).toHaveBeenCalledTimes(1)
     })
 
@@ -94,18 +100,13 @@ describe('ProjectController', () => {
         unableToCreditTimePath: '/unable-to-credit-time',
       }
       page.viewData.mockReturnValue(viewData)
-
-      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId, team: teamCode } })
-
-      const projects = pagedModelProjectOutcomeSummaryFactory.build()
-      projectService.getProjects.mockResolvedValue(projects)
-
       const projectItems = [
         { text: 'Project 1', value: '1' },
         { text: 'Project 2', value: '2' },
       ]
+      getProjectsAndTeamsMock.mockResolvedValue({ teamItems, projectItems })
 
-      jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId, team: teamCode } })
 
       const requestHandler = projectController.show()
       await requestHandler(request, response, next)
@@ -114,11 +115,18 @@ describe('ProjectController', () => {
         ...viewData,
         teamItems,
         form: formId,
-        teamCode,
         projectItems,
       })
-
-      expect(getTeams).toHaveBeenCalledWith({ providerService, response, teamCode, providerCode })
+      expect(getProjectsAndTeamsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectService,
+          providerService,
+          projectTypeGroup: 'ETE',
+          providerCode,
+          teamCode,
+          response,
+        }),
+      )
     })
 
     it('returns selected team and projectItems if teamCode on form not undefined', async () => {
@@ -135,17 +143,12 @@ describe('ProjectController', () => {
         unableToCreditTimePath: '/unable-to-credit-time',
       }
       page.viewData.mockReturnValue(viewData)
-      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
-
-      const projects = pagedModelProjectOutcomeSummaryFactory.build()
-      projectService.getProjects.mockResolvedValue(projects)
-
       const projectItems = [
         { text: 'Project 1', value: '1' },
         { text: 'Project 2', value: '2' },
       ]
-
-      jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
+      getProjectsAndTeamsMock.mockResolvedValue({ teamItems, projectItems, teamCode })
+      const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: {} })
 
       const requestHandler = projectController.show()
       await requestHandler(request, response, next)
@@ -157,8 +160,16 @@ describe('ProjectController', () => {
         teamCode,
         projectItems,
       })
-
-      expect(getTeams).toHaveBeenCalledWith({ providerService, response, teamCode, providerCode })
+      expect(getProjectsAndTeamsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectService,
+          providerService,
+          projectTypeGroup: 'ETE',
+          providerCode,
+          teamCode,
+          response,
+        }),
+      )
     })
   })
 
@@ -211,6 +222,15 @@ describe('ProjectController', () => {
           teamCode: undefined,
           projectItems: undefined,
         })
+        expect(getProjectsAndTeamsMock).toHaveBeenCalledWith({
+          projectService,
+          providerService,
+          projectTypeGroup: 'ETE',
+          providerCode,
+          teamCode: undefined,
+          projectCode: undefined,
+          response,
+        })
         expect(formService.getForm).toHaveBeenCalledTimes(1)
       })
 
@@ -232,18 +252,13 @@ describe('ProjectController', () => {
         ]
         const errors = { project: { text: 'Error' } }
         page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
-
-        const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: { team: teamCode } })
-
-        const projects = pagedModelProjectOutcomeSummaryFactory.build()
-        projectService.getProjects.mockResolvedValue(projects)
-
         const projectItems = [
           { text: 'Project 1', value: '1' },
           { text: 'Project 2', value: '2' },
         ]
+        getProjectsAndTeamsMock.mockResolvedValue({ teamItems, projectItems, teamCode })
 
-        jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
+        const request = createMock<Request>({ params: { id: '1' }, query: { form: formId }, body: { team: teamCode } })
 
         const requestHandler = projectController.submit()
         await requestHandler(request, response, next)
@@ -257,14 +272,15 @@ describe('ProjectController', () => {
           errorSummary,
           projectItems,
         })
-
-        expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
-          projects.content,
-          'projectName',
-          'projectCode',
-          'Choose project',
-          undefined,
-        )
+        expect(getProjectsAndTeamsMock).toHaveBeenCalledWith({
+          projectService,
+          providerService,
+          projectTypeGroup: 'ETE',
+          providerCode,
+          teamCode,
+          projectCode: undefined,
+          response,
+        })
       })
 
       it('populates project code if project provided on body', async () => {
@@ -286,6 +302,11 @@ describe('ProjectController', () => {
         ]
         const errors = { project: { text: 'Error' } }
         page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+        const projectItems = [
+          { text: 'Project 1', value: '1' },
+          { text: 'Project 2', value: '2' },
+        ]
+        getProjectsAndTeamsMock.mockResolvedValue({ teamItems, projectItems, teamCode })
 
         const request = createMock<Request>({
           params: { id: '1' },
@@ -293,26 +314,17 @@ describe('ProjectController', () => {
           body: { team: teamCode, project: projectCode },
         })
 
-        const projects = pagedModelProjectOutcomeSummaryFactory.build()
-        projectService.getProjects.mockResolvedValue(projects)
-
-        const projectItems = [
-          { text: 'Project 1', value: '1' },
-          { text: 'Project 2', value: '2' },
-        ]
-
-        jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
-
         const requestHandler = projectController.submit()
         await requestHandler(request, response, next)
-
-        expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
-          projects.content,
-          'projectName',
-          'projectCode',
-          'Choose project',
+        expect(getProjectsAndTeamsMock).toHaveBeenCalledWith({
+          projectService,
+          providerService,
+          projectTypeGroup: 'ETE',
+          providerCode,
+          teamCode,
           projectCode,
-        )
+          response,
+        })
       })
     })
   })

--- a/server/controllers/courseCompletions/process/projectController.ts
+++ b/server/controllers/courseCompletions/process/projectController.ts
@@ -1,14 +1,11 @@
-import type { Response } from 'express'
-
 import ProjectPage from '../../../pages/courseCompletions/process/projectPage'
 import CourseCompletionFormService from '../../../services/forms/courseCompletionFormService'
 import CourseCompletionService from '../../../services/courseCompletionService'
 import BaseController, { StepViewDataParams } from './baseController'
-import getTeams from '../../shared/getTeams'
 import ProviderService from '../../../services/providerService'
 import ProjectService from '../../../services/projectService'
-import GovUkSelectInput from '../../../forms/GovUkSelectInput'
 import AuditService, { Page } from '../../../services/auditService'
+import getProjectsAndTeams from '../../shared/getProjectsAndTeams'
 
 export default class ProjectController extends BaseController<ProjectPage> {
   constructor(
@@ -26,12 +23,6 @@ export default class ProjectController extends BaseController<ProjectPage> {
     const { providerCode } = courseCompletion.pdu
     const teamCode = this.getPropertyValue({ propertyName: 'team', req, formData })
     const projectCode = this.getPropertyValue({ propertyName: 'project', req, formData })
-    const teamItems = await getTeams({
-      providerService: this.providerService,
-      providerCode,
-      response: res,
-      teamCode,
-    })
 
     this.auditService.sendAuditMessage({
       action: Page.VIEW_COURSE_COMPLETION_PROJECT,
@@ -40,32 +31,16 @@ export default class ProjectController extends BaseController<ProjectPage> {
       correlationId: req.id,
     })
 
-    const projectItems = await this.getProjects(res, providerCode, teamCode, projectCode)
-    return { teamItems, teamCode, projectItems, form: formId }
-  }
-
-  private async getProjects(
-    res: Response,
-    providerCode: string,
-    teamCode?: string,
-    projectCode?: string,
-  ): Promise<Array<GovUkSelectInput> | undefined> {
-    if (!teamCode) {
-      return undefined
-    }
-    const projects = await this.projectService.getProjects({
+    const items = await getProjectsAndTeams({
+      projectService: this.projectService,
+      providerService: this.providerService,
       projectTypeGroup: 'ETE',
-      username: res.locals.user.username,
       providerCode,
       teamCode,
+      projectCode,
+      response: res,
     })
 
-    return GovUkSelectInput.getOptions(
-      projects.content ?? [],
-      'projectName',
-      'projectCode',
-      'Choose project',
-      projectCode,
-    )
+    return { ...items, form: formId }
   }
 }

--- a/server/controllers/shared/getProjectsAndTeams.test.ts
+++ b/server/controllers/shared/getProjectsAndTeams.test.ts
@@ -1,0 +1,138 @@
+import type { Response } from 'express'
+import ProviderService from '../../services/providerService'
+import ProjectService from '../../services/projectService'
+import { GovUkSelectOption } from '../../@types/user-defined'
+import GovUkSelectInput from '../../forms/GovUkSelectInput'
+import getTeams from './getTeams'
+import getProjectsAndTeams from './getProjectsAndTeams'
+import pagedModelProjectOutcomeSummaryFactory from '../../testutils/factories/pagedModelProjectOutcomeSummaryFactory'
+
+jest.mock('./getTeams')
+
+describe('getProjectsAndTeams', () => {
+  const teamItems = [
+    { value: '1', text: 'Team 1' },
+    { value: '2', text: 'Team 2' },
+  ]
+  const getTeamsMock: jest.Mock = getTeams as unknown as jest.Mock<Promise<Array<GovUkSelectOption>>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    getTeamsMock.mockResolvedValue(teamItems)
+  })
+
+  it('returns only team items when team code is not provided', async () => {
+    const providerService = {} as ProviderService
+    const projectService = { getProjects: jest.fn() } as unknown as ProjectService
+
+    const response = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    const result = await getProjectsAndTeams({
+      projectService,
+      providerService,
+      projectTypeGroup: 'GROUP',
+      providerCode: 'P1',
+      response,
+    })
+
+    expect(result).toEqual({ teamItems })
+    expect(getTeamsMock).toHaveBeenCalledWith({
+      providerService,
+      providerCode: 'P1',
+      response,
+      teamCode: undefined,
+    })
+    expect(projectService.getProjects).not.toHaveBeenCalled()
+  })
+
+  it('returns team and project items when team code is provided', async () => {
+    const providerService = {} as ProviderService
+    const projects = pagedModelProjectOutcomeSummaryFactory.build()
+    const projectService = {
+      getProjects: jest.fn().mockResolvedValue(projects),
+    } as unknown as ProjectService
+
+    const response = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    const projectItems = [
+      { value: 'A', text: 'Project A' },
+      { value: 'B', text: 'Project B' },
+    ]
+    jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
+
+    const result = await getProjectsAndTeams({
+      projectService,
+      providerService,
+      projectTypeGroup: 'GROUP',
+      providerCode: 'P1',
+      teamCode: 'T1',
+      projectCode: 'B',
+      response,
+    })
+
+    const teamCode = 'T1'
+    expect(projectService.getProjects).toHaveBeenCalledWith({
+      projectTypeGroup: 'GROUP',
+      username: 'username',
+      providerCode: 'P1',
+      teamCode,
+    })
+    expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
+      projects.content,
+      'projectName',
+      'projectCode',
+      'Choose project',
+      'B',
+    )
+    expect(result).toEqual({ teamItems, projectItems, teamCode })
+  })
+
+  it('uses empty projects list when project response content is undefined', async () => {
+    const providerService = {} as ProviderService
+    const projectService = {
+      getProjects: jest.fn().mockResolvedValue({ content: undefined }),
+    } as unknown as ProjectService
+
+    const response = {
+      locals: {
+        user: {
+          username: 'username',
+        },
+      },
+    } as Response
+
+    const projectItems = [{ value: 'A', text: 'Project A' }]
+    jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(projectItems)
+
+    const teamCode = 'T1'
+    const result = await getProjectsAndTeams({
+      projectService,
+      providerService,
+      projectTypeGroup: 'GROUP',
+      providerCode: 'P1',
+      teamCode,
+      response,
+    })
+
+    expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
+      [],
+      'projectName',
+      'projectCode',
+      'Choose project',
+      undefined,
+    )
+    expect(result).toEqual({ teamItems, projectItems, teamCode })
+  })
+})

--- a/server/controllers/shared/getProjectsAndTeams.ts
+++ b/server/controllers/shared/getProjectsAndTeams.ts
@@ -1,0 +1,58 @@
+import type { Response } from 'express'
+import { GovUkSelectOption } from '../../@types/user-defined'
+import ProviderService from '../../services/providerService'
+import getTeams from './getTeams'
+import ProjectService from '../../services/projectService'
+import { ProjectTypeDto } from '../../@types/shared'
+import GovUkSelectInput from '../../forms/GovUkSelectInput'
+
+interface ViewData {
+  projectItems?: Array<GovUkSelectOption>
+  teamItems: Array<GovUkSelectOption>
+  teamCode?: string
+}
+export default async ({
+  projectService,
+  providerService,
+  projectTypeGroup,
+  providerCode,
+  teamCode,
+  projectCode,
+  response,
+}: {
+  projectService: ProjectService
+  providerService: ProviderService
+  projectTypeGroup: ProjectTypeDto['group']
+  providerCode?: string
+  teamCode?: string
+  projectCode?: string
+  response: Response
+}): Promise<ViewData> => {
+  const teamItems = await getTeams({
+    providerService,
+    providerCode,
+    response,
+    teamCode,
+  })
+
+  if (!teamCode) {
+    return {
+      teamItems,
+    }
+  }
+  const projects = await projectService.getProjects({
+    projectTypeGroup,
+    username: response.locals.user.username,
+    providerCode,
+    teamCode,
+  })
+
+  const projectItems = GovUkSelectInput.getOptions(
+    projects.content ?? [],
+    'projectName',
+    'projectCode',
+    'Choose project',
+    projectCode,
+  )
+  return { teamItems, projectItems, teamCode }
+}

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -8,7 +8,7 @@ import AttendanceOutcomePage, { AttendanceOutcomeBody } from './attendanceOutcom
 import * as Utils from '../../utils/utils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
-import NotesUtils from '../../utils/notesUtils'
+import NotesUtils from '../../utils/components/notesUtils'
 
 jest.mock('../../models/offender')
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -11,7 +11,7 @@ import {
 import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import DateTimeFormats from '../../utils/dateTimeUtils'
-import NotesUtils from '../../utils/notesUtils'
+import NotesUtils from '../../utils/components/notesUtils'
 import { AppointmentFormPage } from './pathMap'
 
 export type AttendanceOutcomeBody = {

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -48,7 +48,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     const selectedSupervisor = supervisors.find(supervisor => supervisor.code === this.query.supervisor)
     return {
       ...data,
-      team: selectedTeam,
+      supervisingTeam: selectedTeam,
       supervisor: selectedSupervisor,
     }
   }
@@ -59,7 +59,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     supervisors: SupervisorSummaryDto[],
     form: AppointmentOutcomeForm,
   ): ViewData {
-    const teamCode = this.query.team || form.team?.code
+    const teamCode = this.query.team || form.supervisingTeam?.code
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -14,7 +14,7 @@ import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import HtmlUtils from '../../utils/htmlUtils'
-import NotesUtils from '../../utils/notesUtils'
+import NotesUtils from '../../utils/components/notesUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -12,7 +12,7 @@ import paths from '../../../paths'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
 import ReferenceDataService from '../../../services/referenceDataService'
 import DateTimeFormats from '../../../utils/dateTimeUtils'
-import NotesUtils from '../../../utils/notesUtils'
+import NotesUtils from '../../../utils/components/notesUtils'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
 

--- a/server/pages/courseCompletions/process/outcomePage.ts
+++ b/server/pages/courseCompletions/process/outcomePage.ts
@@ -6,7 +6,7 @@ import { CourseCompletionPage } from './pathMap'
 import { UnpaidWorkDetailsDto } from '../../../@types/shared'
 import UnpaidWorkUtils, { UnpaidWorkHoursDetails } from '../../../utils/unpaidWorkUtils'
 import HoursAndMinutesInput, { ObjectWithHoursAndMinutes } from '../../../forms/hoursAndMinutesInput'
-import NotesUtils from '../../../utils/notesUtils'
+import NotesUtils from '../../../utils/components/notesUtils'
 
 type TimePeriods = 'day' | 'month' | 'year'
 type DateKeys = `date-${TimePeriods}`

--- a/server/pages/courseCompletions/process/projectPage.test.ts
+++ b/server/pages/courseCompletions/process/projectPage.test.ts
@@ -5,6 +5,7 @@ import pathMap from './pathMap'
 import { pathWithQuery } from '../../../utils/utils'
 import * as ErrorUtils from '../../../utils/errorUtils'
 import courseCompletionFormFactory from '../../../testutils/factories/courseCompletionFormFactory'
+import ProjectQuestions from '../../../utils/components/projectQuestions'
 
 describe('ProjectPage', () => {
   const pageName = 'project'
@@ -75,30 +76,21 @@ describe('ProjectPage', () => {
       jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
     })
 
-    it.each(['', undefined])('returns team error if no answers given', (value?: string) => {
-      const query = { team: value, project: value }
+    it('returns errors if any errors', () => {
+      const error = { team: { text: 'Choose a team' } }
+      jest.spyOn(ProjectQuestions, 'getValidationErrors').mockReturnValue(error)
 
-      const result = page.validationErrors(query)
-
-      expect(result.hasErrors).toBe(true)
-      expect(result.errorSummary).toEqual(errorSummary)
-      expect(result.errors).toEqual({ team: { text: 'Choose a team' } })
-    })
-
-    it.each(['', undefined])('returns project error if no project given', (value?: string) => {
-      const query = { team: '1', project: value }
-
-      const result = page.validationErrors(query)
+      const result = page.validationErrors({})
 
       expect(result.hasErrors).toBe(true)
       expect(result.errorSummary).toEqual(errorSummary)
-      expect(result.errors).toEqual({ project: { text: 'Choose a project' } })
+      expect(result.errors).toEqual(error)
     })
 
-    it('returns no errors if team and project answer given', () => {
-      const query = { team: '1', project: '2' }
+    it('returns no errors if no errors', () => {
+      jest.spyOn(ProjectQuestions, 'getValidationErrors').mockReturnValue({})
 
-      const result = page.validationErrors(query)
+      const result = page.validationErrors({})
 
       expect(result.hasErrors).toBe(false)
       expect(result.errors).toEqual({})

--- a/server/pages/courseCompletions/process/projectPage.ts
+++ b/server/pages/courseCompletions/process/projectPage.ts
@@ -1,31 +1,17 @@
 import { ValidationErrors } from '../../../@types/user-defined'
 import { CourseCompletionForm } from '../../../services/forms/courseCompletionFormService'
+import ProjectQuestions, { ProjectQuestionsBody } from '../../../utils/components/projectQuestions'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
 
-interface Body {
-  team?: string
-  project?: string
-}
-
-export default class ProjectPage extends BaseCourseCompletionFormPage<Body> {
+export default class ProjectPage extends BaseCourseCompletionFormPage<ProjectQuestionsBody> {
   protected page: CourseCompletionPage = 'project'
 
-  getFormData(formData: CourseCompletionForm, body: Body): CourseCompletionForm {
-    // TODO: implement form data to save
-    return { ...formData, team: body.team, project: body.project }
+  protected getValidationErrors(body: ProjectQuestionsBody): ValidationErrors<ProjectQuestionsBody> {
+    return ProjectQuestions.getValidationErrors(body)
   }
 
-  protected getValidationErrors(body: Body): ValidationErrors<Body> {
-    // Team is required before selecting a project, so return one error at a time
-    if (!body.team) {
-      return { team: { text: 'Choose a team' } }
-    }
-
-    if (!body.project) {
-      return { project: { text: 'Choose a project' } }
-    }
-
-    return {}
+  getFormData(formData: CourseCompletionForm, body: ProjectQuestionsBody): CourseCompletionForm {
+    return { ...formData, team: body.team, project: body.project }
   }
 }

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -64,7 +64,7 @@ describe('AppointmentFormService', () => {
         },
         sensitive: appointment.sensitive,
         originalSearch: search,
-        team: {
+        supervisingTeam: {
           code: appointment.supervisingTeamCode,
         },
       }

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -40,7 +40,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
           code: appointment.contactOutcomeCode,
         } as ContactOutcomeDto,
         attendanceData: appointment.attendanceData,
-        team: {
+        supervisingTeam: {
           code: appointment.supervisingTeamCode,
         } as ProviderTeamSummaryDto,
         supervisor: {

--- a/server/utils/components/notesUtils.test.ts
+++ b/server/utils/components/notesUtils.test.ts
@@ -1,5 +1,5 @@
-import appointmentFactory from '../testutils/factories/appointmentFactory'
-import courseCompletionFormFactory from '../testutils/factories/courseCompletionFormFactory'
+import appointmentFactory from '../../testutils/factories/appointmentFactory'
+import courseCompletionFormFactory from '../../testutils/factories/courseCompletionFormFactory'
 import NotesUtils from './notesUtils'
 
 describe('NotesUtils', () => {

--- a/server/utils/components/notesUtils.ts
+++ b/server/utils/components/notesUtils.ts
@@ -1,6 +1,6 @@
-import { AppointmentDto } from '../@types/shared'
-import { BodyWithNotes, GovUkSummaryListItem, ViewDataWithNotes, YesOrNo } from '../@types/user-defined'
-import GovUkRadioGroup from '../forms/GovUkRadioGroup'
+import { AppointmentDto } from '../../@types/shared'
+import { BodyWithNotes, GovUkSummaryListItem, ViewDataWithNotes, YesOrNo } from '../../@types/user-defined'
+import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 
 export default class NotesUtils {
   static sensitiveInfoContentMarkedAsSensitive =

--- a/server/utils/components/projectQuestions.test.ts
+++ b/server/utils/components/projectQuestions.test.ts
@@ -1,0 +1,28 @@
+import ProjectQuestions from './projectQuestions'
+
+describe('projectQuestions', () => {
+  describe('validationErrors', () => {
+    it.each(['', undefined])('returns team error if no answers given', (value?: string) => {
+      const query = { team: value, project: value }
+
+      const result = ProjectQuestions.getValidationErrors(query)
+
+      expect(result).toEqual({ team: { text: 'Choose a team' } })
+    })
+
+    it.each(['', undefined])('returns project error if no project given', (value?: string) => {
+      const query = { team: '1', project: value }
+
+      const result = ProjectQuestions.getValidationErrors(query)
+
+      expect(result).toEqual({ project: { text: 'Choose a project' } })
+    })
+
+    it('returns no errors if team and project answer given', () => {
+      const query = { team: '1', project: '2' }
+
+      const result = ProjectQuestions.getValidationErrors(query)
+      expect(result).toEqual({})
+    })
+  })
+})

--- a/server/utils/components/projectQuestions.ts
+++ b/server/utils/components/projectQuestions.ts
@@ -1,0 +1,21 @@
+import { ValidationErrors } from '../../@types/user-defined'
+
+export interface ProjectQuestionsBody {
+  team?: string
+  project?: string
+}
+
+export default class ProjectQuestions {
+  static getValidationErrors(body: ProjectQuestionsBody): ValidationErrors<ProjectQuestionsBody> {
+    // Team is required before selecting a project, so return one error at a time
+    if (!body.team) {
+      return { team: { text: 'Choose a team' } }
+    }
+
+    if (!body.project) {
+      return { project: { text: 'Choose a project' } }
+    }
+
+    return {}
+  }
+}

--- a/server/views/courseCompletions/process/project.njk
+++ b/server/views/courseCompletions/process/project.njk
@@ -1,5 +1,5 @@
 {% extends "./layout.njk" %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
+
 
 {% set pageTitle = 'Match with a project' %}
 
@@ -8,51 +8,12 @@
     <div class="govuk-grid-column-full">
       <h2>Add project details</h2>
       <p>Select the project team and project name to match the course record in nDelius.</p>
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-       <form action="{{ updatePath }}" method="get" class="govuk-!-margin-bottom-5">
-        <input type="hidden" name="form" value="{{ form }}">
-        <div class="search-and-filter__row">
-          {{ govukSelect({
-            label: {
-              text: "Choose project team",
-              classes: "govuk-label--s"
-            },
-            id: "team",
-            name: "team",
-            items: teamItems,
-            errorMessage: errors.team
-          }) }}
-          {{ govukButton({
-            "text": "Select team",
-            preventDoubleClick: true,
-            classes: "govuk-button--secondary"
-          }) }}
-        </div>
-      </form>
+
+      {% include "../../partials/selectProject/projectTeamInput.njk" %}
     </div>
   </div>
 {% endblock %}
 
 {% block formContent %}
-  {% if projectItems %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <input type="hidden" name="team" value="{{ teamCode }}">
-
-        {{ govukSelect({
-          label: {
-            text: "Choose project",
-            classes: "govuk-label--s"
-          },
-          id: "project",
-          name: "project",
-          items: projectItems,
-          errorMessage: errors.project
-        }) }}
-      </div>
-    </div>
-  {% endif %}
+  {% include "../../partials/selectProject/projectInput.njk" %}
 {% endblock %}

--- a/server/views/partials/selectProject/projectInput.njk
+++ b/server/views/partials/selectProject/projectInput.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% if projectItems %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <input type="hidden" name="team" value="{{ teamCode }}">
+
+      {{ govukSelect({
+        label: {
+          text: "Choose project",
+          classes: "govuk-label--s"
+        },
+        id: "project",
+        name: "project",
+        items: projectItems,
+        errorMessage: errors.project
+      }) }}
+    </div>
+  </div>
+{% endif %}

--- a/server/views/partials/selectProject/projectTeamInput.njk
+++ b/server/views/partials/selectProject/projectTeamInput.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+<form action="{{ updatePath }}" method="get" class="govuk-!-margin-bottom-5">
+  <input type="hidden" name="form" value="{{ form }}">
+  <div class="search-and-filter__row">
+    {{ govukSelect({
+      label: {
+        text: "Choose project team",
+        classes: "govuk-label--s"
+      },
+      id: "team",
+      name: "team",
+      items: teamItems,
+      errorMessage: errors.team
+    }) }}
+    {{ govukButton({
+      "text": "Select team",
+      preventDoubleClick: true,
+      classes: "govuk-button--secondary"
+    }) }}
+  </div>
+</form>


### PR DESCRIPTION
## Context

This introduces some shared components, functionality and test components to enable the addition of a 'Add project details' question step into the Update appointment journey. This question is currently present in the course completion form, so we can largely share the behaviour.

This doesn't change any functionality, and paves the way for #646 

## Changes in this PR

- Add shared controller method to get interdependent options lists for project teams and projects, this is similar to other shared controller methods for building interdependent options lists
- Add shared integration and e2e test components to make testing these questions more shareable across journeys
- Introduce a component utility class (and introduce the concept of components in the utils namespace).

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
