### PR TITLE
CPB-1119: Enable `COURSE_COMPLETIONS_ENABLED` feature flag in dev, test, and preprod environment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
     PROBATION_OFFENDER_SEARCH_API_URL: 'https://probation-offender-search-dev.hmpps.service.justice.gov.uk'
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "true"
+    COURSE_COMPLETIONS_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-community-payback-nonprod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,7 @@ generic-service:
     AUDIT_ENABLED: "true"
     TRAVEL_TIME_ENABLED: "false"
     CREATE_APPOINTMENT_ENABLED: "false"
+    COURSE_COMPLETIONS_ENABLED: "true"
 
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -16,6 +16,7 @@ generic-service:
     PROBATION_OFFENDER_SEARCH_API_URL: 'https://probation-offender-search-dev.hmpps.service.justice.gov.uk'
     ENVIRONMENT_NAME: TEST
     AUDIT_ENABLED: "false"
+    COURSE_COMPLETIONS_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-community-payback-nonprod


### PR DESCRIPTION
Enable `COURSE_COMPLETIONS_ENABLED` feature flag in dev, test, and preprod environment

## Context

Enable `COURSE_COMPLETIONS_ENABLED` feature flag in dev, test, and preprod environment
Prod is disabled.

## Changes in this PR

Updated helm files.

