### PR TITLE
Tidy up supervisor selection

### DIFF
--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -96,7 +96,6 @@ export default class ChooseSupervisorController implements IFormPageController {
           ...page.viewData(appointmentOrSession, teams, supervisors, form),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
-          chooseSupervisorPath: page.updatePath(appointmentOrSession),
           form: page.formId,
         })
       }

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -1,7 +1,6 @@
 import { AppointmentDto } from '../../@types/shared'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
-import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import SessionUtils from '../../utils/sessionUtils'
 import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
@@ -560,12 +559,10 @@ describe('CheckAppointmentDetailsPage', () => {
   describe('form', () => {
     it('returns data from query given object with existing data', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const supervisors = supervisorSummaryFactory.buildList(2)
-      const [selectedSupervisor] = supervisors
-      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code })
+      const page = new CheckAppointmentDetailsPage({})
 
-      const result = page.updateForm(form, supervisors)
-      expect(result).toEqual({ ...form, supervisor: selectedSupervisor })
+      const result = page.updateForm(form)
+      expect(result).toEqual(form)
     })
   })
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ContactOutcomeDto, ProjectDto, SupervisorSummaryDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, ProjectDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
@@ -48,12 +48,8 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     super(query)
   }
 
-  protected getForm(data: AppointmentOutcomeForm, supervisors: SupervisorSummaryDto[]): AppointmentOutcomeForm {
-    const selectedSupervisor = supervisors.find(supervisor => supervisor.code === this.query.supervisor)
-    return {
-      ...data,
-      supervisor: selectedSupervisor,
-    }
+  protected getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
+    return data
   }
 
   setFormId(id: string) {

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -4,7 +4,6 @@ import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
-import CheckAppointmentDetailsPage from './checkAppointmentDetailsPage'
 import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
@@ -218,10 +217,13 @@ describe('ChooseSupervisorPage', () => {
       const form = appointmentOutcomeFormFactory.build()
       const supervisors = supervisorSummaryFactory.buildList(2)
       const [selectedSupervisor] = supervisors
-      const page = new CheckAppointmentDetailsPage({ supervisor: selectedSupervisor.code })
 
-      const result = page.updateForm(form, supervisors)
-      expect(result).toEqual({ ...form, supervisor: selectedSupervisor })
+      const teams = providerTeamSummaryFactory.buildList(2)
+      const [selectedTeam] = teams
+      const page = new ChooseSupervisorPage({ supervisor: selectedSupervisor.code, team: selectedTeam.code })
+
+      const result = page.updateForm(form, { providers: teams }, supervisors)
+      expect(result).toEqual({ ...form, supervisor: selectedSupervisor, supervisingTeam: selectedTeam })
     })
   })
 })

--- a/server/views/appointments/update/chooseSupervisor.njk
+++ b/server/views/appointments/update/chooseSupervisor.njk
@@ -8,7 +8,7 @@
 {% block beforeForm %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <form action="{{ chooseSupervisorPath }}" method="get" class="govuk-!-margin-bottom-5">
+      <form action="{{ updatePath }}" method="get" class="govuk-!-margin-bottom-5">
         <input type="hidden" name="form" value="{{ form }}">
         <div class="search-and-filter__row">
           {{ govukSelect({


### PR DESCRIPTION
## Context

I have noticed that there is still some logic related to supervisors on the appointment details page. This is hangover from when there was a supervisor question on this page, and should be removed.

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
