### PR TITLE
Refactor appointment pages to remove form state

### DIFF
--- a/server/controllers/appointments/appointmentDetailsController.test.ts
+++ b/server/controllers/appointments/appointmentDetailsController.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../utils/errorUtils')
 describe('AppointmentsController', () => {
   const userName = 'user'
   const appointmentId = '1'
+  const formId = '123'
   const request: DeepMocked<Request> = createMock<Request>({ params: { appointmentId } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const checkAppointmentDetailsPageMock: jest.Mock =
@@ -47,7 +48,6 @@ describe('AppointmentsController', () => {
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => {
         return {
           viewData: () => pageViewData,
-          setFormId: () => {},
         }
       })
       const appointment = appointmentFactory.build()
@@ -72,8 +72,6 @@ describe('AppointmentsController', () => {
       const newFormId = 'some-id'
       const newForm = { key: { id: newFormId, type: 'some type' }, data: appointmentOutcomeFormFactory.build() }
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
-        formId: undefined,
-        setFormId: () => {},
         viewData: () => {},
       }))
 
@@ -88,14 +86,11 @@ describe('AppointmentsController', () => {
     })
 
     it('should fetch the in progress form if it exists', async () => {
-      const formId = '123'
       const viewData = {
         someProp: '',
       }
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
-        formId,
-        setFormId: () => {},
         viewData: () => viewData,
       }))
 
@@ -103,8 +98,11 @@ describe('AppointmentsController', () => {
 
       const requestHandler = appointmentsController.show()
       const response = createMock<Response>({ locals: { user: { username: userName } } })
-
-      await requestHandler(request, response, next)
+      const requestWithForm = createMock<Request>({
+        params: { appointmentId: '1', projectCode: '2' },
+        query: { form: formId },
+      })
+      await requestHandler(requestWithForm, response, next)
 
       expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
       expect(response.render).toHaveBeenCalledWith('appointments/update/appointmentDetails', viewData)
@@ -115,8 +113,6 @@ describe('AppointmentsController', () => {
       const contactOutcome = contactOutcomeFactory.build({ code: 'OUTCOME_001' })
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
-        formId: undefined,
-        setFormId: () => {},
         viewData: () => ({}),
       }))
 
@@ -136,8 +132,6 @@ describe('AppointmentsController', () => {
       const appointment = appointmentFactory.build({ contactOutcomeCode: undefined })
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
-        formId: undefined,
-        setFormId: () => {},
         viewData: () => ({}),
       }))
 
@@ -165,7 +159,6 @@ describe('AppointmentsController', () => {
         validationErrors: {},
         next: () => nextPath,
         updateForm: (args: AppointmentOutcomeForm) => args,
-        setFormId: () => {},
       }))
 
       const appointment = appointmentFactory.build()

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -38,10 +38,11 @@ export default class AppointmentDetailsController {
 
       const page = new CheckAppointmentDetailsPage(_req.query)
 
+      let formId = _req.query.form?.toString()
       let form: AppointmentOutcomeForm
-      if (page.formId) {
+      if (formId) {
         // A form might exist if user has navigated back to this page
-        form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+        form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       } else {
         const { data, key } = await this.appointmentFormService.createForm(
           appointment,
@@ -50,11 +51,11 @@ export default class AppointmentDetailsController {
           _req.query as Record<string, string>,
         )
         form = data
-        page.setFormId(key.id)
+        formId = key.id
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData({ appointment, project, originalSearch: form.originalSearch, contactOutcome }),
+        ...page.viewData({ appointment, project, originalSearch: form.originalSearch, contactOutcome, formId }),
       })
     }
   }
@@ -65,7 +66,9 @@ export default class AppointmentDetailsController {
 
       const page = new CheckAppointmentDetailsPage(_req.body)
 
-      return res.redirect(page.next(appointmentParams))
+      const formId = _req.body.form?.toString()
+
+      return res.redirect(page.next({ ...appointmentParams, formId }))
     }
   }
 }

--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -95,13 +95,16 @@ describe('attendanceOutcomeController', () => {
       const nextPath = '/somePath'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
       const formId = '123'
+      const submitRequest = createMock<Request>({
+        params: { appointmentId: appointment.id.toString(), projectCode: '2' },
+        body: { form: formId },
+      })
 
       beforeEach(() => {
         appointmentService.getAppointment.mockResolvedValue(appointment)
         referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
 
         attendanceOutcomePageMock.mockImplementationOnce(() => ({
-          formId,
           viewData: () => pageViewData,
           validationErrors: () => ({}),
           next: () => nextPath,
@@ -111,7 +114,7 @@ describe('attendanceOutcomeController', () => {
 
       it('should redirect to the next page', async () => {
         const requestHandler = attendanceOutcomeController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
@@ -122,7 +125,7 @@ describe('attendanceOutcomeController', () => {
         formService.getForm.mockResolvedValue(existingForm)
 
         const requestHandler = attendanceOutcomeController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -72,7 +72,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const toSave = page.updateForm(form, outcomes.contactOutcomes)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
     }
   }
 }

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -27,15 +27,16 @@ export default class AttendanceOutcomeController implements IFormPageController 
       })
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
+      const formId = _req.query.form?.toString()
       const page = new AttendanceOutcomePage({
         query: _req.query,
         appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
 
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      res.render('appointments/update/attendanceOutcome', page.viewData(form))
+      res.render('appointments/update/attendanceOutcome', page.viewData(form, false, formId))
     }
   }
 
@@ -51,26 +52,27 @@ export default class AttendanceOutcomeController implements IFormPageController 
       })
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
+      const formId = _req.body.form?.toString()
       const page = new AttendanceOutcomePage({
         query: _req.body,
         appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
       const validationErrors = page.validationErrors()
 
       if (Object.keys(validationErrors).length) {
         return res.render('appointments/update/attendanceOutcome', {
-          ...page.viewData(form, true),
+          ...page.viewData(form, true, formId),
           errorSummary: generateErrorSummary(validationErrors),
           errors: validationErrors,
         })
       }
 
       const toSave = page.updateForm(form, outcomes.contactOutcomes)
-      await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
+      await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentOrSessionParams))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
     }
   }
 }

--- a/server/controllers/appointments/chooseProjectController.test.ts
+++ b/server/controllers/appointments/chooseProjectController.test.ts
@@ -58,7 +58,6 @@ describe('ChooseProjectController', () => {
 
     chooseProjectPageMock.mockImplementation(() => {
       return {
-        formId: 'form-1',
         commonViewData: () => ({ common: 'value' }),
       } as unknown as ChooseProjectPage
     })
@@ -132,7 +131,6 @@ describe('ChooseProjectController', () => {
 
       chooseProjectPageMock.mockImplementationOnce(() => {
         return {
-          formId: 'form-1',
           commonViewData: () => ({ common: 'value' }),
           getValidationErrors: () => validationErrors,
         }
@@ -161,7 +159,7 @@ describe('ChooseProjectController', () => {
     it('saves form and redirects if no errors', async () => {
       const request = createMock<Request>({
         params: { projectCode: 'PROJECT-1', appointmentId: '1' },
-        body: { team: 'TEAM-1', project: 'PROJECT-2' },
+        body: { team: 'TEAM-1', project: 'PROJECT-2', form: 'form-1' },
       })
       const response = createMock<Response>({ locals: { user: { username } } })
       const form = appointmentOutcomeFormFactory.build()
@@ -171,7 +169,6 @@ describe('ChooseProjectController', () => {
 
       chooseProjectPageMock.mockImplementationOnce(() => {
         return {
-          formId: 'form-1',
           getValidationErrors: () => ({ hasErrors: false, errors: {}, errorSummary: [] as Array<ErrorSummaryItem> }),
           updateForm: () => updatedForm,
           next: () => '/next',

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -36,7 +36,8 @@ export default class ChooseProjectController implements IFormPageController {
 
       const page = new ChooseProjectPage(req.query)
 
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = req.query.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
       const teamCode = (req.query?.team ?? form.projectTeam?.code)?.toString()
       const projectCode = form.project.code
@@ -53,7 +54,7 @@ export default class ChooseProjectController implements IFormPageController {
       })
 
       res.render('appointments/update/chooseProject', {
-        ...page.commonViewData({ appointmentOrSession, form }),
+        ...page.commonViewData({ appointmentOrSession, form, formId }),
         ...items,
       })
     }
@@ -79,7 +80,8 @@ export default class ChooseProjectController implements IFormPageController {
       const projectCode = req.body?.project?.toString()
 
       const page = new ChooseProjectPage(req.body)
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = req.body.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
       const items = await getProjectsAndTeams({
         projectService: this.projectService,
@@ -96,7 +98,7 @@ export default class ChooseProjectController implements IFormPageController {
 
       if (hasErrors) {
         return res.render('appointments/update/chooseProject', {
-          ...page.commonViewData({ appointmentOrSession, form }),
+          ...page.commonViewData({ appointmentOrSession, form, formId }),
           ...items,
           errors,
           errorSummary,
@@ -104,9 +106,9 @@ export default class ChooseProjectController implements IFormPageController {
       }
 
       const toSave = page.updateForm(form, items.teamItems, items.projectItems)
-      await this.appointmentFormService.saveForm(page.formId, res.locals.user.username, toSave)
+      await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentOrSessionParams))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
     }
   }
 }

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -108,7 +108,7 @@ export default class ChooseProjectController implements IFormPageController {
       const toSave = page.updateForm(form, items.teamItems, items.projectItems)
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
     }
   }
 }

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -22,7 +22,11 @@ describe('ChooseSupervisorController', () => {
   const appointmentId = '1'
   const projectCode = '2'
   const team = 'X123'
-  const request: DeepMocked<Request> = createMock<Request>({ params: { appointmentId, projectCode }, query: { team } })
+  const formId = '123'
+  const request: DeepMocked<Request> = createMock<Request>({
+    params: { appointmentId, projectCode },
+    query: { team, form: formId },
+  })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const chooseSupervisorPageMock: jest.Mock = ChooseSupervisorPage as unknown as jest.Mock<ChooseSupervisorPage>
   const generateErrorSummaryMock: jest.Mock = generateErrorSummary as jest.Mock
@@ -75,7 +79,6 @@ describe('ChooseSupervisorController', () => {
     })
 
     it('should fetch the in progress form if it exists', async () => {
-      const formId = '123'
       const supervisorPath = '/path'
       const viewData = {
         someProp: '',
@@ -85,7 +88,6 @@ describe('ChooseSupervisorController', () => {
       }
 
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        formId,
         viewData: () => viewData,
         updatePath: () => supervisorPath,
       }))
@@ -103,6 +105,10 @@ describe('ChooseSupervisorController', () => {
   })
 
   describe('submit', () => {
+    const submitRequest = createMock<Request>({
+      params: { appointmentId: '1' },
+      body: { form: formId },
+    })
     it('should return view if errors', async () => {
       const errors = { someKey: { text: 'some error' } }
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
@@ -129,7 +135,7 @@ describe('ChooseSupervisorController', () => {
       providerDataService.getProviders.mockResolvedValue(providers)
 
       const requestHandler = appointmentsController.submit()
-      await requestHandler(request, response, next)
+      await requestHandler(submitRequest, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
         'appointments/update/chooseSupervisor',
@@ -161,17 +167,15 @@ describe('ChooseSupervisorController', () => {
       providerDataService.getProviders.mockResolvedValue(providers)
 
       const requestHandler = appointmentsController.submit()
-      await requestHandler(request, response, next)
+      await requestHandler(submitRequest, response, next)
 
       expect(response.redirect).toHaveBeenCalledWith(nextPath)
     })
 
     it('should handle form progress', async () => {
-      const formId = '123'
       const existingForm = appointmentOutcomeFormFactory.build()
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        formId,
         validate: () => {},
         hasErrors: false,
         validationErrors: {},
@@ -184,7 +188,7 @@ describe('ChooseSupervisorController', () => {
       const requestHandler = appointmentsController.submit()
       const response = createMock<Response>({ locals: { user: { username: userName } } })
 
-      await requestHandler(request, response, next)
+      await requestHandler(submitRequest, response, next)
 
       expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
       expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -105,7 +105,7 @@ export default class ChooseSupervisorController implements IFormPageController {
       const toSave = page.updateForm(form, teams, supervisors)
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
     }
   }
 }

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -37,7 +37,8 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       const page = new ChooseSupervisorPage(_req.query)
 
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = _req.query.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
       const team = _req.query.team?.toString() || form?.supervisingTeam?.code
 
@@ -50,9 +51,9 @@ export default class ChooseSupervisorController implements IFormPageController {
         : []
 
       res.render('appointments/update/chooseSupervisor', {
-        ...page.viewData(appointmentOrSession, teams, supervisors, form),
-        chooseSupervisorPath: page.updatePath(appointmentOrSession),
-        form: page.formId,
+        ...page.viewData(appointmentOrSession, teams, supervisors, form, formId),
+        chooseSupervisorPath: page.updatePath(appointmentOrSession, formId),
+        form: formId,
         team,
       })
     }
@@ -87,23 +88,24 @@ export default class ChooseSupervisorController implements IFormPageController {
         : []
 
       const page = new ChooseSupervisorPage(_req.body)
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = _req.body.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
       page.validate()
 
       if (page.hasErrors) {
         return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointmentOrSession, teams, supervisors, form),
+          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
-          form: page.formId,
+          form: formId,
         })
       }
 
       const toSave = page.updateForm(form, teams, supervisors)
-      await this.appointmentFormService.saveForm(page.formId, res.locals.user.username, toSave)
+      await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentOrSessionParams))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
     }
   }
 }

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -83,7 +83,6 @@ describe('ConfirmController', () => {
       confirmPageMock.mockImplementationOnce(() => {
         return {
           viewData: () => pageViewData,
-          formId,
         }
       })
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -31,12 +31,13 @@ export default class ConfirmController implements IFormPageController {
       })
 
       const page = new ConfirmPage(_req.query)
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = _req.query.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
 
       res.render('appointments/update/confirm', {
-        ...page.viewData(appointmentOrSession, form),
+        ...page.viewData(appointmentOrSession, form, formId),
         errorList,
         preventDoubleClick,
       })
@@ -60,7 +61,8 @@ export default class ConfirmController implements IFormPageController {
       })
 
       const page = new ConfirmPage(_req.body)
-      const form = await this.appointmentFormService.getForm(page.formId, res.locals.user.username)
+      const formId = _req.body.form?.toString()
+      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const didAttend = form.contactOutcome.attended
 
       if (appointmentOrSessionParams.appointmentId) {
@@ -90,7 +92,7 @@ export default class ConfirmController implements IFormPageController {
           _req.flash('success', message)
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         } catch (error) {
-          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment))
+          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment, formId))
         }
       } else {
         const updates = await Promise.all(

--- a/server/controllers/appointments/logComplianceController.test.ts
+++ b/server/controllers/appointments/logComplianceController.test.ts
@@ -16,8 +16,9 @@ jest.mock('../../pages/appointments/logCompliancePage')
 describe('logComplianceController', () => {
   const userName = 'user'
   const appointment = appointmentFactory.build({ offender: offenderFullFactory.build() })
+  const formId = '123'
 
-  const request = createMock<Request>({ params: { appointmentId: appointment.id.toString() } })
+  const request = createMock<Request>({ params: { appointmentId: appointment.id.toString() }, query: { form: formId } })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   let logComplianceController: LogComplianceController
@@ -92,14 +93,16 @@ describe('logComplianceController', () => {
     describe('when no validation errrors occur', () => {
       const nextPath = '/nextPath'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
-      const formId = '123'
+      const submitRequest = createMock<Request>({
+        params: { appointmentId: appointment.id.toString() },
+        body: { form: formId },
+      })
 
       beforeEach(() => {
         appointmentService.getAppointment.mockResolvedValue(appointment)
 
         logCompliancePageMock.mockImplementationOnce(() => {
           return {
-            formId,
             validate: () => {},
             hasError: false,
             next: () => nextPath,
@@ -110,7 +113,7 @@ describe('logComplianceController', () => {
 
       it('should redirect to the confirm details page', async () => {
         const requestHandler = logComplianceController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
@@ -121,7 +124,7 @@ describe('logComplianceController', () => {
         formService.getForm.mockResolvedValue(existingForm)
 
         const requestHandler = logComplianceController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -24,10 +24,11 @@ export default class LogComplianceController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
+      const formId = _req.query.form?.toString()
       const page = new LogCompliancePage(_req.query)
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      res.render('appointments/update/logCompliance', page.viewData(appointmentOrSession, form))
+      res.render('appointments/update/logCompliance', page.viewData(appointmentOrSession, form, formId))
     }
   }
 
@@ -35,8 +36,9 @@ export default class LogComplianceController implements IFormPageController {
     return async (_req: Request, res: Response) => {
       const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
+      const formId = _req.body.form?.toString()
       const page = new LogCompliancePage(_req.body)
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
 
       page.validate()
 
@@ -49,16 +51,16 @@ export default class LogComplianceController implements IFormPageController {
         })
 
         return res.render('appointments/update/logCompliance', {
-          ...page.viewData(appointmentOrSession, form),
+          ...page.viewData(appointmentOrSession, form, formId),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
       }
 
       const toSave = page.updateForm(form)
-      await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
+      await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentOrSessionParams))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
     }
   }
 }

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -60,7 +60,7 @@ export default class LogComplianceController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
     }
   }
 }

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -87,10 +87,13 @@ describe('logHoursController', () => {
       const nextPath = '/next'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
       const formId = '123'
+      const submitRequest = createMock<Request>({
+        params: { appointmentId: appointment.id.toString() },
+        body: { form: formId },
+      })
 
       beforeEach(() => {
         logHoursPage.mockImplementationOnce(() => ({
-          formId,
           validate: () => {},
           hasErrors: false,
           validationErrors: {},
@@ -103,7 +106,7 @@ describe('logHoursController', () => {
 
       it('should redirect to the next page', async () => {
         const requestHandler = logHoursController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
@@ -114,7 +117,7 @@ describe('logHoursController', () => {
         formService.getForm.mockResolvedValue(existingForm)
 
         const requestHandler = logHoursController.submit()
-        await requestHandler(request, response, next)
+        await requestHandler(submitRequest, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -63,7 +63,7 @@ export default class LogHoursController implements IFormPageController {
       const toSave = page.updateForm(form)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
     }
   }
 }

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -24,12 +24,13 @@ export default class LogHoursController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
+      const formId = _req.query.form?.toString()
       const page = new LogHoursPage(_req.query)
 
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
 
       res.render('appointments/update/logHours', {
-        ...page.viewData(appointment, form),
+        ...page.viewData(appointment, form, formId),
       })
     }
   }
@@ -38,10 +39,11 @@ export default class LogHoursController implements IFormPageController {
     return async (_req: Request, res: Response) => {
       const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
+      const formId = _req.body.form?.toString()
       const page = new LogHoursPage(_req.body)
       page.validate()
 
-      const form = await this.formService.getForm(page.formId, res.locals.user.username)
+      const form = await this.formService.getForm(formId, res.locals.user.username)
 
       const appointmentOrSession = await getAppointmentOrSession({
         appointmentOrSessionParams,
@@ -52,16 +54,16 @@ export default class LogHoursController implements IFormPageController {
 
       if (page.hasErrors) {
         return res.render('appointments/update/logHours', {
-          ...page.viewData(appointmentOrSession, form),
+          ...page.viewData(appointmentOrSession, form, formId),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
       }
 
       const toSave = page.updateForm(form)
-      await this.formService.saveForm(page.formId, res.locals.user.username, toSave)
+      await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
-      return res.redirect(page.next(appointmentOrSessionParams))
+      return res.redirect(page.next({ ...appointmentOrSessionParams, formId }))
     }
   }
 }

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -529,7 +529,13 @@ describe('AttendanceOutcomePage', () => {
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-        expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
+        expect(
+          page.next({
+            projectCode,
+            appointmentId,
+            form: appointmentOutcomeFormFactory.build({ contactOutcome: attendedOutcome }),
+          }),
+        ).toBe(pathWithQuery)
         expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-hours' })
       })
     })
@@ -549,7 +555,13 @@ describe('AttendanceOutcomePage', () => {
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
-        expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
+        expect(
+          page.next({
+            projectCode,
+            appointmentId,
+            form: appointmentOutcomeFormFactory.build({ contactOutcome: notAttendedOutcome }),
+          }),
+        ).toBe(pathWithQuery)
         expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
       })
     })

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -100,10 +100,8 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return 'choose-project'
   }
 
-  protected nextPage(): AppointmentFormPage {
-    const contactOutcome = this.contactOutcomes.find(outcome => outcome.code === this.query.attendanceOutcome)
-
-    if (!contactOutcome?.attended) {
+  protected nextPage(form?: AppointmentOutcomeForm): AppointmentFormPage {
+    if (!form?.contactOutcome?.attended) {
       return 'confirm-details'
     }
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -47,7 +47,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     appointmentOrSession: AppointmentOrSession
     contactOutcomes: ContactOutcomeDto[]
   }) {
-    super(query)
+    super()
     this.query = query
     this.appointmentOrSession = appointmentOrSession
     this.contactOutcomes = contactOutcomes
@@ -86,11 +86,11 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return validationErrors
   }
 
-  viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false): ViewData {
+  viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false, formId?: string): ViewData {
     const isSingleAppointment = this.isSingleAppointment(this.appointmentOrSession)
     const appointment = isSingleAppointment ? (this.appointmentOrSession as AppointmentDto) : undefined
     return {
-      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession, form }),
+      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession, form, formId }),
       ...NotesUtils.questionItems(this.query, form, appointment, isSingleAppointment),
       items: this.items(form, hasErrors),
     }

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -33,13 +33,13 @@ describe('BaseAppointmentUpdatePage', () => {
 
   describe('next()', () => {
     it('throws an error when nextPage returns undefined', () => {
-      const page = new PageWithoutNextPage({})
+      const page = new PageWithoutNextPage()
 
       expect(() => page.next({ projectCode: 'P123', appointmentId: '1' })).toThrow('No next page configured')
     })
 
     it('throws an error when only projectCode is provided', () => {
-      const page = new PageWithNextPage({})
+      const page = new PageWithNextPage()
 
       expect(() => page.next({ projectCode: 'P123' })).toThrow('Path must have an appointment ID or session date')
     })
@@ -48,11 +48,12 @@ describe('BaseAppointmentUpdatePage', () => {
   describe('viewData', () => {
     describe('heading', () => {
       it('returns heading containing offender details when appointment is provided', () => {
-        const page = new PageWithNextPage({})
+        const page = new PageWithNextPage()
 
         const result = page.getCommonViewDataForTest({
           appointmentOrSession: appointmentFactory.build(),
           form,
+          formId: '1',
         })
 
         expect(result.heading).toEqual({
@@ -62,7 +63,7 @@ describe('BaseAppointmentUpdatePage', () => {
       })
 
       it('returns heading containing project name and formatted date when session is provided', () => {
-        const page = new PageWithNextPage({})
+        const page = new PageWithNextPage()
         const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
         const formattedDate = '10 June 2026'
 
@@ -71,6 +72,7 @@ describe('BaseAppointmentUpdatePage', () => {
         const result = page.getCommonViewDataForTest({
           appointmentOrSession: session,
           form,
+          formId: '1',
         })
 
         expect(result.heading).toEqual({
@@ -83,19 +85,19 @@ describe('BaseAppointmentUpdatePage', () => {
     })
     describe('selectedPeopleCard', () => {
       it('should be undefined given appointment', () => {
-        const page = new PageWithNextPage({})
+        const page = new PageWithNextPage()
 
         const result = page.getCommonViewDataForTest({
           appointmentOrSession: appointmentFactory.build(),
           form,
+          formId: '1',
         })
 
         expect(result.selectedPeopleCard).toBeUndefined()
       })
 
       it('should return card given session', () => {
-        const page = new PageWithNextPage({})
-        page.formId = '1'
+        const page = new PageWithNextPage()
         const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
 
         const selectedPeopleCard = {
@@ -104,7 +106,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
         jest.spyOn(SessionUtils, 'selectedPeopleCard').mockReturnValue(selectedPeopleCard)
 
-        const result = page.getCommonViewDataForTest({ appointmentOrSession: session, form })
+        const result = page.getCommonViewDataForTest({ appointmentOrSession: session, form, formId: '1' })
 
         expect(result.selectedPeopleCard).toEqual(selectedPeopleCard)
         expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(session, form.appointments, '1')
@@ -121,6 +123,7 @@ class PageWithNextPage extends BaseAppointmentUpdatePage {
     originalSearch?: Record<string, string>
     project?: ProjectDto
     form: AppointmentOutcomeForm
+    formId: string
   }): AppointmentUpdatePageViewData {
     return this.commonViewData(args)
   }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -8,13 +8,14 @@ import { pathWithQuery } from '../../utils/utils'
 import { AppointmentFormPage } from './pathMap'
 
 export default abstract class BaseAppointmentUpdatePage {
-  form?: AppointmentOutcomeForm
-
   protected abstract page: AppointmentFormPage
 
-  protected abstract nextPage(): AppointmentFormPage | undefined
+  protected abstract nextPage(form?: AppointmentOutcomeForm): AppointmentFormPage | undefined
 
-  protected abstract backPage(appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined
+  protected abstract backPage(
+    appointmentOrSession: AppointmentOrSession,
+    form?: AppointmentOutcomeForm,
+  ): AppointmentFormPage | undefined
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 
@@ -34,13 +35,15 @@ export default abstract class BaseAppointmentUpdatePage {
     date,
     projectCode,
     formId,
+    form,
   }: {
     projectCode: string
     appointmentId?: string
     date?: string
     formId?: string
+    form?: AppointmentOutcomeForm
   }) {
-    const nextPage = this.nextPage()
+    const nextPage = this.nextPage(form)
 
     if (!nextPage) {
       throw new Error('No next page configured')
@@ -72,8 +75,7 @@ export default abstract class BaseAppointmentUpdatePage {
   }
 
   updateForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm {
-    this.form = this.getForm(form, ...args)
-    return this.form
+    return this.getForm(form, ...args)
   }
 
   updatePath(appointmentOrSession: AppointmentOrSession, formId?: string) {
@@ -88,8 +90,9 @@ export default abstract class BaseAppointmentUpdatePage {
     originalSearch?: Record<string, string>,
     project?: ProjectDto,
     formId?: string,
+    form?: AppointmentOutcomeForm,
   ) {
-    const backPage = this.backPage(appointmentOrSession)
+    const backPage = this.backPage(appointmentOrSession, form)
 
     if (!backPage) {
       return this.exitForm(appointmentOrSession, project, originalSearch)
@@ -112,7 +115,7 @@ export default abstract class BaseAppointmentUpdatePage {
     formId?: string
   }): AppointmentUpdatePageViewData {
     const viewData: AppointmentUpdatePageViewData = {
-      backLink: this.backPath(appointmentOrSession, originalSearch, project, formId),
+      backLink: this.backPath(appointmentOrSession, originalSearch, project, formId, form),
       updatePath: this.updatePath(appointmentOrSession, formId),
       form: formId,
       heading: this.buildHeading(appointmentOrSession),

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -1,10 +1,5 @@
 import { ProjectDto } from '../../@types/shared'
-import {
-  AppointmentOrSession,
-  AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
-  AppointmentUpdateQuery,
-} from '../../@types/user-defined'
+import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import DateTimeFormats from '../../utils/dateTimeUtils'
@@ -23,12 +18,6 @@ export default abstract class BaseAppointmentUpdatePage {
 
   protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
 
-  formId: string | undefined
-
-  constructor(query: AppointmentUpdateQuery) {
-    this.formId = query.form?.toString()
-  }
-
   exitForm(
     appointmentOrSession: AppointmentOrSession,
     project?: ProjectDto,
@@ -40,7 +29,17 @@ export default abstract class BaseAppointmentUpdatePage {
     return pathWithQuery(paths.projects.show({ projectCode: appointmentOrSession.projectCode }), originalSearch)
   }
 
-  next({ appointmentId, date, projectCode }: { projectCode: string; appointmentId?: string; date?: string }) {
+  next({
+    appointmentId,
+    date,
+    projectCode,
+    formId,
+  }: {
+    projectCode: string
+    appointmentId?: string
+    date?: string
+    formId?: string
+  }) {
     const nextPage = this.nextPage()
 
     if (!nextPage) {
@@ -54,6 +53,7 @@ export default abstract class BaseAppointmentUpdatePage {
           appointmentId,
           page: nextPage,
         }),
+        formId,
       )
     }
 
@@ -64,6 +64,7 @@ export default abstract class BaseAppointmentUpdatePage {
           date,
           page: nextPage,
         }),
+        formId,
       )
     }
 
@@ -75,8 +76,8 @@ export default abstract class BaseAppointmentUpdatePage {
     return this.form
   }
 
-  updatePath(appointmentOrSession: AppointmentOrSession) {
-    return this.buildPath(appointmentOrSession, this.page)
+  updatePath(appointmentOrSession: AppointmentOrSession, formId?: string) {
+    return this.buildPath(appointmentOrSession, this.page, formId)
   }
 
   protected isSingleAppointment = (appointmentOrSession: AppointmentOrSession) =>
@@ -86,6 +87,7 @@ export default abstract class BaseAppointmentUpdatePage {
     appointmentOrSession: AppointmentOrSession,
     originalSearch?: Record<string, string>,
     project?: ProjectDto,
+    formId?: string,
   ) {
     const backPage = this.backPage(appointmentOrSession)
 
@@ -93,7 +95,7 @@ export default abstract class BaseAppointmentUpdatePage {
       return this.exitForm(appointmentOrSession, project, originalSearch)
     }
 
-    return this.buildPath(appointmentOrSession, backPage, originalSearch)
+    return this.buildPath(appointmentOrSession, backPage, formId, originalSearch)
   }
 
   commonViewData({
@@ -101,16 +103,18 @@ export default abstract class BaseAppointmentUpdatePage {
     originalSearch,
     project,
     form,
+    formId,
   }: {
     appointmentOrSession: AppointmentOrSession
     originalSearch?: Record<string, string>
     project?: ProjectDto
     form: AppointmentOutcomeForm
+    formId?: string
   }): AppointmentUpdatePageViewData {
     const viewData: AppointmentUpdatePageViewData = {
-      backLink: this.backPath(appointmentOrSession, originalSearch, project),
-      updatePath: this.updatePath(appointmentOrSession),
-      form: this.formId,
+      backLink: this.backPath(appointmentOrSession, originalSearch, project, formId),
+      updatePath: this.updatePath(appointmentOrSession, formId),
+      form: formId,
       heading: this.buildHeading(appointmentOrSession),
     }
 
@@ -118,7 +122,7 @@ export default abstract class BaseAppointmentUpdatePage {
       viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(
         appointmentOrSession,
         form.appointments ?? [],
-        this.formId,
+        formId,
       )
     }
 
@@ -140,13 +144,14 @@ export default abstract class BaseAppointmentUpdatePage {
     }
   }
 
-  protected pathWithFormId(path: string): string {
-    return pathWithQuery(path, { form: this.formId })
+  protected pathWithFormId(path: string, formId?: string): string {
+    return pathWithQuery(path, { form: formId })
   }
 
   private buildPath(
     appointmentOrSession: AppointmentOrSession,
     page: AppointmentFormPage,
+    formId?: string,
     originalSearch?: Record<string, string>,
   ): string {
     if (this.isSingleAppointment(appointmentOrSession)) {
@@ -157,6 +162,7 @@ export default abstract class BaseAppointmentUpdatePage {
             appointmentId: appointmentOrSession.id.toString(),
             page,
           }),
+          formId,
         ),
         originalSearch,
       )
@@ -169,6 +175,7 @@ export default abstract class BaseAppointmentUpdatePage {
           date: appointmentOrSession.date,
           page,
         }),
+        formId,
       ),
       originalSearch,
     )

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -565,13 +565,4 @@ describe('CheckAppointmentDetailsPage', () => {
       expect(result).toEqual(form)
     })
   })
-
-  describe('setFormId', () => {
-    it('should update the formId', () => {
-      const page = new CheckAppointmentDetailsPage({})
-      page.setFormId('1')
-
-      expect(page.formId).toEqual('1')
-    })
-  })
 })

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -45,15 +45,11 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
   validationErrors: ValidationErrors<Body> = {}
 
   constructor(private readonly query: AppointmentDetailsQuery) {
-    super(query)
+    super()
   }
 
   protected getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return data
-  }
-
-  setFormId(id: string) {
-    this.formId = id
   }
 
   viewData({
@@ -61,11 +57,13 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     project,
     originalSearch,
     contactOutcome,
+    formId,
   }: {
     appointment: AppointmentDto
     project: ProjectDto
     originalSearch: Record<string, string>
     contactOutcome?: ContactOutcomeDto
+    formId?: string
   }): ViewData {
     return {
       ...this.commonViewData({
@@ -73,6 +71,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
         originalSearch,
         project,
         form: {} as AppointmentOutcomeForm,
+        formId,
       }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
@@ -82,7 +81,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       sharedItems: this.buildSharedDetails(appointment),
       contactOutcome: this.buildContactOutcomeDetails(contactOutcome),
       showMissingOutcomeMessage: this.isMissingOutcome(appointment),
-      nextPath: this.next({ projectCode: appointment.projectCode, appointmentId: appointment.id.toString() }),
+      nextPath: this.next({ projectCode: appointment.projectCode, appointmentId: appointment.id.toString(), formId }),
     }
   }
 

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -15,9 +15,9 @@ describe('ChooseProjectPage', () => {
     it('returns backLink and updatePath for the expected pages', () => {
       const appointment = appointmentFactory.build({ projectCode: 'P1', id: 123 })
       const form = appointmentOutcomeFormFactory.build()
-      const page = new ChooseProjectPage({ form: 'F1' })
+      const page = new ChooseProjectPage({})
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form })
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'F1' })
 
       expect(result.backLink).toBe(
         pathWithQuery(
@@ -44,11 +44,11 @@ describe('ChooseProjectPage', () => {
 
   describe('next', () => {
     it('returns attendance outcome path for an appointment', () => {
-      const page = new ChooseProjectPage({ form: 'F1' })
+      const page = new ChooseProjectPage({})
       const projectCode = 'P1'
       const appointmentId = '123'
 
-      const result = page.next({ projectCode, appointmentId })
+      const result = page.next({ projectCode, appointmentId, formId: 'F1' })
 
       expect(result).toBe(
         pathWithQuery(

--- a/server/pages/appointments/chooseProjectPage.ts
+++ b/server/pages/appointments/chooseProjectPage.ts
@@ -15,7 +15,7 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'choose-project'
 
   constructor(private query: Query) {
-    super(query)
+    super()
   }
 
   protected nextPage(): AppointmentFormPage | undefined {

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -32,7 +32,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
   validationErrors: ValidationErrors<Body> = {}
 
   constructor(private readonly query: AppointmentDetailsQuery) {
-    super(query)
+    super()
   }
 
   get hasErrors() {
@@ -58,12 +58,13 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     teams: ProviderTeamSummariesDto,
     supervisors: SupervisorSummaryDto[],
     form: AppointmentOutcomeForm,
+    formId?: string,
   ): ViewData {
     const teamCode = this.query.team || form.supervisingTeam?.code
     const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
 
     return {
-      ...this.commonViewData({ appointmentOrSession, form }),
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -33,21 +33,21 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'confirm-details'
 
   constructor(private readonly query: Query) {
-    super(query)
+    super()
   }
 
   protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return form
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
     const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
     this.form = form
 
     return {
-      ...this.commonViewData({ appointmentOrSession, form }),
-      submittedItems: this.formItems(form, appointmentOrSession),
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
+      submittedItems: this.formItems(form, appointmentOrSession, formId),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({
         checkedValue: GovUkRadioGroup.determineCheckedValue(alertValue),
@@ -95,10 +95,14 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return `Hours credited: ${hours}`
   }
 
-  private formItems(form: AppointmentOutcomeForm, appointment: AppointmentOrSession): GovUkSummaryListItem[] {
+  private formItems(
+    form: AppointmentOutcomeForm,
+    appointment: AppointmentOrSession,
+    formId: string,
+  ): GovUkSummaryListItem[] {
     const isSingleAppointment = this.isSingleAppointment(appointment)
     const items = [
-      ...this.buildOffenderItem(form, appointment),
+      ...this.buildOffenderItem(form, appointment, formId),
       {
         key: {
           text: 'Supervising officer',
@@ -109,7 +113,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-supervisor'),
+              href: this.changePath(appointment, 'choose-supervisor', formId),
               text: 'Change',
               visuallyHiddenText: 'supervising officer',
             },
@@ -126,7 +130,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-project'),
+              href: this.changePath(appointment, 'choose-project', formId),
               text: 'Change',
               visuallyHiddenText: 'project team',
             },
@@ -143,7 +147,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-project'),
+              href: this.changePath(appointment, 'choose-project', formId),
               text: 'Change',
               visuallyHiddenText: 'project',
             },
@@ -158,7 +162,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'attendance-outcome'),
+              href: this.changePath(appointment, 'attendance-outcome', formId),
               text: 'Change',
               visuallyHiddenText: 'attendance outcome',
             },
@@ -180,7 +184,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
             actions: {
               items: [
                 {
-                  href: this.changePath(appointment, 'log-hours'),
+                  href: this.changePath(appointment, 'log-hours', formId),
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
                 },
@@ -197,7 +201,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
             actions: {
               items: [
                 {
-                  href: this.changePath(appointment, 'log-compliance'),
+                  href: this.changePath(appointment, 'log-compliance', formId),
                   text: 'Change',
                   visuallyHiddenText: 'compliance',
                 },
@@ -211,7 +215,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     items.push(
       ...NotesUtils.checkYourAnswersRows(
         form,
-        this.changePath(appointment, 'attendance-outcome'),
+        this.changePath(appointment, 'attendance-outcome', formId),
         isSingleAppointment ? appointment : undefined,
         isSingleAppointment,
       ),
@@ -233,6 +237,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   buildOffenderItem(
     form: AppointmentOutcomeForm,
     appointmentOrSession: AppointmentOrSession,
+    formId: string,
   ): Array<GovUkSummaryListItem> {
     if (this.isSingleAppointment(appointmentOrSession)) {
       return []
@@ -263,7 +268,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         actions: {
           items: [
             {
-              href: this.changePath(appointmentOrSession, 'select-people'),
+              href: this.changePath(appointmentOrSession, 'select-people', formId),
               text: 'Change',
               visuallyHiddenText: 'people',
             },
@@ -273,7 +278,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     ]
   }
 
-  private changePath(appointmentOrSession: AppointmentOrSession, page: AppointmentFormPage) {
+  private changePath(appointmentOrSession: AppointmentOrSession, page: AppointmentFormPage, formId: string) {
     if ('deliusEventNumber' in appointmentOrSession) {
       return this.pathWithFormId(
         paths.appointments.update({
@@ -281,6 +286,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
           appointmentId: appointmentOrSession.id.toString(),
           page,
         }),
+        formId,
       )
     }
 
@@ -290,6 +296,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
         date: appointmentOrSession.date,
         page,
       }),
+      formId,
     )
   }
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -43,7 +43,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
   viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
     const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
-    this.form = form
 
     return {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
@@ -74,8 +73,8 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     return undefined
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
-    if (this.form && this.form.contactOutcome?.attended) {
+  protected backPage(_appointmentOrSession: AppointmentOrSession, form?: AppointmentOutcomeForm): AppointmentFormPage {
+    if (form && form.contactOutcome?.attended) {
       return 'log-compliance'
     }
     return 'attendance-outcome'

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -254,7 +254,6 @@ describe('LogCompliancePage', () => {
       }
 
       expect(result).toEqual(expected)
-      expect(page.form).toEqual(expected)
     })
   })
 })

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -33,7 +33,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   validationErrors: ValidationErrors<Body> = {}
 
   constructor(private readonly query: LogComplianceQuery) {
-    super(query)
+    super()
   }
 
   getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
@@ -48,10 +48,10 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
     const formValues = this.getFormDisplayValues(form)
     return {
-      ...this.commonViewData({ appointmentOrSession, form }),
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
       workQualityItems: this.getItems(formValues.workQuality),
       behaviourItems: this.getItems(formValues.behaviour),
     }

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -32,7 +32,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
   validationErrors: ValidationErrors<LogHoursBody> = {}
 
   constructor(private readonly query: LogHoursQuery = {}) {
-    super(query)
+    super()
   }
 
   getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
@@ -65,9 +65,9 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     this.hasErrors = Object.keys(this.validationErrors).length > 0
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm): ViewData {
+  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
     const viewData = {
-      ...this.commonViewData({ appointmentOrSession, form }),
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
       startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
       endTime: form.endTime ? DateTimeFormats.stripTime(form.endTime) : '',
     }


### PR DESCRIPTION
## Context

The page models in the appointment form journey currently set and read from state related to the in progress form. I am moving towards a stateless page model as in the course completions form, so replacing these with method parameters as and when needed.

## Changes in this PR

- Replace setting of formId in constructor, or using the `setFormId` method
- Remove method side effects which set `form`, for other methods to read later (not ideal anyway)

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
