### PR TITLE
Refactor/remove state from appointment pages

### DIFF
--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -36,7 +36,7 @@ export default class AppointmentDetailsController {
         ? await this.referenceDataService.getContactOutcome(res.locals.user.username, appointment.contactOutcomeCode)
         : undefined
 
-      const page = new CheckAppointmentDetailsPage(_req.query)
+      const page = new CheckAppointmentDetailsPage()
 
       let formId = _req.query.form?.toString()
       let form: AppointmentOutcomeForm
@@ -64,7 +64,7 @@ export default class AppointmentDetailsController {
     return async (_req: Request, res: Response) => {
       const appointmentParams = { ..._req.params } as unknown as AppointmentParams
 
-      const page = new CheckAppointmentDetailsPage(_req.body)
+      const page = new CheckAppointmentDetailsPage()
 
       const formId = _req.body.form?.toString()
 

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -28,14 +28,14 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
       const formId = _req.query.form?.toString()
-      const page = new AttendanceOutcomePage({
-        appointmentOrSession,
-        contactOutcomes: outcomes.contactOutcomes,
-      })
+      const page = new AttendanceOutcomePage()
 
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      res.render('appointments/update/attendanceOutcome', page.viewData(form, false, formId, _req.query))
+      res.render(
+        'appointments/update/attendanceOutcome',
+        page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, false, formId, _req.query),
+      )
     }
   }
 
@@ -52,16 +52,13 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
 
       const formId = _req.body.form?.toString()
-      const page = new AttendanceOutcomePage({
-        appointmentOrSession,
-        contactOutcomes: outcomes.contactOutcomes,
-      })
+      const page = new AttendanceOutcomePage()
       const form = await this.formService.getForm(formId, res.locals.user.username)
-      const validationErrors = page.validationErrors(_req.body)
+      const validationErrors = page.validationErrors(_req.body, appointmentOrSession, outcomes.contactOutcomes)
 
       if (Object.keys(validationErrors).length) {
         return res.render('appointments/update/attendanceOutcome', {
-          ...page.viewData(form, true, formId, _req.body),
+          ...page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, true, formId, _req.body),
           errorSummary: generateErrorSummary(validationErrors),
           errors: validationErrors,
         })

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -29,14 +29,13 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
       const formId = _req.query.form?.toString()
       const page = new AttendanceOutcomePage({
-        query: _req.query,
         appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
 
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      res.render('appointments/update/attendanceOutcome', page.viewData(form, false, formId))
+      res.render('appointments/update/attendanceOutcome', page.viewData(form, false, formId, _req.query))
     }
   }
 
@@ -54,22 +53,21 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
       const formId = _req.body.form?.toString()
       const page = new AttendanceOutcomePage({
-        query: _req.body,
         appointmentOrSession,
         contactOutcomes: outcomes.contactOutcomes,
       })
       const form = await this.formService.getForm(formId, res.locals.user.username)
-      const validationErrors = page.validationErrors()
+      const validationErrors = page.validationErrors(_req.body)
 
       if (Object.keys(validationErrors).length) {
         return res.render('appointments/update/attendanceOutcome', {
-          ...page.viewData(form, true, formId),
+          ...page.viewData(form, true, formId, _req.body),
           errorSummary: generateErrorSummary(validationErrors),
           errors: validationErrors,
         })
       }
 
-      const toSave = page.updateForm(form, outcomes.contactOutcomes)
+      const toSave = page.updateForm(form, outcomes.contactOutcomes, _req.body)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -34,7 +34,7 @@ export default class ChooseProjectController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
-      const page = new ChooseProjectPage(req.query)
+      const page = new ChooseProjectPage()
 
       const formId = req.query.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
@@ -79,7 +79,7 @@ export default class ChooseProjectController implements IFormPageController {
       const teamCode = req.body?.team?.toString()
       const projectCode = req.body?.project?.toString()
 
-      const page = new ChooseProjectPage(req.body)
+      const page = new ChooseProjectPage()
       const formId = req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
@@ -94,7 +94,7 @@ export default class ChooseProjectController implements IFormPageController {
         response: res,
       })
 
-      const { hasErrors, errorSummary, errors } = page.getValidationErrors()
+      const { hasErrors, errorSummary, errors } = page.getValidationErrors(req.body)
 
       if (hasErrors) {
         return res.render('appointments/update/chooseProject', {
@@ -105,7 +105,7 @@ export default class ChooseProjectController implements IFormPageController {
         })
       }
 
-      const toSave = page.updateForm(form, items.teamItems, items.projectItems)
+      const toSave = page.updateForm(form, items.teamItems, items.projectItems, req.body)
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -35,7 +35,7 @@ export default class ChooseSupervisorController implements IFormPageController {
 
       const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
 
-      const page = new ChooseSupervisorPage(_req.query)
+      const page = new ChooseSupervisorPage()
 
       const formId = _req.query.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
@@ -51,7 +51,7 @@ export default class ChooseSupervisorController implements IFormPageController {
         : []
 
       res.render('appointments/update/chooseSupervisor', {
-        ...page.viewData(appointmentOrSession, teams, supervisors, form, formId),
+        ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.query),
         chooseSupervisorPath: page.updatePath(appointmentOrSession, formId),
         form: formId,
         team,
@@ -87,22 +87,22 @@ export default class ChooseSupervisorController implements IFormPageController {
           })
         : []
 
-      const page = new ChooseSupervisorPage(_req.body)
+      const page = new ChooseSupervisorPage()
       const formId = _req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
-      page.validate()
+      page.validate(_req.body)
 
       if (page.hasErrors) {
         return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId),
+          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.body),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
           form: formId,
         })
       }
 
-      const toSave = page.updateForm(form, teams, supervisors)
+      const toSave = page.updateForm(form, teams, supervisors, _req.body)
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -116,7 +116,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => nextPath,
-            isAlertSelected: true,
+            isAlertSelected: () => true,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -164,7 +164,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => nextPath,
-            isAlertSelected: true,
+            isAlertSelected: () => true,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -238,7 +238,7 @@ describe('ConfirmController', () => {
           async (userSelectedValue: boolean) => {
             confirmPageMock.mockImplementationOnce(() => {
               return {
-                isAlertSelected: userSelectedValue,
+                isAlertSelected: () => userSelectedValue,
                 exitForm: () => '',
               }
             })
@@ -267,7 +267,7 @@ describe('ConfirmController', () => {
           async (appointmentValue?: boolean) => {
             confirmPageMock.mockImplementationOnce(() => {
               return {
-                isAlertSelected: null,
+                isAlertSelected: (): boolean | null => null,
                 exitForm: () => '',
               }
             })
@@ -340,6 +340,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => nextPath,
+            isAlertSelected: (): boolean | null => null,
           }
         })
         formAppointmentVersion = '1'
@@ -379,7 +380,7 @@ describe('ConfirmController', () => {
 
         confirmPageMock.mockImplementationOnce(() => {
           return {
-            isAlertSelected: true,
+            isAlertSelected: () => true,
             updatePath: () => '/update/path',
           }
         })
@@ -426,7 +427,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => nextPath,
-            isAlertSelected: true,
+            isAlertSelected: () => true,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -493,7 +494,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => '',
-            isAlertSelected: false,
+            isAlertSelected: () => false,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -529,7 +530,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => '',
-            isAlertSelected: false,
+            isAlertSelected: () => false,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -565,7 +566,7 @@ describe('ConfirmController', () => {
         it.each([true, false])('uses user selected value for alertActive', async (userSelectedValue: boolean) => {
           confirmPageMock.mockImplementationOnce(() => {
             return {
-              isAlertSelected: userSelectedValue,
+              isAlertSelected: () => userSelectedValue,
               exitForm: () => '',
             }
           })
@@ -603,7 +604,7 @@ describe('ConfirmController', () => {
           async (appointmentValue?: boolean) => {
             confirmPageMock.mockImplementationOnce(() => {
               return {
-                isAlertSelected: null,
+                isAlertSelected: (): boolean | null => null,
                 exitForm: () => '',
               }
             })
@@ -681,7 +682,7 @@ describe('ConfirmController', () => {
         confirmPageMock.mockImplementationOnce(() => {
           return {
             exitForm: () => nextPath,
-            isAlertSelected: true,
+            isAlertSelected: () => true,
           }
         })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -733,7 +734,7 @@ describe('ConfirmController', () => {
           confirmPageMock.mockImplementationOnce(() => {
             return {
               exitForm: () => nextPath,
-              isAlertSelected: true,
+              isAlertSelected: () => true,
             }
           })
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -776,7 +777,7 @@ describe('ConfirmController', () => {
           confirmPageMock.mockImplementationOnce(() => {
             return {
               exitForm: () => nextPath,
-              isAlertSelected: true,
+              isAlertSelected: () => true,
             }
           })
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -827,7 +828,7 @@ describe('ConfirmController', () => {
           confirmPageMock.mockImplementationOnce(() => {
             return {
               exitForm: () => nextPath,
-              isAlertSelected: true,
+              isAlertSelected: () => true,
             }
           })
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -871,7 +872,7 @@ describe('ConfirmController', () => {
           confirmPageMock.mockImplementationOnce(() => {
             return {
               exitForm: () => nextPath,
-              isAlertSelected: true,
+              isAlertSelected: () => true,
             }
           })
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -30,7 +30,7 @@ export default class ConfirmController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
-      const page = new ConfirmPage(_req.query)
+      const page = new ConfirmPage()
       const formId = _req.query.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const errorList = generateErrorTextList(res.locals.errorMessages)
@@ -60,10 +60,11 @@ export default class ConfirmController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
-      const page = new ConfirmPage(_req.body)
+      const page = new ConfirmPage()
       const formId = _req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const didAttend = form.contactOutcome.attended
+      const isAlertSelected = page.isAlertSelected(_req.body)
 
       if (appointmentOrSessionParams.appointmentId) {
         const appointment = appointmentOrSession as AppointmentDto
@@ -72,7 +73,14 @@ export default class ConfirmController implements IFormPageController {
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         }
 
-        const payload = this.buildAppointmentUpdate(form.deliusVersion, form, appointment, page, didAttend, false)
+        const payload = this.buildAppointmentUpdate(
+          form.deliusVersion,
+          form,
+          appointment,
+          isAlertSelected,
+          didAttend,
+          false,
+        )
 
         try {
           await this.appointmentService.saveAppointment(appointment.projectCode, payload, res.locals.user.username)
@@ -103,7 +111,14 @@ export default class ConfirmController implements IFormPageController {
               username: res.locals.user.username,
             })
 
-            return this.buildAppointmentUpdate(formAppointment.deliusVersion, form, appointment, page, didAttend, true)
+            return this.buildAppointmentUpdate(
+              formAppointment.deliusVersion,
+              form,
+              appointment,
+              isAlertSelected,
+              didAttend,
+              true,
+            )
           }),
         )
 
@@ -141,7 +156,7 @@ export default class ConfirmController implements IFormPageController {
     deliusVersionToUpdate: string,
     form: AppointmentOutcomeForm,
     appointment: AppointmentDto,
-    page: ConfirmPage,
+    isAlertSelected: boolean | null,
     didAttend: boolean,
     isBulk: boolean,
   ): UpdateAppointmentDto {
@@ -150,7 +165,7 @@ export default class ConfirmController implements IFormPageController {
       ...NotesUtils.requestBody(form, appointment.sensitive, allowSensitiveUpdate),
       deliusId: appointment.id,
       deliusVersionToUpdate,
-      alertActive: page.isAlertSelected ?? appointment.alertActive,
+      alertActive: isAlertSelected ?? appointment.alertActive,
       startTime: form.startTime || appointment.startTime,
       endTime: form.endTime || appointment.endTime,
       contactOutcomeCode: form.contactOutcome.code,

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -25,7 +25,7 @@ export default class LogComplianceController implements IFormPageController {
       })
 
       const formId = _req.query.form?.toString()
-      const page = new LogCompliancePage(_req.query)
+      const page = new LogCompliancePage()
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
       res.render('appointments/update/logCompliance', page.viewData(appointmentOrSession, form, formId))
@@ -37,10 +37,10 @@ export default class LogComplianceController implements IFormPageController {
       const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
       const formId = _req.body.form?.toString()
-      const page = new LogCompliancePage(_req.body)
+      const page = new LogCompliancePage()
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      page.validate()
+      page.validate(_req.body)
 
       if (page.hasError) {
         const appointmentOrSession = await getAppointmentOrSession({
@@ -51,13 +51,13 @@ export default class LogComplianceController implements IFormPageController {
         })
 
         return res.render('appointments/update/logCompliance', {
-          ...page.viewData(appointmentOrSession, form, formId),
+          ...page.viewData(appointmentOrSession, form, formId, _req.body),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
       }
 
-      const toSave = page.updateForm(form)
+      const toSave = page.updateForm(form, _req.body)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -25,7 +25,7 @@ export default class LogHoursController implements IFormPageController {
       })
 
       const formId = _req.query.form?.toString()
-      const page = new LogHoursPage(_req.query)
+      const page = new LogHoursPage()
 
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
@@ -40,8 +40,8 @@ export default class LogHoursController implements IFormPageController {
       const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
 
       const formId = _req.body.form?.toString()
-      const page = new LogHoursPage(_req.body)
-      page.validate()
+      const page = new LogHoursPage()
+      page.validate(_req.body)
 
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
@@ -54,13 +54,13 @@ export default class LogHoursController implements IFormPageController {
 
       if (page.hasErrors) {
         return res.render('appointments/update/logHours', {
-          ...page.viewData(appointmentOrSession, form, formId),
+          ...page.viewData(appointmentOrSession, form, formId, _req.body),
           errors: page.validationErrors,
           errorSummary: generateErrorSummary(page.validationErrors),
         })
       }
 
-      const toSave = page.updateForm(form)
+      const toSave = page.updateForm(form, _req.body)
       await this.formService.saveForm(formId, res.locals.user.username, toSave)
 
       return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -25,12 +25,9 @@ describe('AttendanceOutcomePage', () => {
 
   describe('validationErrors', () => {
     it('returns error when attendance outcome is empty', () => {
-      const page = new AttendanceOutcomePage({
-        appointmentOrSession: appointment,
-        contactOutcomes,
-      })
+      const page = new AttendanceOutcomePage()
 
-      expect(page.validationErrors({} as AttendanceOutcomeBody)).toEqual({
+      expect(page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes)).toEqual({
         attendanceOutcome: { text: 'Select an attendance outcome' },
       })
     })
@@ -42,13 +39,14 @@ describe('AttendanceOutcomePage', () => {
 
       it('returns error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInTheFuture,
-          contactOutcomes: [...contactOutcomes, attendedContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInTheFuture,
+            [...contactOutcomes, attendedContactOutcome],
+          ),
         ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
@@ -58,13 +56,14 @@ describe('AttendanceOutcomePage', () => {
 
       it('returns error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInTheFuture,
-          contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInTheFuture,
+            [...contactOutcomes, enforceableContactOutcome],
+          ),
         ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
@@ -74,13 +73,14 @@ describe('AttendanceOutcomePage', () => {
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInTheFuture,
-          contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInTheFuture,
+            [...contactOutcomes, acceptableAbsenceContactOutcome],
+          ),
         ).toEqual({})
       })
 
@@ -89,13 +89,14 @@ describe('AttendanceOutcomePage', () => {
           date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
         })
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: sessionInTheFuture,
-          contactOutcomes: [...contactOutcomes, attendedContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
+            sessionInTheFuture,
+            [...contactOutcomes, attendedContactOutcome],
+          ),
         ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
@@ -111,37 +112,40 @@ describe('AttendanceOutcomePage', () => {
 
       it('does not return error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentToday,
-          contactOutcomes: [...contactOutcomes, attendedContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentToday,
+            [...contactOutcomes, attendedContactOutcome],
+          ),
         ).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentToday,
-          contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentToday,
+            [...contactOutcomes, enforceableContactOutcome],
+          ),
         ).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentToday,
-          contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentToday,
+            [...contactOutcomes, acceptableAbsenceContactOutcome],
+          ),
         ).toEqual({})
       })
     })
@@ -151,72 +155,68 @@ describe('AttendanceOutcomePage', () => {
 
       it('does not return error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInThePast,
-          contactOutcomes: [...contactOutcomes, attendedContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInThePast,
+            [...contactOutcomes, attendedContactOutcome],
+          ),
         ).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInThePast,
-          contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInThePast,
+            [...contactOutcomes, enforceableContactOutcome],
+          ),
         ).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointmentInThePast,
-          contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
         expect(
-          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+          page.validationErrors(
+            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
+            appointmentInThePast,
+            [...contactOutcomes, acceptableAbsenceContactOutcome],
+          ),
         ).toEqual({})
       })
     })
 
     describe('notes', () => {
       it('should not have any errors if no notes value', () => {
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
-        page.validationErrors({} as AttendanceOutcomeBody)
+        const page = new AttendanceOutcomePage()
+        page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes)
 
-        expect(page.validationErrors({} as AttendanceOutcomeBody).notes).toBeFalsy()
+        expect(page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes).notes).toBeFalsy()
       })
 
       it.each([4000, 3999, 0])('should not have any errors if notes count is less than 4000', (count: number) => {
         const notes = faker.string.alpha(count)
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
-        page.validationErrors({ notes } as AttendanceOutcomeBody)
+        const page = new AttendanceOutcomePage()
+        page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes)
 
-        expect(page.validationErrors({ notes } as AttendanceOutcomeBody).notes).toBeFalsy()
+        expect(
+          page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes).notes,
+        ).toBeFalsy()
       })
 
       it('should have errors if the notes count is greater than 4000', () => {
         const notes = faker.string.alpha(4001)
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
-        page.validationErrors({ notes } as AttendanceOutcomeBody)
+        const page = new AttendanceOutcomePage()
+        page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes)
 
-        expect(page.validationErrors({ notes } as AttendanceOutcomeBody).notes).toEqual({
+        expect(page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes).notes).toEqual({
           text: 'Notes must be 4000 characters or less',
         })
       })
@@ -230,10 +230,7 @@ describe('AttendanceOutcomePage', () => {
         notes: 'Test notes',
         isSensitive: undefined,
       })
-      const page = new AttendanceOutcomePage({
-        appointmentOrSession: appointment,
-        contactOutcomes,
-      })
+      const page = new AttendanceOutcomePage()
       const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
       const offender = {
         name: 'Sam Smith',
@@ -275,7 +272,7 @@ describe('AttendanceOutcomePage', () => {
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const result = page.viewData(formWithOutcomes, false, undefined, {})
+      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, false, undefined, {})
 
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
@@ -328,12 +325,9 @@ describe('AttendanceOutcomePage', () => {
         jest.spyOn(paths.sessions, 'update')
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: session,
-          contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(form)
+        const result = page.viewData(session, form, contactOutcomes)
 
         const expectedItems = [
           {
@@ -380,12 +374,9 @@ describe('AttendanceOutcomePage', () => {
         const notesItems = { notes: 'some note', showIsSensitiveQuestion: false }
         const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: session,
-          contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
-        const viewData = page.viewData(form)
+        const viewData = page.viewData(session, form, contactOutcomes)
 
         expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
         expect(viewData).toEqual(expect.objectContaining(notesItems))
@@ -397,12 +388,9 @@ describe('AttendanceOutcomePage', () => {
         const form = appointmentOutcomeFormFactory.build({
           contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[0].code }),
         })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(form)
+        const result = page.viewData(appointment, form, contactOutcomes)
 
         const expectedItems = [
           {
@@ -429,12 +417,9 @@ describe('AttendanceOutcomePage', () => {
         const hintedOutcome = contactOutcomeFactory.build({
           hintText: 'Use this when the person gave advance notice',
         })
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes: [hintedOutcome],
-        })
+        const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(appointmentOutcomeFormFactory.build())
+        const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), [hintedOutcome])
 
         expect(result.items[0]).toEqual({
           text: hintedOutcome.name,
@@ -448,13 +433,10 @@ describe('AttendanceOutcomePage', () => {
         const notesItems = { notes: 'Test', showIsSensitiveQuestion: true }
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
         const query = { notes: notesItems.notes }
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
         const form = appointmentOutcomeFormFactory.build()
-        const result = page.viewData(form, true, undefined, query)
+        const result = page.viewData(appointment, form, contactOutcomes, true, undefined, query)
 
         const expectedItems = [
           {
@@ -480,13 +462,10 @@ describe('AttendanceOutcomePage', () => {
       })
 
       it('should return items if page has Errors and contact outcome is undefined', () => {
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
-        page.validationErrors({})
+        const page = new AttendanceOutcomePage()
+        page.validationErrors({}, appointment, contactOutcomes)
 
-        const result = page.viewData(appointmentOutcomeFormFactory.build())
+        const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), contactOutcomes)
 
         const expectedItems = [
           {
@@ -520,10 +499,7 @@ describe('AttendanceOutcomePage', () => {
 
         const attendedOutcome = contactOutcomeFactory.build({ attended: true })
 
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] }).contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -545,10 +521,7 @@ describe('AttendanceOutcomePage', () => {
 
         const notAttendedOutcome = contactOutcomeFactory.build({ attended: false })
 
-        const page = new AttendanceOutcomePage({
-          appointmentOrSession: appointment,
-          contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }).contactOutcomes,
-        })
+        const page = new AttendanceOutcomePage()
 
         jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -569,10 +542,7 @@ describe('AttendanceOutcomePage', () => {
       const appointmentNotes = 'Existing notes'
       const queryNotes = 'New notes'
       const form = appointmentOutcomeFormFactory.build({ notes: appointmentNotes })
-      const page = new AttendanceOutcomePage({
-        appointmentOrSession: appointment,
-        contactOutcomes,
-      })
+      const page = new AttendanceOutcomePage()
 
       const result = page.updateForm(form, contactOutcomes, {
         attendanceOutcome: contactOutcomes[0].code,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -26,12 +26,11 @@ describe('AttendanceOutcomePage', () => {
   describe('validationErrors', () => {
     it('returns error when attendance outcome is empty', () => {
       const page = new AttendanceOutcomePage({
-        query: {} as AttendanceOutcomeBody,
         appointmentOrSession: appointment,
         contactOutcomes,
       })
 
-      expect(page.validationErrors()).toEqual({
+      expect(page.validationErrors({} as AttendanceOutcomeBody)).toEqual({
         attendanceOutcome: { text: 'Select an attendance outcome' },
       })
     })
@@ -44,12 +43,13 @@ describe('AttendanceOutcomePage', () => {
       it('returns error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({
+        expect(
+          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -59,12 +59,13 @@ describe('AttendanceOutcomePage', () => {
       it('returns error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({
+        expect(
+          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -74,12 +75,13 @@ describe('AttendanceOutcomePage', () => {
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInTheFuture,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
 
       it('returns error if appointmentOrSession is a session and contact outcome is attended', () => {
@@ -88,12 +90,13 @@ describe('AttendanceOutcomePage', () => {
         })
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: sessionInTheFuture,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({
+        expect(
+          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -109,34 +112,37 @@ describe('AttendanceOutcomePage', () => {
       it('does not return error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentToday,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
     })
 
@@ -146,71 +152,71 @@ describe('AttendanceOutcomePage', () => {
       it('does not return error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, attendedContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
           appointmentOrSession: appointmentInThePast,
           contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
         })
 
-        expect(page.validationErrors()).toEqual({})
+        expect(
+          page.validationErrors({ attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody),
+        ).toEqual({})
       })
     })
 
     describe('notes', () => {
       it('should not have any errors if no notes value', () => {
         const page = new AttendanceOutcomePage({
-          query: {} as AttendanceOutcomeBody,
           appointmentOrSession: appointment,
           contactOutcomes,
         })
-        page.validationErrors()
+        page.validationErrors({} as AttendanceOutcomeBody)
 
-        expect(page.validationErrors().notes).toBeFalsy()
+        expect(page.validationErrors({} as AttendanceOutcomeBody).notes).toBeFalsy()
       })
 
       it.each([4000, 3999, 0])('should not have any errors if notes count is less than 4000', (count: number) => {
         const notes = faker.string.alpha(count)
         const page = new AttendanceOutcomePage({
-          query: { notes } as AttendanceOutcomeBody,
           appointmentOrSession: appointment,
           contactOutcomes,
         })
-        page.validationErrors()
+        page.validationErrors({ notes } as AttendanceOutcomeBody)
 
-        expect(page.validationErrors().notes).toBeFalsy()
+        expect(page.validationErrors({ notes } as AttendanceOutcomeBody).notes).toBeFalsy()
       })
 
       it('should have errors if the notes count is greater than 4000', () => {
         const notes = faker.string.alpha(4001)
         const page = new AttendanceOutcomePage({
-          query: { notes } as AttendanceOutcomeBody,
           appointmentOrSession: appointment,
           contactOutcomes,
         })
-        page.validationErrors()
+        page.validationErrors({ notes } as AttendanceOutcomeBody)
 
-        expect(page.validationErrors().notes).toEqual({
+        expect(page.validationErrors({ notes } as AttendanceOutcomeBody).notes).toEqual({
           text: 'Notes must be 4000 characters or less',
         })
       })
@@ -225,7 +231,6 @@ describe('AttendanceOutcomePage', () => {
         isSensitive: undefined,
       })
       const page = new AttendanceOutcomePage({
-        query: {} as AttendanceOutcomeBody,
         appointmentOrSession: appointment,
         contactOutcomes,
       })
@@ -270,7 +275,7 @@ describe('AttendanceOutcomePage', () => {
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const result = page.viewData(formWithOutcomes)
+      const result = page.viewData(formWithOutcomes, false, undefined, {})
 
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
@@ -324,7 +329,6 @@ describe('AttendanceOutcomePage', () => {
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
         const page = new AttendanceOutcomePage({
-          query: {} as AttendanceOutcomeBody,
           appointmentOrSession: session,
           contactOutcomes,
         })
@@ -377,7 +381,6 @@ describe('AttendanceOutcomePage', () => {
         const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
         const page = new AttendanceOutcomePage({
-          query: {} as AttendanceOutcomeBody,
           appointmentOrSession: session,
           contactOutcomes,
         })
@@ -395,7 +398,6 @@ describe('AttendanceOutcomePage', () => {
           contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[0].code }),
         })
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: contactOutcomes[1].code },
           appointmentOrSession: appointment,
           contactOutcomes,
         })
@@ -428,7 +430,6 @@ describe('AttendanceOutcomePage', () => {
           hintText: 'Use this when the person gave advance notice',
         })
         const page = new AttendanceOutcomePage({
-          query: {},
           appointmentOrSession: appointment,
           contactOutcomes: [hintedOutcome],
         })
@@ -448,13 +449,12 @@ describe('AttendanceOutcomePage', () => {
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
         const query = { notes: notesItems.notes }
         const page = new AttendanceOutcomePage({
-          query,
           appointmentOrSession: appointment,
           contactOutcomes,
         })
 
         const form = appointmentOutcomeFormFactory.build()
-        const result = page.viewData(form, true)
+        const result = page.viewData(form, true, undefined, query)
 
         const expectedItems = [
           {
@@ -481,11 +481,10 @@ describe('AttendanceOutcomePage', () => {
 
       it('should return items if page has Errors and contact outcome is undefined', () => {
         const page = new AttendanceOutcomePage({
-          query: {},
           appointmentOrSession: appointment,
           contactOutcomes,
         })
-        page.validationErrors()
+        page.validationErrors({})
 
         const result = page.viewData(appointmentOutcomeFormFactory.build())
 
@@ -522,7 +521,6 @@ describe('AttendanceOutcomePage', () => {
         const attendedOutcome = contactOutcomeFactory.build({ attended: true })
 
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: attendedOutcome.code },
           appointmentOrSession: appointment,
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] }).contactOutcomes,
         })
@@ -548,7 +546,6 @@ describe('AttendanceOutcomePage', () => {
         const notAttendedOutcome = contactOutcomeFactory.build({ attended: false })
 
         const page = new AttendanceOutcomePage({
-          query: { attendanceOutcome: notAttendedOutcome.code },
           appointmentOrSession: appointment,
           contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }).contactOutcomes,
         })
@@ -573,12 +570,15 @@ describe('AttendanceOutcomePage', () => {
       const queryNotes = 'New notes'
       const form = appointmentOutcomeFormFactory.build({ notes: appointmentNotes })
       const page = new AttendanceOutcomePage({
-        query: { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes, isSensitive: 'yes' },
         appointmentOrSession: appointment,
         contactOutcomes,
       })
 
-      const result = page.updateForm(form, contactOutcomes)
+      const result = page.updateForm(form, contactOutcomes, {
+        attendanceOutcome: contactOutcomes[0].code,
+        notes: queryNotes,
+        isSensitive: 'yes',
+      })
       expect(result).toEqual({
         ...form,
         contactOutcome: contactOutcomes[0],

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -32,22 +32,6 @@ type ViewData = {
 export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'attendance-outcome'
 
-  private appointmentOrSession: AppointmentOrSession
-
-  private contactOutcomes: ContactOutcomeDto[]
-
-  constructor({
-    appointmentOrSession,
-    contactOutcomes,
-  }: {
-    appointmentOrSession: AppointmentOrSession
-    contactOutcomes: ContactOutcomeDto[]
-  }) {
-    super()
-    this.appointmentOrSession = appointmentOrSession
-    this.contactOutcomes = contactOutcomes
-  }
-
   protected getForm(
     data: AppointmentOutcomeForm,
     outcomes: ContactOutcomeDto[],
@@ -62,7 +46,11 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validationErrors(query: AttendanceOutcomeQuery) {
+  validationErrors(
+    query: AttendanceOutcomeQuery,
+    appointmentOrSession: AppointmentOrSession,
+    contactOutcomes: ContactOutcomeDto[],
+  ) {
     const validationErrors: ValidationErrors<AttendanceOutcomeBody> = {}
 
     if (!query.attendanceOutcome) {
@@ -70,8 +58,8 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
 
     if (
-      this.outcomeIsAttendedOrEnforceable(query.attendanceOutcome) &&
-      DateTimeFormats.dateIsInFuture(this.appointmentOrSession.date)
+      this.outcomeIsAttendedOrEnforceable(query.attendanceOutcome, contactOutcomes) &&
+      DateTimeFormats.dateIsInFuture(appointmentOrSession.date)
     ) {
       validationErrors.attendanceOutcome = {
         text: 'The outcome entered must be: acceptable absence',
@@ -86,17 +74,19 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   }
 
   viewData(
+    appointmentOrSession: AppointmentOrSession,
     form: AppointmentOutcomeForm,
+    contactOutcomes: ContactOutcomeDto[],
     hasErrors: boolean = false,
     formId?: string,
     query?: AttendanceOutcomeQuery,
   ): ViewData {
-    const isSingleAppointment = this.isSingleAppointment(this.appointmentOrSession)
-    const appointment = isSingleAppointment ? (this.appointmentOrSession as AppointmentDto) : undefined
+    const isSingleAppointment = this.isSingleAppointment(appointmentOrSession)
+    const appointment = isSingleAppointment ? (appointmentOrSession as AppointmentDto) : undefined
     return {
-      ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession, form, formId }),
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
       ...NotesUtils.questionItems(query ?? {}, form, appointment, isSingleAppointment),
-      items: this.items(form, hasErrors, query),
+      items: this.items(form, contactOutcomes, hasErrors, query),
     }
   }
 
@@ -114,11 +104,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
 
   private items(
     form: AppointmentOutcomeForm,
+    contactOutcomes: ContactOutcomeDto[],
     hasErrors: boolean,
     query?: AttendanceOutcomeQuery,
   ): { text: string; value: string }[] {
     const code = hasErrors ? query?.attendanceOutcome : form.contactOutcome?.code
-    return this.contactOutcomes.map(outcome => ({
+    return contactOutcomes.map(outcome => ({
       text: outcome.name,
       value: outcome.code,
       hint: outcome.hintText ? { text: outcome.hintText } : undefined,
@@ -126,10 +117,10 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }))
   }
 
-  private outcomeIsAttendedOrEnforceable(outcomeCode: string): boolean {
+  private outcomeIsAttendedOrEnforceable(outcomeCode: string, contactOutcomes: ContactOutcomeDto[]): boolean {
     if (!outcomeCode) return false
 
-    const outcome = this.contactOutcomes.filter(o => o.code === outcomeCode)[0]
+    const outcome = contactOutcomes.filter(o => o.code === outcomeCode)[0]
 
     return outcome.attended || outcome.enforceable
   }

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -32,46 +32,45 @@ type ViewData = {
 export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'attendance-outcome'
 
-  private query: AttendanceOutcomeQuery
-
   private appointmentOrSession: AppointmentOrSession
 
   private contactOutcomes: ContactOutcomeDto[]
 
   constructor({
-    query,
     appointmentOrSession,
     contactOutcomes,
   }: {
-    query: AttendanceOutcomeQuery
     appointmentOrSession: AppointmentOrSession
     contactOutcomes: ContactOutcomeDto[]
   }) {
     super()
-    this.query = query
     this.appointmentOrSession = appointmentOrSession
     this.contactOutcomes = contactOutcomes
   }
 
-  protected getForm(data: AppointmentOutcomeForm, outcomes: ContactOutcomeDto[]): AppointmentOutcomeForm {
-    const contactOutcome = outcomes.find(outcome => outcome.code === this.query.attendanceOutcome)
+  protected getForm(
+    data: AppointmentOutcomeForm,
+    outcomes: ContactOutcomeDto[],
+    query: AttendanceOutcomeQuery,
+  ): AppointmentOutcomeForm {
+    const contactOutcome = outcomes.find(outcome => outcome.code === query.attendanceOutcome)
 
     return {
       ...data,
-      ...NotesUtils.formData(this.query),
+      ...NotesUtils.formData(query),
       contactOutcome,
     }
   }
 
-  validationErrors() {
+  validationErrors(query: AttendanceOutcomeQuery) {
     const validationErrors: ValidationErrors<AttendanceOutcomeBody> = {}
 
-    if (!this.query.attendanceOutcome) {
+    if (!query.attendanceOutcome) {
       validationErrors.attendanceOutcome = { text: 'Select an attendance outcome' }
     }
 
     if (
-      this.outcomeIsAttendedOrEnforceable(this.query.attendanceOutcome) &&
+      this.outcomeIsAttendedOrEnforceable(query.attendanceOutcome) &&
       DateTimeFormats.dateIsInFuture(this.appointmentOrSession.date)
     ) {
       validationErrors.attendanceOutcome = {
@@ -79,20 +78,25 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
       }
     }
 
-    if (this.query.notes && this.query.notes.length > 4000) {
+    if (query.notes && query.notes.length > 4000) {
       validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
     }
 
     return validationErrors
   }
 
-  viewData(form: AppointmentOutcomeForm, hasErrors: boolean = false, formId?: string): ViewData {
+  viewData(
+    form: AppointmentOutcomeForm,
+    hasErrors: boolean = false,
+    formId?: string,
+    query?: AttendanceOutcomeQuery,
+  ): ViewData {
     const isSingleAppointment = this.isSingleAppointment(this.appointmentOrSession)
     const appointment = isSingleAppointment ? (this.appointmentOrSession as AppointmentDto) : undefined
     return {
       ...this.commonViewData({ appointmentOrSession: this.appointmentOrSession, form, formId }),
-      ...NotesUtils.questionItems(this.query, form, appointment, isSingleAppointment),
-      items: this.items(form, hasErrors),
+      ...NotesUtils.questionItems(query ?? {}, form, appointment, isSingleAppointment),
+      items: this.items(form, hasErrors, query),
     }
   }
 
@@ -108,8 +112,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     return 'log-hours'
   }
 
-  private items(form: AppointmentOutcomeForm, hasErrors: boolean): { text: string; value: string }[] {
-    const code = hasErrors ? this.query.attendanceOutcome : form.contactOutcome?.code
+  private items(
+    form: AppointmentOutcomeForm,
+    hasErrors: boolean,
+    query?: AttendanceOutcomeQuery,
+  ): { text: string; value: string }[] {
+    const code = hasErrors ? query?.attendanceOutcome : form.contactOutcome?.code
     return this.contactOutcomes.map(outcome => ({
       text: outcome.name,
       value: outcome.code,

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -27,7 +27,7 @@ describe('CheckAppointmentDetailsPage', () => {
     const updatePath = '/update'
 
     beforeEach(() => {
-      page = new CheckAppointmentDetailsPage({})
+      page = new CheckAppointmentDetailsPage()
       appointment = appointmentFactory.build({ sensitive: false })
       jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
@@ -168,7 +168,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const backLink = '/project/1'
       jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
       const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
-      page = new CheckAppointmentDetailsPage({})
+      page = new CheckAppointmentDetailsPage()
       const search = { provider: 'provider' }
       const result = page.viewData({ appointment, project, originalSearch: search })
       expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
@@ -543,7 +543,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const path = '/path'
-      const page = new CheckAppointmentDetailsPage({})
+      const page = new CheckAppointmentDetailsPage()
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -559,7 +559,7 @@ describe('CheckAppointmentDetailsPage', () => {
   describe('form', () => {
     it('returns data from query given object with existing data', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const page = new CheckAppointmentDetailsPage({})
+      const page = new CheckAppointmentDetailsPage()
 
       const result = page.updateForm(form)
       expect(result).toEqual(form)

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -3,7 +3,6 @@ import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
-  AppointmentUpdateQuery,
   GovUkSummaryListItem,
   ValidationErrors,
 } from '../../@types/user-defined'
@@ -35,18 +34,10 @@ interface Body {
   supervisor: string
 }
 
-interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
-  supervisor?: string
-}
-
 export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'appointment-details'
 
   validationErrors: ValidationErrors<Body> = {}
-
-  constructor(private readonly query: AppointmentDetailsQuery) {
-    super()
-  }
 
   protected getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return data

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -15,7 +15,7 @@ describe('ChooseProjectPage', () => {
     it('returns backLink and updatePath for the expected pages', () => {
       const appointment = appointmentFactory.build({ projectCode: 'P1', id: 123 })
       const form = appointmentOutcomeFormFactory.build()
-      const page = new ChooseProjectPage({})
+      const page = new ChooseProjectPage()
 
       const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'F1' })
 
@@ -44,7 +44,7 @@ describe('ChooseProjectPage', () => {
 
   describe('next', () => {
     it('returns attendance outcome path for an appointment', () => {
-      const page = new ChooseProjectPage({})
+      const page = new ChooseProjectPage()
       const projectCode = 'P1'
       const appointmentId = '123'
 
@@ -73,8 +73,8 @@ describe('ChooseProjectPage', () => {
       jest.spyOn(SelectProjectComponent, 'getValidationErrors').mockReturnValue(errors)
       jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
 
-      const page = new ChooseProjectPage({ form: 'F1' })
-      const result = page.getValidationErrors()
+      const page = new ChooseProjectPage()
+      const result = page.getValidationErrors({ form: 'F1' })
 
       expect(result).toEqual({
         errors,
@@ -91,8 +91,8 @@ describe('ChooseProjectPage', () => {
       jest.spyOn(SelectProjectComponent, 'getValidationErrors').mockReturnValue(errors)
       jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
 
-      const page = new ChooseProjectPage({ form: 'F1' })
-      const result = page.getValidationErrors()
+      const page = new ChooseProjectPage()
+      const result = page.getValidationErrors({ form: 'F1' })
 
       expect(result).toEqual({
         errors,
@@ -106,7 +106,7 @@ describe('ChooseProjectPage', () => {
   describe('updateForm', () => {
     it('sets team and project values', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const page = new ChooseProjectPage({ form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' })
+      const page = new ChooseProjectPage()
       const teams = [
         { value: 'TEAM-1', text: 'Team 1' },
         { value: 'TEAM-2', text: 'Team 2' },
@@ -117,7 +117,7 @@ describe('ChooseProjectPage', () => {
         { value: 'PROJECT-1', text: 'Project 1' },
       ]
 
-      const result = page.updateForm(form, teams, projects)
+      const result = page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' })
 
       expect(result).toEqual({
         ...form,
@@ -128,22 +128,24 @@ describe('ChooseProjectPage', () => {
 
     it('throws when selected team does not exist in options', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const page = new ChooseProjectPage({ form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' })
+      const page = new ChooseProjectPage()
       const teams = [{ value: 'TEAM-2', text: 'Team 2' }]
       const projects = [{ value: 'PROJECT-1', text: 'Project 1' }]
 
-      expect(() => page.updateForm(form, teams, projects)).toThrow('Selected team with code TEAM-1 was not found.')
+      expect(() =>
+        page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' }),
+      ).toThrow('Selected team with code TEAM-1 was not found.')
     })
 
     it('throws when selected project does not exist in options', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const page = new ChooseProjectPage({ form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' })
+      const page = new ChooseProjectPage()
       const teams = [{ value: 'TEAM-1', text: 'Team 1' }]
       const projects = [{ value: 'PROJECT-2', text: 'Project 2' }]
 
-      expect(() => page.updateForm(form, teams, projects)).toThrow(
-        'Selected project with code PROJECT-1 was not found.',
-      )
+      expect(() =>
+        page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' }),
+      ).toThrow('Selected project with code PROJECT-1 was not found.')
     })
   })
 })

--- a/server/pages/appointments/chooseProjectPage.ts
+++ b/server/pages/appointments/chooseProjectPage.ts
@@ -14,10 +14,6 @@ type Query = AppointmentUpdateQuery & ProjectQuestionsBody
 export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'choose-project'
 
-  constructor(private query: Query) {
-    super()
-  }
-
   protected nextPage(): AppointmentFormPage | undefined {
     return 'attendance-outcome'
   }
@@ -26,8 +22,8 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
     return 'choose-supervisor'
   }
 
-  getValidationErrors(): ErrorViewData<ProjectQuestionsBody> {
-    const errors = SelectProjectComponent.getValidationErrors(this.query)
+  getValidationErrors(query: Query): ErrorViewData<ProjectQuestionsBody> {
+    const errors = SelectProjectComponent.getValidationErrors(query)
     const errorSummary = generateErrorSummary(errors)
 
     return { errors, hasErrors: Object.keys(errors).length > 0, errorSummary }
@@ -37,16 +33,17 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
     form: AppointmentOutcomeForm,
     teams: Array<GovUkSelectOption>,
     projects: Array<GovUkSelectOption>,
+    query: Query,
   ): AppointmentOutcomeForm {
-    const selectedTeam = teams.find(team => team.value === this.query.team)
-    const selectedProject = projects.find(project => project.value === this.query.project)
+    const selectedTeam = teams.find(team => team.value === query.team)
+    const selectedProject = projects.find(project => project.value === query.project)
 
     if (!selectedTeam) {
-      throw new Error(`Selected team with code ${this.query.team} was not found.`)
+      throw new Error(`Selected team with code ${query.team} was not found.`)
     }
 
     if (!selectedProject) {
-      throw new Error(`Selected project with code ${this.query.project} was not found.`)
+      throw new Error(`Selected project with code ${query.project} was not found.`)
     }
 
     return {

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -30,7 +30,7 @@ describe('ChooseSupervisorPage', () => {
 
     beforeEach(() => {
       appointment = appointmentFactory.build()
-      page = new ChooseSupervisorPage({})
+      page = new ChooseSupervisorPage()
       supervisors = supervisorSummaryFactory.buildList(2)
       form = appointmentOutcomeFormFactory.build()
       teams = { providers: providerTeamSummaryFactory.buildList(3) }
@@ -55,9 +55,9 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234' })
+      page = new ChooseSupervisorPage()
 
-      const result = page.viewData(appointment, teams, supervisors, form)
+      const result = page.viewData(appointment, teams, supervisors, form, undefined, { team: '1234' })
 
       expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
@@ -79,9 +79,9 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234' })
+      page = new ChooseSupervisorPage()
 
-      const result = page.viewData(appointmentFactory.build(), teams, supervisors, form)
+      const result = page.viewData(appointmentFactory.build(), teams, supervisors, form, undefined, { team: '1234' })
 
       expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
@@ -102,10 +102,13 @@ describe('ChooseSupervisorPage', () => {
       ]
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: '1234', supervisor })
-      page.validate()
+      page = new ChooseSupervisorPage()
+      page.validate({ team: '1234', supervisor })
 
-      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build())
+      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build(), undefined, {
+        team: '1234',
+        supervisor,
+      })
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
         supervisors,
@@ -142,9 +145,9 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValueOnce(teamItems).mockReturnValueOnce(supervisorItems)
 
-      page = new ChooseSupervisorPage({ team: 'T1' })
+      page = new ChooseSupervisorPage()
 
-      const result = page.viewData(session, teams, supervisors, form)
+      const result = page.viewData(session, teams, supervisors, form, undefined, { team: 'T1' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,
@@ -171,8 +174,8 @@ describe('ChooseSupervisorPage', () => {
   describe('validate', () => {
     it('has no errors if team has value and supervisor has value', () => {
       const query = { team: 'X123', supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query)
-      page.validate()
+      const page = new ChooseSupervisorPage()
+      page.validate(query)
 
       expect(page.hasErrors).toBe(false)
       expect(page.validationErrors).toStrictEqual({})
@@ -180,8 +183,8 @@ describe('ChooseSupervisorPage', () => {
 
     it.each(['', undefined])('has errors if team is empty', (team: string | undefined) => {
       const query = { team, supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query)
-      page.validate()
+      const page = new ChooseSupervisorPage()
+      page.validate(query)
 
       expect(page.hasErrors).toBe(true)
       expect(page.validationErrors).toStrictEqual({ team: { text: 'Select a supervising team' } })
@@ -189,8 +192,8 @@ describe('ChooseSupervisorPage', () => {
 
     it.each(['', undefined])('has errors if supervisor is empty', (supervisor: string | undefined) => {
       const query = { team: 'X123', supervisor }
-      const page = new ChooseSupervisorPage(query)
-      page.validate()
+      const page = new ChooseSupervisorPage()
+      page.validate(query)
 
       expect(page.hasErrors).toBe(true)
       expect(page.validationErrors).toStrictEqual({ supervisor: { text: 'Select a supervisor' } })
@@ -202,8 +205,7 @@ describe('ChooseSupervisorPage', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const path = '/path'
-      const query = { supervisor: 'Jane' }
-      const page = new ChooseSupervisorPage(query)
+      const page = new ChooseSupervisorPage()
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(path)
 
@@ -220,9 +222,12 @@ describe('ChooseSupervisorPage', () => {
 
       const teams = providerTeamSummaryFactory.buildList(2)
       const [selectedTeam] = teams
-      const page = new ChooseSupervisorPage({ supervisor: selectedSupervisor.code, team: selectedTeam.code })
+      const page = new ChooseSupervisorPage()
 
-      const result = page.updateForm(form, { providers: teams }, supervisors)
+      const result = page.updateForm(form, { providers: teams }, supervisors, {
+        supervisor: selectedSupervisor.code,
+        team: selectedTeam.code,
+      })
       expect(result).toEqual({ ...form, supervisor: selectedSupervisor, supervisingTeam: selectedTeam })
     })
   })

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -31,10 +31,6 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
 
   validationErrors: ValidationErrors<Body> = {}
 
-  constructor(private readonly query: AppointmentDetailsQuery) {
-    super()
-  }
-
   get hasErrors() {
     return Object.keys(this.validationErrors).length > 0
   }
@@ -43,9 +39,10 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     data: AppointmentOutcomeForm,
     teams: ProviderTeamSummariesDto,
     supervisors: SupervisorSummaryDto[],
+    query: AppointmentDetailsQuery,
   ): AppointmentOutcomeForm {
-    const selectedTeam = teams.providers.find(team => team.code === this.query.team)
-    const selectedSupervisor = supervisors.find(supervisor => supervisor.code === this.query.supervisor)
+    const selectedTeam = teams.providers.find(team => team.code === query.team)
+    const selectedSupervisor = supervisors.find(supervisor => supervisor.code === query.supervisor)
     return {
       ...data,
       supervisingTeam: selectedTeam,
@@ -59,9 +56,10 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     supervisors: SupervisorSummaryDto[],
     form: AppointmentOutcomeForm,
     formId?: string,
+    query?: AppointmentDetailsQuery,
   ): ViewData {
-    const teamCode = this.query.team || form.supervisingTeam?.code
-    const code = this.hasErrors ? this.query.supervisor : form.supervisor?.code
+    const teamCode = query?.team || form.supervisingTeam?.code
+    const code = this.hasErrors ? query?.supervisor : form.supervisor?.code
 
     return {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
@@ -72,13 +70,13 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validate() {
-    if (!this.query.team) {
+  validate(query: AppointmentDetailsQuery) {
+    if (!query.team) {
       this.validationErrors.team = { text: 'Select a supervising team' }
       return
     }
 
-    if (!this.query.supervisor) {
+    if (!query.supervisor) {
       this.validationErrors.supervisor = { text: 'Select a supervisor' }
     }
   }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -25,7 +25,7 @@ describe('ConfirmPage', () => {
     const pathWithQuery = '/path?'
 
     beforeEach(() => {
-      page = new ConfirmPage({})
+      page = new ConfirmPage()
       appointment = appointmentFactory.build({ sensitive: false })
       form = appointmentOutcomeFormFactory.build()
       jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
@@ -622,7 +622,7 @@ describe('ConfirmPage', () => {
     it('should return session link if project type is "GROUP"', () => {
       const projectCode = '2'
       const path = '/path'
-      const page = new ConfirmPage({})
+      const page = new ConfirmPage()
       const search = { provider: 'provider' }
 
       jest.spyOn(paths.sessions, 'show').mockReturnValue(path)
@@ -634,7 +634,7 @@ describe('ConfirmPage', () => {
     it('should return project link if project type is "INDIVIDUAL"', () => {
       const projectCode = '2'
       const path = '/path'
-      const page = new ConfirmPage({})
+      const page = new ConfirmPage()
       const search = { provider: 'provider' }
 
       jest.spyOn(paths.projects, 'show').mockReturnValue(path)
@@ -647,7 +647,7 @@ describe('ConfirmPage', () => {
 
   describe('nextPath', () => {
     it('should throw not implemented error', () => {
-      const page = new ConfirmPage({})
+      const page = new ConfirmPage()
       expect(() => page.next({ projectCode: '', appointmentId: '' })).toThrow(new Error('No next page configured'))
     })
   })
@@ -658,8 +658,8 @@ describe('ConfirmPage', () => {
       (queryValue?: YesOrNo) => {
         const mockReturnValue = false
         jest.spyOn(GovUkRadioGroup, 'nullableValueFromYesOrNoItem').mockReturnValue(mockReturnValue)
-        const page = new ConfirmPage({ alertPractitioner: queryValue })
-        const result = page.isAlertSelected
+        const page = new ConfirmPage()
+        const result = page.isAlertSelected({ alertPractitioner: queryValue })
         expect(GovUkRadioGroup.nullableValueFromYesOrNoItem).toHaveBeenCalledWith(queryValue)
         expect(result).toEqual(mockReturnValue)
       },
@@ -668,7 +668,7 @@ describe('ConfirmPage', () => {
 
   describe('deliusVersionChangedMessage', () => {
     it('should return singular form message for 1 appointment', () => {
-      const page = new ConfirmPage({})
+      const page = new ConfirmPage()
       const appointment = appointmentFactory.build({
         offender: offenderFullFactory.build({
           forename: 'John',
@@ -685,7 +685,7 @@ describe('ConfirmPage', () => {
     })
 
     it('should return plural form message for multiple appointments', () => {
-      const page = new ConfirmPage({})
+      const page = new ConfirmPage()
       const appointments = [
         appointmentFactory.build({
           offender: offenderFullFactory.build({

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -32,10 +32,6 @@ interface Query extends AppointmentUpdateQuery {
 export default class ConfirmPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'confirm-details'
 
-  constructor(private readonly query: Query) {
-    super()
-  }
-
   protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return form
   }
@@ -55,8 +51,8 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  get isAlertSelected(): boolean | null {
-    return GovUkRadioGroup.nullableValueFromYesOrNoItem(this.query.alertPractitioner)
+  isAlertSelected(query: Query): boolean | null {
+    return GovUkRadioGroup.nullableValueFromYesOrNoItem(query.alertPractitioner)
   }
 
   deliusVersionChangedMessage(appointments: Array<AppointmentDto>): string {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -23,7 +23,7 @@ describe('LogCompliancePage', () => {
     let form: AppointmentOutcomeForm
 
     beforeEach(() => {
-      page = new LogCompliancePage({})
+      page = new LogCompliancePage()
       appointment = appointmentFactory.build()
       form = appointmentOutcomeFormFactory.build()
     })
@@ -148,13 +148,16 @@ describe('LogCompliancePage', () => {
             behaviour: 'GOOD',
           },
         })
-        page = new LogCompliancePage({
+        page = new LogCompliancePage()
+        page.validate({
           behaviour: null,
           workQuality: 'EXCELLENT',
         })
-        page.validate()
 
-        const result = page.viewData(appointment, formData)
+        const result = page.viewData(appointment, formData, undefined, {
+          behaviour: null,
+          workQuality: 'EXCELLENT',
+        })
 
         expect(result).toEqual(
           expect.objectContaining({
@@ -175,8 +178,8 @@ describe('LogCompliancePage', () => {
   describe('validate', () => {
     describe('when workQuality is not present', () => {
       it('should return the correct error', () => {
-        page = new LogCompliancePage({ workQuality: null })
-        page.validate()
+        page = new LogCompliancePage()
+        page.validate({ workQuality: null })
 
         expect(page.validationErrors.workQuality).toEqual({
           text: 'Select their work quality',
@@ -187,8 +190,8 @@ describe('LogCompliancePage', () => {
 
     describe('when behaviour is not present', () => {
       it('should return the correct error', () => {
-        page = new LogCompliancePage({ behaviour: null })
-        page.validate()
+        page = new LogCompliancePage()
+        page.validate({ behaviour: null })
 
         expect(page.validationErrors.behaviour).toEqual({
           text: 'Select their behaviour',
@@ -203,7 +206,7 @@ describe('LogCompliancePage', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const nextPath = '/path'
-      page = new LogCompliancePage({})
+      page = new LogCompliancePage()
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
@@ -217,8 +220,8 @@ describe('LogCompliancePage', () => {
       const nextPath = '/path'
       const existingForm = appointmentOutcomeFormFactory.build()
 
-      page = new LogCompliancePage({})
-      page.updateForm(existingForm)
+      page = new LogCompliancePage()
+      page.updateForm(existingForm, {})
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
@@ -239,9 +242,9 @@ describe('LogCompliancePage', () => {
         behaviour: 'GOOD',
       }
 
-      page = new LogCompliancePage(query)
+      page = new LogCompliancePage()
 
-      const result = page.updateForm(form)
+      const result = page.updateForm(form, query)
 
       const expected = {
         ...form,

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -32,24 +32,25 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
 
   validationErrors: ValidationErrors<Body> = {}
 
-  constructor(private readonly query: LogComplianceQuery) {
-    super()
-  }
-
-  getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
+  getForm(data: AppointmentOutcomeForm, query: LogComplianceQuery): AppointmentOutcomeForm {
     return {
       ...data,
 
       attendanceData: {
         ...data.attendanceData,
-        workQuality: this.query.workQuality,
-        behaviour: this.query.behaviour,
+        workQuality: query.workQuality,
+        behaviour: query.behaviour,
       },
     }
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
-    const formValues = this.getFormDisplayValues(form)
+  viewData(
+    appointmentOrSession: AppointmentOrSession,
+    form: AppointmentOutcomeForm,
+    formId?: string,
+    query?: LogComplianceQuery,
+  ): ViewData {
+    const formValues = this.getFormDisplayValues(form, query)
     return {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
       workQualityItems: this.getItems(formValues.workQuality),
@@ -57,12 +58,12 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validate() {
-    if (!this.query.workQuality) {
+  validate(query: LogComplianceQuery) {
+    if (!query.workQuality) {
       this.validationErrors.workQuality = { text: 'Select their work quality' }
     }
 
-    if (!this.query.behaviour) {
+    if (!query.behaviour) {
       this.validationErrors.behaviour = { text: 'Select their behaviour' }
     }
 
@@ -93,9 +94,9 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }))
   }
 
-  private getFormDisplayValues(form: AppointmentOutcomeForm): LogComplianceQuery {
-    if (this.hasError) {
-      return this.query
+  private getFormDisplayValues(form: AppointmentOutcomeForm, query?: LogComplianceQuery): LogComplianceQuery {
+    if (this.hasError && query) {
+      return query
     }
 
     return {

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -21,8 +21,8 @@ describe('LogHoursPage', () => {
     describe('startTime', () => {
       describe('when startTime is not present', () => {
         it('should return the correct error', () => {
-          page = new LogHoursPage({ startTime: null })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ startTime: null })
 
           expect(page.validationErrors.startTime).toEqual({
             text: 'Enter a start time',
@@ -32,8 +32,8 @@ describe('LogHoursPage', () => {
 
       describe('when startTime is not valid', () => {
         it('should return the correct error', () => {
-          page = new LogHoursPage({ startTime: '8475438' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ startTime: '8475438' })
 
           expect(page.validationErrors.startTime).toEqual({
             text: 'Enter a valid start time, for example 09:00',
@@ -43,8 +43,8 @@ describe('LogHoursPage', () => {
 
       describe('when startTime is present', () => {
         it('should not return an error', () => {
-          page = new LogHoursPage({ startTime: '09:00' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ startTime: '09:00' })
 
           expect(page.validationErrors.startTime).toBeUndefined()
         })
@@ -52,8 +52,8 @@ describe('LogHoursPage', () => {
 
       describe('when startTime is after endTime', () => {
         it('should return an error', () => {
-          page = new LogHoursPage({ startTime: '09:00', endTime: '08:00' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ startTime: '09:00', endTime: '08:00' })
 
           expect(page.validationErrors.startTime).toEqual({
             text: `Start time should be before 08:00`,
@@ -63,8 +63,8 @@ describe('LogHoursPage', () => {
 
       describe('when startTime is the same as endTime', () => {
         it('should return an error', () => {
-          page = new LogHoursPage({ startTime: '09:00', endTime: '09:00' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ startTime: '09:00', endTime: '09:00' })
 
           expect(page.validationErrors.startTime).toEqual({
             text: 'Start time should be before 09:00',
@@ -76,8 +76,8 @@ describe('LogHoursPage', () => {
     describe('endTime', () => {
       describe('when endTime is not present', () => {
         it('should return the correct error', () => {
-          page = new LogHoursPage({ endTime: null })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ endTime: null })
 
           expect(page.validationErrors.endTime).toEqual({
             text: 'Enter an end time',
@@ -87,8 +87,8 @@ describe('LogHoursPage', () => {
 
       describe('when endTime is not valid', () => {
         it('should return the correct error', () => {
-          page = new LogHoursPage({ endTime: '837:02' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ endTime: '837:02' })
 
           expect(page.validationErrors.endTime).toEqual({
             text: 'Enter a valid end time, for example 17:00',
@@ -98,8 +98,8 @@ describe('LogHoursPage', () => {
 
       describe('when endTime is present', () => {
         it('should not return an error', () => {
-          page = new LogHoursPage({ endTime: '17:00' })
-          page.validate()
+          page = new LogHoursPage()
+          page.validate({ endTime: '17:00' })
 
           expect(page.validationErrors.endTime).toBeUndefined()
         })
@@ -217,8 +217,8 @@ describe('LogHoursPage', () => {
       const appointmentId = '1'
       const projectCode = '2'
       const nextPath = '/path'
-      page = new LogHoursPage({})
-      page.updateForm(form)
+      page = new LogHoursPage()
+      page.updateForm(form, {})
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
@@ -235,9 +235,9 @@ describe('LogHoursPage', () => {
         endTime: '13:00',
       }
 
-      page = new LogHoursPage(query)
+      page = new LogHoursPage()
 
-      const result = page.updateForm(form)
+      const result = page.updateForm(form, query)
 
       const expected = {
         ...form,

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -31,41 +31,42 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
 
   validationErrors: ValidationErrors<LogHoursBody> = {}
 
-  constructor(private readonly query: LogHoursQuery = {}) {
-    super()
-  }
-
-  getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
+  getForm(data: AppointmentOutcomeForm, query: LogHoursQuery): AppointmentOutcomeForm {
     return {
       ...data,
-      startTime: this.query.startTime,
-      endTime: this.query.endTime,
+      startTime: query.startTime,
+      endTime: query.endTime,
     }
   }
 
-  validate() {
-    if (!this.query.startTime) {
+  validate(query: LogHoursQuery) {
+    if (!query.startTime) {
       this.validationErrors.startTime = { text: 'Enter a start time' }
-    } else if (!DateTimeFormats.isValidTime(this.query.startTime as string)) {
+    } else if (!DateTimeFormats.isValidTime(query.startTime as string)) {
       this.validationErrors.startTime = { text: 'Enter a valid start time, for example 09:00' }
     }
 
-    if (!this.query.endTime) {
+    if (!query.endTime) {
       this.validationErrors.endTime = { text: 'Enter an end time' }
-    } else if (!DateTimeFormats.isValidTime(this.query.endTime as string)) {
+    } else if (!DateTimeFormats.isValidTime(query.endTime as string)) {
       this.validationErrors.endTime = { text: 'Enter a valid end time, for example 17:00' }
     }
 
     if (!this.validationErrors.startTime && !this.validationErrors.endTime) {
-      if (!DateTimeFormats.timesAreOrdered(this.query.startTime, this.query.endTime)) {
-        this.validationErrors.startTime = { text: `Start time should be before ${this.query.endTime}` }
+      if (!DateTimeFormats.timesAreOrdered(query.startTime, query.endTime)) {
+        this.validationErrors.startTime = { text: `Start time should be before ${query.endTime}` }
       }
     }
 
     this.hasErrors = Object.keys(this.validationErrors).length > 0
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
+  viewData(
+    appointmentOrSession: AppointmentOrSession,
+    form: AppointmentOutcomeForm,
+    formId?: string,
+    query: LogHoursQuery = {},
+  ): ViewData {
     const viewData = {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
       startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
@@ -75,7 +76,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     if (this.hasErrors) {
       return {
         ...viewData,
-        ...this.query,
+        ...query,
       }
     }
 


### PR DESCRIPTION
## Context

This removes state from the appointment for page models. This is a step towards adopting a shared abstract controller class for these classes - similar to that used in the course completions forms.

This change should enable:
- Extension of the `PageWithValidation` abstract page model to enforce consistent validation behaviour
- Addition of a base controller class

## Changes in this PR

- Move `query` from all page constructors to method arguments
- Move additional state related parameters from `AttendaceOutcomeController` to method arguments. Note, I plan to remove the need for the `appointment` parameter in a future PR, but this just moves them for now.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
