### PR TITLE
Move create appointment path into course completions namespace

### DIFF
--- a/server/controllers/courseCompletions/process/appointmentsController.ts
+++ b/server/controllers/courseCompletions/process/appointmentsController.ts
@@ -35,7 +35,9 @@ export default class AppointmentsController extends BaseController<AppointmentPa
 
     return {
       appointmentOptions,
-      createNewAppointmentPath: pathWithQuery(paths.appointments.create({ id: courseCompletion.id }), { form: formId }),
+      createNewAppointmentPath: pathWithQuery(paths.courseCompletions.createAppointment({ id: courseCompletion.id }), {
+        form: formId,
+      }),
     }
   }
 

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -31,10 +31,10 @@ const paths = {
     show: courseCompletionsShowPath,
     search: courseCompletionsPath.path('search'),
     process: courseCompletionsShowPath.path(':page'),
+    createAppointment: courseCompletionsShowPath.path('create-new-appointment'),
     unableToCreditTime: courseCompletionsShowPath.path('unable-to-credit-time'),
   },
   appointments: {
-    create: courseCompletionsShowPath.path('create-new-appointment'),
     update: appointmentPath.path(':page'),
     travelTime: {
       index: appointmentsPath.path('attended'),

--- a/server/routes/courseCompletion.ts
+++ b/server/routes/courseCompletion.ts
@@ -20,7 +20,7 @@ export default function courseCompletionRoutes(controllers: Controllers, router:
     auditEvent: Page.VIEW_COURSE_COMPLETION,
   })
   post(
-    paths.appointments.create.pattern,
+    paths.courseCompletions.createAppointment.pattern,
     (processCourseCompletionsControllers.appointments as AppointmentsController).create(),
   )
   get(


### PR DESCRIPTION
## Context

We are introducing a dedicated appointment create form, and this path will probably be needed to that. Moving to make it clear this is specifically for creating appointments related to course completions.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
