### PR TITLE
CPB-1097 - Show update appointment link for appointments with an outcome

### DIFF
--- a/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/checkAppointmentDetailsPage.ts
@@ -128,8 +128,8 @@ export default class CheckAppointmentDetailsPage extends Page {
       .should('contain.text', yesNoDisplayValue(this.appointment.alertActive))
   }
 
-  shouldNotShowContinueButton(): void {
-    cy.contains('button', 'Continue').should('not.exist')
+  shouldShowUpdateAppointmentLink(): void {
+    cy.contains('a', 'Update appointment').should('exist')
   }
 
   protected override customCheckOnPage(): void {

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -42,7 +42,7 @@
 //  Scenario: Viewing the appointment details page with an existing outcome
 //    Given I am on the appointment details page
 //    And an outcome has previously been recorded
-//    Then I should not see the Continue button
+//    Then I should see the update appointment link
 //    And I should see outcome details
 
 //  Scenario: Completing the check appointment details page
@@ -362,7 +362,7 @@ context('Session details', () => {
 
   describe('Contact outcome status', () => {
     // Scenario: Viewing the appointment details page with an existing outcome
-    it('shows outcome details and does not show the continue button if a contact outcome exists', function test() {
+    it('shows outcome details and shows the update appointment button if a contact outcome exists', function test() {
       const contactOutcome = contactOutcomeFactory.build({ name: 'Attended - complied' })
 
       const appointmentWithContactOutcome = appointmentFactory.build({
@@ -387,8 +387,8 @@ context('Session details', () => {
 
       // And an outcome has previously been recorded
 
-      // Then I should not see the Continue button
-      page.shouldNotShowContinueButton()
+      // Then I should see the update appointment button
+      page.shouldShowUpdateAppointmentLink()
 
       // And I should see outcome details
       page.shouldContainComplianceDetails()

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -500,42 +500,6 @@ describe('CheckAppointmentDetailsPage', () => {
         expect(result.showMissingOutcomeMessage).toBe(true)
       })
     })
-
-    describe('showContinueButton', () => {
-      it('should return true if no outcome is associated with the appointment', () => {
-        const appointmentWithNoOutcome = appointmentFactory.build({ contactOutcomeCode: undefined })
-        const projectDto = projectFactory.build()
-        const dateAndTime = '1 January 2025, 09:00 - 17:00'
-        const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
-        jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
-        jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
-
-        const result = page.viewData({
-          appointment: appointmentWithNoOutcome,
-          project: projectDto,
-          originalSearch: {},
-        })
-
-        expect(result.showContinueButton).toBe(true)
-      })
-
-      it('should return false if an outcome is associated with the appointment', () => {
-        const appointmentWithOutcome = appointmentFactory.build({ contactOutcomeCode: 'OUTC' })
-        const projectDto = projectFactory.build()
-        const dateAndTime = '1 January 2025, 09:00 - 17:00'
-        const location = '1001, 14B Office Street, City, Shireshire, ZY98XW'
-        jest.spyOn(DateTimeFormats, 'dateAndTimePeriod').mockReturnValue(dateAndTime)
-        jest.spyOn(LocationUtils, 'locationToString').mockReturnValue(location)
-
-        const result = page.viewData({
-          appointment: appointmentWithOutcome,
-          project: projectDto,
-          originalSearch: {},
-        })
-
-        expect(result.showContinueButton).toBe(false)
-      })
-    })
   })
 
   describe('next', () => {

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -17,7 +17,6 @@ import { AppointmentFormPage } from './pathMap'
 
 interface ViewData extends AppointmentUpdatePageViewData {
   projectItems: Array<GovUkSummaryListItem>
-  showContinueButton: boolean
   showMissingOutcomeMessage: boolean
   appointmentItems: Array<GovUkSummaryListItem>
   complianceItems: Array<GovUkSummaryListItem>
@@ -64,7 +63,6 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
       }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
-      showContinueButton: !appointment.contactOutcomeCode,
       complianceItems: this.buildComplianceDetails(appointment),
       timeItems: this.buildTimeDetails(appointment),
       sharedItems: this.buildSharedDetails(appointment),

--- a/server/views/appointments/update/appointmentDetails.njk
+++ b/server/views/appointments/update/appointmentDetails.njk
@@ -8,15 +8,11 @@
 
 {% set pageTitle = 'Appointment details' %}
 
-{% set showContinue = showContinueButton %}
-
 {% block headerCallToAction %}
-  {% if showContinueButton %}
-    {{ govukButton({
-      text: "Update appointment",
-      href: nextPath
-    }) }}
-  {% endif %}
+  {{ govukButton({
+    text: "Update appointment",
+    href: nextPath
+  }) }}
 {% endblock %}
 
 {% block beforeForm %}


### PR DESCRIPTION
Depends on https://dsdmoj.atlassian.net/browse/PI-4341 and https://dsdmoj.atlassian.net/browse/CPB-1139

[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1097?atlOrigin=eyJpIjoiNGU2NjBiN2I1ZTgxNDMwNjkzOWM5ZjRiOTU3MzU4NTkiLCJwIjoiaiJ9)

## Context
We want to allow case admins to update appointments which already have an outcome set. This change removes the condition for hiding the "Update appointment" link.

We also remove setting the "showContinue" variable as this had no effect given that the form block where this is used is being overwritten in the template.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

### Screenshots of UI changes
#### Before
<img width="1261" height="637" alt="Screenshot 2026-07-14 at 14 37 11" src="https://github.com/user-attachments/assets/09045fa8-228f-4447-bef6-b4afc0d7d7e1" />

#### After
<img width="1232" height="637" alt="image" src="https://github.com/user-attachments/assets/f28cd842-4e1b-412b-90ed-1495eb25d915" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
