### PR TITLE
Remove `h3` from success banners

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -61,7 +61,7 @@ export default abstract class Page {
   shouldShowSuccessMessage(message: string): void {
     cy.get('.govuk-notification-banner').within(() => {
       cy.get('h2').contains('Success')
-      cy.get('h3').contains(message)
+      cy.get('div').contains(message)
     })
   }
 

--- a/server/views/appointments/update/layout.njk
+++ b/server/views/appointments/update/layout.njk
@@ -37,7 +37,7 @@
   {% if successMessages %}
     {% for message in successMessages %}
       {{ govukNotificationBanner({
-            html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+            html: message,
             type: 'success',
             titleId: 'success-title'
           }) }}

--- a/server/views/appointments/update/travelTime/index.njk
+++ b/server/views/appointments/update/travelTime/index.njk
@@ -9,7 +9,7 @@
 {% if successMessages %}
   {% for message in successMessages %}
     {{ govukNotificationBanner({
-          html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+          html: message,
           type: 'success',
           titleId: 'success-title-' + loop.index
         }) }}

--- a/server/views/courseCompletions/index.njk
+++ b/server/views/courseCompletions/index.njk
@@ -24,7 +24,7 @@
   {% if successMessages %}
     {% for message in successMessages %}
       {{ govukNotificationBanner({
-        html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+        html: message,
         type: 'success',
         titleId: 'success-title-' + loop.index
       }) }}

--- a/server/views/courseCompletions/process/layout.njk
+++ b/server/views/courseCompletions/process/layout.njk
@@ -30,7 +30,7 @@
   {% if successMessages %}
     {% for message in successMessages %}
       {{ govukNotificationBanner({
-            html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+            html: message,
             type: 'success',
             titleId: 'success-title'
           }) }}

--- a/server/views/projects/show.njk
+++ b/server/views/projects/show.njk
@@ -29,7 +29,7 @@
 {% if successMessages %}
   {% for message in successMessages %}
     {{ govukNotificationBanner({
-          html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+          html: message,
           type: 'success',
           titleId: 'success-title-' + loop.index
         }) }}
@@ -90,4 +90,3 @@
     </div>
   </div>
 {% endblock %}
-

--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -33,7 +33,7 @@
 {% if successMessages %}
   {% for message in successMessages %}
     {{ govukNotificationBanner({
-          html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
+          html: message,
           type: 'success',
           titleId: 'success-title'
         }) }}


### PR DESCRIPTION
The guidance states that a h3 should not be used when there is only one line of content.

Instead following the 'whole service' example:
https://design-system.service.gov.uk/components/notification-banner/whole-service/

### Screenshots of UI changes


<img width="1553" height="953" alt="Success banner on appointment update" src="https://github.com/user-attachments/assets/4aef269f-67e1-4bfe-8986-0b4ddbe65159" />
<img width="1585" height="960" alt="Success banner on processing a course completion" src="https://github.com/user-attachments/assets/2721ab22-cd5d-4d6e-a85e-4c2480dfd836" />
<img width="1590" height="957" alt="Success banner on crediting travel time" src="https://github.com/user-attachments/assets/9f2b81b6-22d2-454c-b271-43a12856c71d" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
