### PR TITLE
Refactor: Extend appointment pages from `PageWithValidation`

### DIFF
--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -65,14 +65,17 @@ describe('attendanceOutcomeController', () => {
     describe('when a validation error occurs', () => {
       it('should render the attendance outcome page with errors', async () => {
         const errors = { someKey: { text: 'some error' } }
-        attendanceOutcomePageMock.mockImplementationOnce(() => ({
-          viewData: () => pageViewData,
-          validationErrors: () => errors,
-        }))
-
         const errorSummary = [
           { attributes: { 'data-cy-error-someKey': 'some error' }, href: '#someKey', text: 'some error' },
         ]
+        attendanceOutcomePageMock.mockImplementationOnce(() => ({
+          viewData: () => pageViewData,
+          validationErrors: () => ({
+            hasErrors: true,
+            errors,
+            errorSummary,
+          }),
+        }))
 
         appointmentService.getAppointment.mockResolvedValue(appointment)
         referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
@@ -106,7 +109,10 @@ describe('attendanceOutcomeController', () => {
 
         attendanceOutcomePageMock.mockImplementationOnce(() => ({
           viewData: () => pageViewData,
-          validationErrors: () => ({}),
+          validationErrors: () => ({
+            hasErrors: false,
+            errors: {},
+          }),
           next: () => nextPath,
           updateForm: () => formToSave,
         }))

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -33,7 +33,7 @@ export default class AttendanceOutcomeController implements IFormPageController 
 
       res.render(
         'appointments/update/attendanceOutcome',
-        page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, false, formId, _req.query),
+        page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, formId, _req.query),
       )
     }
   }
@@ -64,7 +64,6 @@ export default class AttendanceOutcomeController implements IFormPageController 
             appointmentOrSession,
             form,
             outcomes.contactOutcomes,
-            true,
             formId,
             _req.body as AttendanceOutcomeBody,
           ),

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -1,8 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import ReferenceDataService from '../../services/referenceDataService'
-import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
-import { generateErrorSummary } from '../../utils/errorUtils'
+import AttendanceOutcomePage, { AttendanceOutcomeBody } from '../../pages/appointments/attendanceOutcomePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
@@ -54,13 +53,23 @@ export default class AttendanceOutcomeController implements IFormPageController 
       const formId = _req.body.form?.toString()
       const page = new AttendanceOutcomePage()
       const form = await this.formService.getForm(formId, res.locals.user.username)
-      const validationErrors = page.validationErrors(_req.body, appointmentOrSession, outcomes.contactOutcomes)
+      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body, {
+        appointmentOrSession,
+        contactOutcomes: outcomes.contactOutcomes,
+      })
 
-      if (Object.keys(validationErrors).length) {
+      if (hasErrors) {
         return res.render('appointments/update/attendanceOutcome', {
-          ...page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, true, formId, _req.body),
-          errorSummary: generateErrorSummary(validationErrors),
-          errors: validationErrors,
+          ...page.viewData(
+            appointmentOrSession,
+            form,
+            outcomes.contactOutcomes,
+            true,
+            formId,
+            _req.body as AttendanceOutcomeBody,
+          ),
+          errorSummary,
+          errors,
         })
       }
 

--- a/server/controllers/appointments/chooseProjectController.test.ts
+++ b/server/controllers/appointments/chooseProjectController.test.ts
@@ -132,7 +132,7 @@ describe('ChooseProjectController', () => {
       chooseProjectPageMock.mockImplementationOnce(() => {
         return {
           commonViewData: () => ({ common: 'value' }),
-          getValidationErrors: () => validationErrors,
+          validationErrors: () => validationErrors,
         }
       })
 
@@ -169,7 +169,7 @@ describe('ChooseProjectController', () => {
 
       chooseProjectPageMock.mockImplementationOnce(() => {
         return {
-          getValidationErrors: () => ({ hasErrors: false, errors: {}, errorSummary: [] as Array<ErrorSummaryItem> }),
+          validationErrors: () => ({ hasErrors: false, errors: {}, errorSummary: [] as Array<ErrorSummaryItem> }),
           updateForm: () => updatedForm,
           next: () => '/next',
         }

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -94,7 +94,7 @@ export default class ChooseProjectController implements IFormPageController {
         response: res,
       })
 
-      const { hasErrors, errorSummary, errors } = page.getValidationErrors(req.body)
+      const { hasErrors, errorSummary, errors } = page.validationErrors(req.body)
 
       if (hasErrors) {
         return res.render('appointments/update/chooseProject', {

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -4,7 +4,6 @@ import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
-import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -29,7 +28,6 @@ describe('ChooseSupervisorController', () => {
   })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const chooseSupervisorPageMock: jest.Mock = ChooseSupervisorPage as unknown as jest.Mock<ChooseSupervisorPage>
-  const generateErrorSummaryMock: jest.Mock = generateErrorSummary as jest.Mock
   const pageViewData = {
     someKey: 'some value',
   }
@@ -111,19 +109,16 @@ describe('ChooseSupervisorController', () => {
     })
     it('should return view if errors', async () => {
       const errors = { someKey: { text: 'some error' } }
+      const errorSummary = [{ text: 'some error', href: '#someKey' }]
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
         viewData: () => pageViewData,
-        validate: () => {},
-        hasErrors: true,
-        validationErrors: errors,
+        validationErrors: () => ({
+          hasErrors: true,
+          errors,
+          errorSummary,
+        }),
         updatePath: () => '/path',
       }))
-
-      const errorSummary = {
-        text: 'errors',
-        href: '#link',
-      }
-      generateErrorSummaryMock.mockImplementation(() => errorSummary)
 
       const appointment = appointmentFactory.build()
       const supervisors = supervisorSummaryFactory.buildList(2)
@@ -150,9 +145,10 @@ describe('ChooseSupervisorController', () => {
     it('should redirect if no errors', async () => {
       const nextPath = '/nextPath'
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        validate: () => {},
-        hasErrors: false,
-        validationErrors: {},
+        validationErrors: () => ({
+          hasErrors: false,
+          errors: {},
+        }),
         next: () => nextPath,
         updateForm: (args: AppointmentOutcomeForm) => args,
       }))
@@ -176,9 +172,10 @@ describe('ChooseSupervisorController', () => {
       const existingForm = appointmentOutcomeFormFactory.build()
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
       chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        validate: () => {},
-        hasErrors: false,
-        validationErrors: {},
+        validationErrors: () => ({
+          hasErrors: false,
+          errors: {},
+        }),
         next: () => '/nextPath',
         updateForm: () => formToSave,
       }))

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -1,8 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
-import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
+import ChooseSupervisorPage, { SupervisorPageBody } from '../../pages/appointments/chooseSupervisorPage'
 import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
-import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
@@ -91,13 +90,14 @@ export default class ChooseSupervisorController implements IFormPageController {
       const formId = _req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
-      page.validate(_req.body)
+      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
 
-      if (page.hasErrors) {
+      if (hasErrors) {
         return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.body),
-          errors: page.validationErrors,
-          errorSummary: generateErrorSummary(page.validationErrors),
+          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.body as SupervisorPageBody),
+          errors,
+          errorSummary,
+          chooseSupervisorPath: page.updatePath(appointmentOrSession, formId),
           form: formId,
         })
       }

--- a/server/controllers/appointments/logComplianceController.test.ts
+++ b/server/controllers/appointments/logComplianceController.test.ts
@@ -65,9 +65,17 @@ describe('logComplianceController', () => {
         logCompliancePageMock.mockImplementationOnce(() => {
           return {
             viewData: () => pageViewData,
-            validate: () => {},
-            hasError: true,
-            validationErrors: { field: { text: 'Enter a value for field' } },
+            validationErrors: () => ({
+              hasErrors: true,
+              errors: { field: { text: 'Enter a value for field' } },
+              errorSummary: [
+                {
+                  text: 'Enter a value for field',
+                  href: '#field',
+                  attributes: { 'data-cy-error-field': 'Enter a value for field' },
+                },
+              ],
+            }),
           }
         })
 
@@ -103,8 +111,10 @@ describe('logComplianceController', () => {
 
         logCompliancePageMock.mockImplementationOnce(() => {
           return {
-            validate: () => {},
-            hasError: false,
+            validationErrors: () => ({
+              hasErrors: false,
+              errors: {},
+            }),
             next: () => nextPath,
             updateForm: () => formToSave,
           }

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -1,7 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
-import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
@@ -40,9 +39,9 @@ export default class LogComplianceController implements IFormPageController {
       const page = new LogCompliancePage()
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
-      page.validate(_req.body)
+      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
 
-      if (page.hasError) {
+      if (hasErrors) {
         const appointmentOrSession = await getAppointmentOrSession({
           appointmentOrSessionParams,
           res,
@@ -52,8 +51,8 @@ export default class LogComplianceController implements IFormPageController {
 
         return res.render('appointments/update/logCompliance', {
           ...page.viewData(appointmentOrSession, form, formId, _req.body),
-          errors: page.validationErrors,
-          errorSummary: generateErrorSummary(page.validationErrors),
+          errors,
+          errorSummary,
         })
       }
 

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -5,7 +5,6 @@ import LogHoursController from './logHoursController'
 import AppointmentService from '../../services/appointmentService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
-import { generateErrorSummary } from '../../utils/errorUtils'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -22,7 +21,6 @@ describe('logHoursController', () => {
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const logHoursPage: jest.Mock = LogHoursPage as unknown as jest.Mock<LogHoursPage>
-  const generateErrorSummaryMock: jest.Mock = generateErrorSummary as jest.Mock
   const pageViewData = {
     someKey: 'some value',
   }
@@ -57,18 +55,15 @@ describe('logHoursController', () => {
     describe('when a validation error occurs', () => {
       it('should render the log hours page with errors', async () => {
         const errors = { someKey: { text: 'some error' } }
+        const errorSummary = [{ text: 'errors', href: '#link' }]
         logHoursPage.mockImplementationOnce(() => ({
           viewData: () => pageViewData,
-          validate: () => {},
-          hasErrors: true,
-          validationErrors: errors,
+          validationErrors: () => ({
+            hasErrors: true,
+            errors,
+            errorSummary,
+          }),
         }))
-
-        const errorSummary = {
-          text: 'errors',
-          href: '#link',
-        }
-        generateErrorSummaryMock.mockImplementation(() => errorSummary)
 
         appointmentService.getAppointment.mockResolvedValue(appointment)
 
@@ -94,9 +89,10 @@ describe('logHoursController', () => {
 
       beforeEach(() => {
         logHoursPage.mockImplementationOnce(() => ({
-          validate: () => {},
-          hasErrors: false,
-          validationErrors: {},
+          validationErrors: () => ({
+            hasErrors: false,
+            errors: {},
+          }),
           next: () => nextPath,
           updateForm: () => formToSave,
         }))

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -1,7 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
-import { generateErrorSummary } from '../../utils/errorUtils'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
@@ -41,7 +40,7 @@ export default class LogHoursController implements IFormPageController {
 
       const formId = _req.body.form?.toString()
       const page = new LogHoursPage()
-      page.validate(_req.body)
+      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
 
       const form = await this.formService.getForm(formId, res.locals.user.username)
 
@@ -52,11 +51,11 @@ export default class LogHoursController implements IFormPageController {
         sessionService: this.sessionService,
       })
 
-      if (page.hasErrors) {
+      if (hasErrors) {
         return res.render('appointments/update/logHours', {
           ...page.viewData(appointmentOrSession, form, formId, _req.body),
-          errors: page.validationErrors,
-          errorSummary: generateErrorSummary(page.validationErrors),
+          errors,
+          errorSummary,
         })
       }
 

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -27,7 +27,14 @@ describe('AttendanceOutcomePage', () => {
     it('returns error when attendance outcome is empty', () => {
       const page = new AttendanceOutcomePage()
 
-      expect(page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes)).toEqual({
+      const { errors } = page.validationErrors(
+        { attendanceOutcome: '', notes: 'some note' },
+        {
+          appointmentOrSession: appointment,
+          contactOutcomes,
+        },
+      )
+      expect(errors).toEqual({
         attendanceOutcome: { text: 'Select an attendance outcome' },
       })
     })
@@ -41,13 +48,14 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInTheFuture,
-            [...contactOutcomes, attendedContactOutcome],
-          ),
-        ).toEqual({
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: attendedContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentInTheFuture,
+            contactOutcomes: [...contactOutcomes, attendedContactOutcome],
+          },
+        )
+        expect(errors).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -58,13 +66,14 @@ describe('AttendanceOutcomePage', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInTheFuture,
-            [...contactOutcomes, enforceableContactOutcome],
-          ),
-        ).toEqual({
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: enforceableContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentInTheFuture,
+            contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
+          },
+        )
+        expect(errors).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -75,13 +84,14 @@ describe('AttendanceOutcomePage', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInTheFuture,
-            [...contactOutcomes, acceptableAbsenceContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentInTheFuture,
+            contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
+          },
+        )
+        expect(errors).toEqual({})
       })
 
       it('returns error if appointmentOrSession is a session and contact outcome is attended', () => {
@@ -91,13 +101,11 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-            sessionInTheFuture,
-            [...contactOutcomes, attendedContactOutcome],
-          ),
-        ).toEqual({
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: attendedContactOutcome.code, notes: '' },
+          { appointmentOrSession: sessionInTheFuture, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+        )
+        expect(errors).toEqual({
           attendanceOutcome: {
             text: 'The outcome entered must be: acceptable absence',
           },
@@ -114,39 +122,36 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentToday,
-            [...contactOutcomes, attendedContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: attendedContactOutcome.code, notes: '' },
+          { appointmentOrSession: appointmentToday, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+        )
+        expect(errors).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentToday,
-            [...contactOutcomes, enforceableContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: enforceableContactOutcome.code, notes: 'note' },
+          { appointmentOrSession: appointmentToday, contactOutcomes: [...contactOutcomes, enforceableContactOutcome] },
+        )
+        expect(errors).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentToday,
-            [...contactOutcomes, acceptableAbsenceContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentToday,
+            contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
+          },
+        )
+        expect(errors).toEqual({})
       })
     })
 
@@ -157,66 +162,91 @@ describe('AttendanceOutcomePage', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: attendedContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInThePast,
-            [...contactOutcomes, attendedContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: attendedContactOutcome.code, notes: '' },
+          { appointmentOrSession: appointmentInThePast, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+        )
+        expect(errors).toEqual({})
       })
 
       it('does not return error if contact outcome is an enforceable outcome', () => {
         const enforceableContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: true })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: enforceableContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInThePast,
-            [...contactOutcomes, enforceableContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: enforceableContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentInThePast,
+            contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
+          },
+        )
+        expect(errors).toEqual({})
       })
 
       it('does not return an error if contact outcome is not enforceable or attended', () => {
         const acceptableAbsenceContactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const page = new AttendanceOutcomePage()
 
-        expect(
-          page.validationErrors(
-            { attendanceOutcome: acceptableAbsenceContactOutcome.code } as AttendanceOutcomeBody,
-            appointmentInThePast,
-            [...contactOutcomes, acceptableAbsenceContactOutcome],
-          ),
-        ).toEqual({})
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
+          {
+            appointmentOrSession: appointmentInThePast,
+            contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
+          },
+        )
+        expect(errors).toEqual({})
       })
     })
 
     describe('notes', () => {
       it('should not have any errors if no notes value', () => {
         const page = new AttendanceOutcomePage()
-        page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes)
+        page.validationErrors({} as AttendanceOutcomeBody, { appointmentOrSession: appointment, contactOutcomes })
 
-        expect(page.validationErrors({} as AttendanceOutcomeBody, appointment, contactOutcomes).notes).toBeFalsy()
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: contactOutcomes[0].code, notes: '' },
+          {
+            appointmentOrSession: appointment,
+            contactOutcomes,
+          },
+        )
+        expect(errors.notes).toBeFalsy()
       })
 
       it.each([4000, 3999, 0])('should not have any errors if notes count is less than 4000', (count: number) => {
         const notes = faker.string.alpha(count)
         const page = new AttendanceOutcomePage()
-        page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes)
+        page.validationErrors({ notes } as AttendanceOutcomeBody, {
+          appointmentOrSession: appointment,
+          contactOutcomes,
+        })
 
-        expect(
-          page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes).notes,
-        ).toBeFalsy()
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: contactOutcomes[0].code, notes },
+          {
+            appointmentOrSession: appointment,
+            contactOutcomes,
+          },
+        )
+        expect(errors.notes).toBeFalsy()
       })
 
       it('should have errors if the notes count is greater than 4000', () => {
         const notes = faker.string.alpha(4001)
         const page = new AttendanceOutcomePage()
-        page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes)
+        page.validationErrors({ notes } as AttendanceOutcomeBody, {
+          appointmentOrSession: appointment,
+          contactOutcomes,
+        })
 
-        expect(page.validationErrors({ notes } as AttendanceOutcomeBody, appointment, contactOutcomes).notes).toEqual({
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: contactOutcomes[0].code, notes },
+          {
+            appointmentOrSession: appointment,
+            contactOutcomes,
+          },
+        )
+        expect(errors.notes).toEqual({
           text: 'Notes must be 4000 characters or less',
         })
       })
@@ -463,7 +493,7 @@ describe('AttendanceOutcomePage', () => {
 
       it('should return items if page has Errors and contact outcome is undefined', () => {
         const page = new AttendanceOutcomePage()
-        page.validationErrors({}, appointment, contactOutcomes)
+        page.validationErrors({} as AttendanceOutcomeBody, { appointmentOrSession: appointment, contactOutcomes })
 
         const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), contactOutcomes)
 

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -302,7 +302,7 @@ describe('AttendanceOutcomePage', () => {
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, false, undefined, {})
+      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, undefined, {})
 
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
@@ -466,7 +466,7 @@ describe('AttendanceOutcomePage', () => {
         const page = new AttendanceOutcomePage()
 
         const form = appointmentOutcomeFormFactory.build()
-        const result = page.viewData(appointment, form, contactOutcomes, true, undefined, query)
+        const result = page.viewData(appointment, form, contactOutcomes, undefined, query)
 
         const expectedItems = [
           {

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -29,7 +29,15 @@ type ViewData = {
 } & ViewDataWithNotes &
   AppointmentUpdatePageViewData
 
-export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
+type AttendanceOutcomeContext = {
+  appointmentOrSession: AppointmentOrSession
+  contactOutcomes: ContactOutcomeDto[]
+}
+
+export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
+  AttendanceOutcomeBody,
+  AttendanceOutcomeContext
+> {
   protected page: AppointmentFormPage = 'attendance-outcome'
 
   protected getForm(
@@ -46,27 +54,29 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validationErrors(
-    query: AttendanceOutcomeQuery,
-    appointmentOrSession: AppointmentOrSession,
-    contactOutcomes: ContactOutcomeDto[],
-  ) {
+  protected getValidationErrors(
+    body: AttendanceOutcomeBody,
+    additionalParams?: AttendanceOutcomeContext,
+  ): ValidationErrors<AttendanceOutcomeBody> {
     const validationErrors: ValidationErrors<AttendanceOutcomeBody> = {}
 
-    if (!query.attendanceOutcome) {
+    if (!body.attendanceOutcome) {
       validationErrors.attendanceOutcome = { text: 'Select an attendance outcome' }
     }
 
-    if (
-      this.outcomeIsAttendedOrEnforceable(query.attendanceOutcome, contactOutcomes) &&
-      DateTimeFormats.dateIsInFuture(appointmentOrSession.date)
-    ) {
-      validationErrors.attendanceOutcome = {
-        text: 'The outcome entered must be: acceptable absence',
+    if (additionalParams) {
+      const { appointmentOrSession, contactOutcomes } = additionalParams
+      if (
+        this.outcomeIsAttendedOrEnforceable(body.attendanceOutcome, contactOutcomes) &&
+        DateTimeFormats.dateIsInFuture(appointmentOrSession.date)
+      ) {
+        validationErrors.attendanceOutcome = {
+          text: 'The outcome entered must be: acceptable absence',
+        }
       }
     }
 
-    if (query.notes && query.notes.length > 4000) {
+    if (body.notes && body.notes.length > 4000) {
       validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
     }
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -87,7 +87,6 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     appointmentOrSession: AppointmentOrSession,
     form: AppointmentOutcomeForm,
     contactOutcomes: ContactOutcomeDto[],
-    hasErrors: boolean = false,
     formId?: string,
     query?: AttendanceOutcomeQuery,
   ): ViewData {
@@ -96,7 +95,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     return {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
       ...NotesUtils.questionItems(query ?? {}, form, appointment, isSingleAppointment),
-      items: this.items(form, contactOutcomes, hasErrors, query),
+      items: this.items(form, contactOutcomes, query),
     }
   }
 
@@ -115,10 +114,9 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
   private items(
     form: AppointmentOutcomeForm,
     contactOutcomes: ContactOutcomeDto[],
-    hasErrors: boolean,
     query?: AttendanceOutcomeQuery,
   ): { text: string; value: string }[] {
-    const code = hasErrors ? query?.attendanceOutcome : form.contactOutcome?.code
+    const code = query?.attendanceOutcome ?? form.contactOutcome?.code
     return contactOutcomes.map(outcome => ({
       text: outcome.name,
       value: outcome.code,

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -115,7 +115,14 @@ describe('BaseAppointmentUpdatePage', () => {
   })
 })
 
-class PageWithNextPage extends BaseAppointmentUpdatePage {
+class PageWithNextPage extends BaseAppointmentUpdatePage<unknown> {
+  protected getValidationErrors(
+    _query: unknown,
+    _additionalParams?: unknown,
+  ): Partial<Record<never, Record<'text', string>>> {
+    throw new Error('Method not implemented.')
+  }
+
   protected page: AppointmentFormPage = 'attendance-outcome'
 
   public getCommonViewDataForTest(args: {
@@ -141,7 +148,14 @@ class PageWithNextPage extends BaseAppointmentUpdatePage {
   }
 }
 
-class PageWithoutNextPage extends BaseAppointmentUpdatePage {
+class PageWithoutNextPage extends BaseAppointmentUpdatePage<unknown> {
+  protected getValidationErrors(
+    _query: unknown,
+    _additionalParams?: unknown,
+  ): Partial<Record<never, Record<'text', string>>> {
+    throw new Error('Method not implemented.')
+  }
+
   protected page: AppointmentFormPage = 'attendance-outcome'
 
   protected nextPage(): undefined {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -2,12 +2,16 @@ import { ProjectDto } from '../../@types/shared'
 import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
 import Offender from '../../models/offender'
 import paths from '../../paths'
-import DateTimeFormats from '../../utils/dateTimeUtils'
 import SessionUtils from '../../utils/sessionUtils'
 import { pathWithQuery } from '../../utils/utils'
 import { AppointmentFormPage } from './pathMap'
+import PageWithValidation from '../pageWithValidation'
+import DateTimeFormats from '../../utils/dateTimeUtils'
 
-export default abstract class BaseAppointmentUpdatePage {
+export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContext = unknown> extends PageWithValidation<
+  TBody,
+  TContext
+> {
   protected abstract page: AppointmentFormPage
 
   protected abstract nextPage(form?: AppointmentOutcomeForm): AppointmentFormPage | undefined

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -30,17 +30,15 @@ interface ViewData extends AppointmentUpdatePageViewData {
   nextPath: string
 }
 
-interface Body {
-  supervisor: string
-}
-
 export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePage {
   protected page: AppointmentFormPage = 'appointment-details'
 
-  validationErrors: ValidationErrors<Body> = {}
+  protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
+    return form
+  }
 
-  protected getForm(data: AppointmentOutcomeForm): AppointmentOutcomeForm {
-    return data
+  protected getValidationErrors(_query: unknown, _additionalParams?: unknown): ValidationErrors<unknown> {
+    return {}
   }
 
   viewData({

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -74,7 +74,7 @@ describe('ChooseProjectPage', () => {
       jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
 
       const page = new ChooseProjectPage()
-      const result = page.getValidationErrors({ form: 'F1' })
+      const result = page.validationErrors({})
 
       expect(result).toEqual({
         errors,
@@ -92,7 +92,7 @@ describe('ChooseProjectPage', () => {
       jest.spyOn(ErrorUtils, 'generateErrorSummary').mockReturnValue(errorSummary)
 
       const page = new ChooseProjectPage()
-      const result = page.getValidationErrors({ form: 'F1' })
+      const result = page.validationErrors({})
 
       expect(result).toEqual({
         errors,

--- a/server/pages/appointments/chooseProjectPage.ts
+++ b/server/pages/appointments/chooseProjectPage.ts
@@ -3,15 +3,15 @@ import {
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   GovUkSelectOption,
+  ValidationErrors,
 } from '../../@types/user-defined'
 import SelectProjectComponent, { ProjectQuestionsBody } from '../../utils/components/projectQuestions'
-import { ErrorViewData, generateErrorSummary } from '../../utils/errorUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
 type Query = AppointmentUpdateQuery & ProjectQuestionsBody
 
-export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
+export default class ChooseProjectPage extends BaseAppointmentUpdatePage<Query> {
   protected page: AppointmentFormPage = 'choose-project'
 
   protected nextPage(): AppointmentFormPage | undefined {
@@ -20,13 +20,6 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
 
   protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined {
     return 'choose-supervisor'
-  }
-
-  getValidationErrors(query: Query): ErrorViewData<ProjectQuestionsBody> {
-    const errors = SelectProjectComponent.getValidationErrors(query)
-    const errorSummary = generateErrorSummary(errors)
-
-    return { errors, hasErrors: Object.keys(errors).length > 0, errorSummary }
   }
 
   getForm(
@@ -51,5 +44,9 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage {
       projectTeam: { code: selectedTeam.value, name: selectedTeam.text },
       project: { code: selectedProject.value, name: selectedProject.text },
     }
+  }
+
+  protected getValidationErrors(query: Query, _additionalParams?: unknown): ValidationErrors<Query> {
+    return SelectProjectComponent.getValidationErrors(query)
   }
 }

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -103,11 +103,9 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
       page = new ChooseSupervisorPage()
-      page.validate({ team: '1234', supervisor })
-
-      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build(), undefined, {
-        team: '1234',
+      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build(), '1', {
         supervisor,
+        team: teams.providers[0].code,
       })
 
       expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
@@ -175,28 +173,28 @@ describe('ChooseSupervisorPage', () => {
     it('has no errors if team has value and supervisor has value', () => {
       const query = { team: 'X123', supervisor: 'Jane' }
       const page = new ChooseSupervisorPage()
-      page.validate(query)
+      const { hasErrors, errors } = page.validationErrors(query)
 
-      expect(page.hasErrors).toBe(false)
-      expect(page.validationErrors).toStrictEqual({})
+      expect(hasErrors).toBe(false)
+      expect(errors).toStrictEqual({})
     })
 
     it.each(['', undefined])('has errors if team is empty', (team: string | undefined) => {
       const query = { team, supervisor: 'Jane' }
       const page = new ChooseSupervisorPage()
-      page.validate(query)
+      const { hasErrors, errors } = page.validationErrors(query)
 
-      expect(page.hasErrors).toBe(true)
-      expect(page.validationErrors).toStrictEqual({ team: { text: 'Select a supervising team' } })
+      expect(hasErrors).toBe(true)
+      expect(errors).toStrictEqual({ team: { text: 'Select a supervising team' } })
     })
 
     it.each(['', undefined])('has errors if supervisor is empty', (supervisor: string | undefined) => {
       const query = { team: 'X123', supervisor }
       const page = new ChooseSupervisorPage()
-      page.validate(query)
+      const { hasErrors, errors } = page.validationErrors(query)
 
-      expect(page.hasErrors).toBe(true)
-      expect(page.validationErrors).toStrictEqual({ supervisor: { text: 'Select a supervisor' } })
+      expect(hasErrors).toBe(true)
+      expect(errors).toStrictEqual({ supervisor: { text: 'Select a supervisor' } })
     })
   })
 

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -16,7 +16,7 @@ interface ViewData extends AppointmentUpdatePageViewData {
   supervisorItems: GovUkSelectOption[]
 }
 
-interface Body {
+export interface SupervisorPageBody {
   supervisor: string
   team: string
 }
@@ -26,14 +26,8 @@ interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
   team?: string
 }
 
-export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
+export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<SupervisorPageBody> {
   protected page: AppointmentFormPage = 'choose-supervisor'
-
-  validationErrors: ValidationErrors<Body> = {}
-
-  get hasErrors() {
-    return Object.keys(this.validationErrors).length > 0
-  }
 
   protected getForm(
     data: AppointmentOutcomeForm,
@@ -59,26 +53,30 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage {
     query?: AppointmentDetailsQuery,
   ): ViewData {
     const teamCode = query?.team || form.supervisingTeam?.code
-    const code = this.hasErrors ? query?.supervisor : form.supervisor?.code
+    const supervisorCode = query?.supervisor ?? form.supervisor?.code
 
     return {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
-        ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', code)
+        ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', supervisorCode)
         : [],
     }
   }
 
-  validate(query: AppointmentDetailsQuery) {
-    if (!query.team) {
-      this.validationErrors.team = { text: 'Select a supervising team' }
-      return
+  protected getValidationErrors(body: SupervisorPageBody): ValidationErrors<SupervisorPageBody> {
+    const errors: ValidationErrors<SupervisorPageBody> = {}
+
+    if (!body.team) {
+      errors.team = { text: 'Select a supervising team' }
+      return errors
     }
 
-    if (!query.supervisor) {
-      this.validationErrors.supervisor = { text: 'Select a supervisor' }
+    if (!body.supervisor) {
+      errors.supervisor = { text: 'Select a supervisor' }
     }
+
+    return errors
   }
 
   protected backPage(appointmentOrSession: AppointmentOrSession): AppointmentFormPage {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -3,9 +3,9 @@ import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdatePageViewData,
-  AppointmentUpdateQuery,
   GovUkRadioOrCheckboxOption,
   GovUkSummaryListItem,
+  ValidationErrors,
   YesOrNo,
 } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
@@ -25,15 +25,19 @@ interface ViewData extends AppointmentUpdatePageViewData {
   submittedItems: GovUkSummaryListItem[]
 }
 
-interface Query extends AppointmentUpdateQuery {
+interface Query {
   alertPractitioner?: YesOrNo
 }
 
-export default class ConfirmPage extends BaseAppointmentUpdatePage {
+export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
   protected page: AppointmentFormPage = 'confirm-details'
 
   protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return form
+  }
+
+  protected getValidationErrors(_query: Query, _additionalParams?: unknown): ValidationErrors<Query> {
+    return {}
   }
 
   viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -97,7 +97,9 @@ describe('LogCompliancePage', () => {
         })
 
         it('should return items for workQuality with checked answer from form', async () => {
-          form = appointmentOutcomeFormFactory.build({ attendanceData: { workQuality: 'GOOD' } })
+          form = appointmentOutcomeFormFactory.build({
+            attendanceData: attendanceDataFactory.build({ workQuality: 'GOOD' }),
+          })
 
           const result = page.viewData(appointment, form)
           expect(result.workQualityItems).toEqual([
@@ -127,7 +129,9 @@ describe('LogCompliancePage', () => {
         })
 
         it('should return items for behaviour with checked answer from form', async () => {
-          form = appointmentOutcomeFormFactory.build({ attendanceData: { behaviour: 'UNSATISFACTORY' } })
+          form = appointmentOutcomeFormFactory.build({
+            attendanceData: attendanceDataFactory.build({ behaviour: 'UNSATISFACTORY' }),
+          })
 
           const result = page.viewData(appointment, form)
           expect(result.behaviourItems).toEqual([
@@ -149,7 +153,7 @@ describe('LogCompliancePage', () => {
           },
         })
         page = new LogCompliancePage()
-        page.validate({
+        page.validationErrors({
           behaviour: null,
           workQuality: 'EXCELLENT',
         })
@@ -179,24 +183,24 @@ describe('LogCompliancePage', () => {
     describe('when workQuality is not present', () => {
       it('should return the correct error', () => {
         page = new LogCompliancePage()
-        page.validate({ workQuality: null })
+        const { errors, hasErrors } = page.validationErrors({ workQuality: null, behaviour: 'GOOD' })
 
-        expect(page.validationErrors.workQuality).toEqual({
+        expect(errors.workQuality).toEqual({
           text: 'Select their work quality',
         })
-        expect(page.hasError).toBe(true)
+        expect(hasErrors).toBe(true)
       })
     })
 
     describe('when behaviour is not present', () => {
       it('should return the correct error', () => {
         page = new LogCompliancePage()
-        page.validate({ behaviour: null })
+        const { errors, hasErrors } = page.validationErrors({ behaviour: null, workQuality: 'EXCELLENT' })
 
-        expect(page.validationErrors.behaviour).toEqual({
+        expect(errors.behaviour).toEqual({
           text: 'Select their behaviour',
         })
-        expect(page.hasError).toBe(true)
+        expect(hasErrors).toBe(true)
       })
     })
   })

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -25,14 +25,14 @@ export interface LogComplianceQuery extends AppointmentUpdateQuery {
   behaviour?: AttendanceDataDto['behaviour']
 }
 
-export default class LogCompliancePage extends BaseAppointmentUpdatePage {
+export default class LogCompliancePage extends BaseAppointmentUpdatePage<Body> {
   protected page: AppointmentFormPage = 'log-compliance'
 
-  hasError: boolean
+  constructor() {
+    super()
+  }
 
-  validationErrors: ValidationErrors<Body> = {}
-
-  getForm(data: AppointmentOutcomeForm, query: LogComplianceQuery): AppointmentOutcomeForm {
+  getForm(data: AppointmentOutcomeForm, query: LogComplianceQuery = {}): AppointmentOutcomeForm {
     return {
       ...data,
 
@@ -58,16 +58,18 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validate(query: LogComplianceQuery) {
-    if (!query.workQuality) {
-      this.validationErrors.workQuality = { text: 'Select their work quality' }
+  protected getValidationErrors(body: Body): ValidationErrors<Body> {
+    const errors: ValidationErrors<Body> = {}
+
+    if (!body.workQuality) {
+      errors.workQuality = { text: 'Select their work quality' }
     }
 
-    if (!query.behaviour) {
-      this.validationErrors.behaviour = { text: 'Select their behaviour' }
+    if (!body.behaviour) {
+      errors.behaviour = { text: 'Select their behaviour' }
     }
 
-    this.hasError = Object.keys(this.validationErrors).length > 0
+    return errors
   }
 
   protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
@@ -95,13 +97,9 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage {
   }
 
   private getFormDisplayValues(form: AppointmentOutcomeForm, query?: LogComplianceQuery): LogComplianceQuery {
-    if (this.hasError && query) {
-      return query
-    }
-
     return {
-      workQuality: form.attendanceData?.workQuality,
-      behaviour: form.attendanceData?.behaviour,
+      workQuality: query?.workQuality ?? form.attendanceData?.workQuality,
+      behaviour: query?.behaviour ?? form.attendanceData?.behaviour,
     }
   }
 }

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -28,10 +28,6 @@ export interface LogComplianceQuery extends AppointmentUpdateQuery {
 export default class LogCompliancePage extends BaseAppointmentUpdatePage<Body> {
   protected page: AppointmentFormPage = 'log-compliance'
 
-  constructor() {
-    super()
-  }
-
   getForm(data: AppointmentOutcomeForm, query: LogComplianceQuery = {}): AppointmentOutcomeForm {
     return {
       ...data,

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -2,7 +2,7 @@ import { AppointmentDto } from '../../@types/shared'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
-import LogHoursPage, { LogHoursQuery } from './logHoursPage'
+import LogHoursPage from './logHoursPage'
 import * as Utils from '../../utils/utils'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -22,9 +22,9 @@ describe('LogHoursPage', () => {
       describe('when startTime is not present', () => {
         it('should return the correct error', () => {
           page = new LogHoursPage()
-          page.validate({ startTime: null })
+          const { errors } = page.validationErrors({ startTime: null })
 
-          expect(page.validationErrors.startTime).toEqual({
+          expect(errors.startTime).toEqual({
             text: 'Enter a start time',
           })
         })
@@ -33,9 +33,9 @@ describe('LogHoursPage', () => {
       describe('when startTime is not valid', () => {
         it('should return the correct error', () => {
           page = new LogHoursPage()
-          page.validate({ startTime: '8475438' })
+          const { errors } = page.validationErrors({ startTime: '8475438' })
 
-          expect(page.validationErrors.startTime).toEqual({
+          expect(errors.startTime).toEqual({
             text: 'Enter a valid start time, for example 09:00',
           })
         })
@@ -44,18 +44,18 @@ describe('LogHoursPage', () => {
       describe('when startTime is present', () => {
         it('should not return an error', () => {
           page = new LogHoursPage()
-          page.validate({ startTime: '09:00' })
+          const { errors } = page.validationErrors({ startTime: '09:00' })
 
-          expect(page.validationErrors.startTime).toBeUndefined()
+          expect(errors.startTime).toBeUndefined()
         })
       })
 
       describe('when startTime is after endTime', () => {
         it('should return an error', () => {
           page = new LogHoursPage()
-          page.validate({ startTime: '09:00', endTime: '08:00' })
+          const { errors } = page.validationErrors({ startTime: '09:00', endTime: '08:00' })
 
-          expect(page.validationErrors.startTime).toEqual({
+          expect(errors.startTime).toEqual({
             text: `Start time should be before 08:00`,
           })
         })
@@ -64,9 +64,9 @@ describe('LogHoursPage', () => {
       describe('when startTime is the same as endTime', () => {
         it('should return an error', () => {
           page = new LogHoursPage()
-          page.validate({ startTime: '09:00', endTime: '09:00' })
+          const { errors } = page.validationErrors({ startTime: '09:00', endTime: '09:00' })
 
-          expect(page.validationErrors.startTime).toEqual({
+          expect(errors.startTime).toEqual({
             text: 'Start time should be before 09:00',
           })
         })
@@ -77,9 +77,9 @@ describe('LogHoursPage', () => {
       describe('when endTime is not present', () => {
         it('should return the correct error', () => {
           page = new LogHoursPage()
-          page.validate({ endTime: null })
+          const { errors } = page.validationErrors({ endTime: null })
 
-          expect(page.validationErrors.endTime).toEqual({
+          expect(errors.endTime).toEqual({
             text: 'Enter an end time',
           })
         })
@@ -88,9 +88,9 @@ describe('LogHoursPage', () => {
       describe('when endTime is not valid', () => {
         it('should return the correct error', () => {
           page = new LogHoursPage()
-          page.validate({ endTime: '837:02' })
+          const { errors } = page.validationErrors({ endTime: '837:02' })
 
-          expect(page.validationErrors.endTime).toEqual({
+          expect(errors.endTime).toEqual({
             text: 'Enter a valid end time, for example 17:00',
           })
         })
@@ -99,9 +99,9 @@ describe('LogHoursPage', () => {
       describe('when endTime is present', () => {
         it('should not return an error', () => {
           page = new LogHoursPage()
-          page.validate({ endTime: '17:00' })
+          const { errors } = page.validationErrors({ endTime: '17:00' })
 
-          expect(page.validationErrors.endTime).toBeUndefined()
+          expect(errors.endTime).toBeUndefined()
         })
       })
     })
@@ -230,7 +230,7 @@ describe('LogHoursPage', () => {
   describe('form', () => {
     it('returns data from query given object with existing data', () => {
       const form = appointmentOutcomeFormFactory.build()
-      const query: LogHoursQuery = {
+      const query = {
         startTime: '09:00',
         endTime: '13:00',
       }

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -15,23 +15,23 @@ interface ViewData extends AppointmentUpdatePageViewData {
 }
 
 interface LogHoursBody {
-  startTime: string
-  endTime: string
-}
-
-export interface LogHoursQuery extends AppointmentUpdateQuery {
   startTime?: string
   endTime?: string
 }
 
-export default class LogHoursPage extends BaseAppointmentUpdatePage {
+interface LogHoursQuery extends AppointmentUpdateQuery {
+  startTime?: string
+  endTime?: string
+}
+
+export default class LogHoursPage extends BaseAppointmentUpdatePage<LogHoursBody> {
   protected page: AppointmentFormPage = 'log-hours'
 
-  hasErrors: boolean
+  constructor() {
+    super()
+  }
 
-  validationErrors: ValidationErrors<LogHoursBody> = {}
-
-  getForm(data: AppointmentOutcomeForm, query: LogHoursQuery): AppointmentOutcomeForm {
+  getForm(data: AppointmentOutcomeForm, query: LogHoursQuery = {}): AppointmentOutcomeForm {
     return {
       ...data,
       startTime: query.startTime,
@@ -39,26 +39,28 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     }
   }
 
-  validate(query: LogHoursQuery) {
-    if (!query.startTime) {
-      this.validationErrors.startTime = { text: 'Enter a start time' }
-    } else if (!DateTimeFormats.isValidTime(query.startTime as string)) {
-      this.validationErrors.startTime = { text: 'Enter a valid start time, for example 09:00' }
+  protected getValidationErrors(body: LogHoursBody = {}): ValidationErrors<LogHoursBody> {
+    const errors: ValidationErrors<LogHoursBody> = {}
+
+    if (!body.startTime) {
+      errors.startTime = { text: 'Enter a start time' }
+    } else if (!DateTimeFormats.isValidTime(body.startTime as string)) {
+      errors.startTime = { text: 'Enter a valid start time, for example 09:00' }
     }
 
-    if (!query.endTime) {
-      this.validationErrors.endTime = { text: 'Enter an end time' }
-    } else if (!DateTimeFormats.isValidTime(query.endTime as string)) {
-      this.validationErrors.endTime = { text: 'Enter a valid end time, for example 17:00' }
+    if (!body.endTime) {
+      errors.endTime = { text: 'Enter an end time' }
+    } else if (!DateTimeFormats.isValidTime(body.endTime)) {
+      errors.endTime = { text: 'Enter a valid end time, for example 17:00' }
     }
 
-    if (!this.validationErrors.startTime && !this.validationErrors.endTime) {
-      if (!DateTimeFormats.timesAreOrdered(query.startTime, query.endTime)) {
-        this.validationErrors.startTime = { text: `Start time should be before ${query.endTime}` }
+    if (!errors.startTime && !errors.endTime) {
+      if (!DateTimeFormats.timesAreOrdered(body.startTime, body.endTime)) {
+        errors.startTime = { text: `Start time should be before ${body.endTime}` }
       }
     }
 
-    this.hasErrors = Object.keys(this.validationErrors).length > 0
+    return errors
   }
 
   viewData(
@@ -67,13 +69,15 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage {
     formId?: string,
     query: LogHoursQuery = {},
   ): ViewData {
+    const { hasErrors } = this.validationErrors(query as LogHoursBody)
+
     const viewData = {
       ...this.commonViewData({ appointmentOrSession, form, formId }),
       startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
       endTime: form.endTime ? DateTimeFormats.stripTime(form.endTime) : '',
     }
 
-    if (this.hasErrors) {
+    if (hasErrors) {
       return {
         ...viewData,
         ...query,

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -69,23 +69,10 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage<LogHoursBody
     formId?: string,
     query: LogHoursQuery = {},
   ): ViewData {
-    const { hasErrors } = this.validationErrors(query as LogHoursBody)
-
-    const viewData = {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
-      startTime: form.startTime ? DateTimeFormats.stripTime(form.startTime) : '',
-      endTime: form.endTime ? DateTimeFormats.stripTime(form.endTime) : '',
-    }
-
-    if (hasErrors) {
-      return {
-        ...viewData,
-        ...query,
-      }
-    }
-
     return {
-      ...viewData,
+      ...this.commonViewData({ appointmentOrSession, form, formId }),
+      startTime: query.startTime ?? (form.startTime ? DateTimeFormats.stripTime(form.startTime) : ''),
+      endTime: query.endTime ?? (form.endTime ? DateTimeFormats.stripTime(form.endTime) : ''),
     }
   }
 

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -27,10 +27,6 @@ interface LogHoursQuery extends AppointmentUpdateQuery {
 export default class LogHoursPage extends BaseAppointmentUpdatePage<LogHoursBody> {
   protected page: AppointmentFormPage = 'log-hours'
 
-  constructor() {
-    super()
-  }
-
   getForm(data: AppointmentOutcomeForm, query: LogHoursQuery = {}): AppointmentOutcomeForm {
     return {
       ...data,


### PR DESCRIPTION
## Context

This makes handling of form validation consistent across this form journey - and brings it inline with other forms in the app, such as course completions and travel time.

This should also enable the addition of a shared controller class for these pages, to make future changes and pages easier to handle.

## Changes in this PR

- Extend `BaseAppointmentUpdatePage` from `PageWithValidation`
- Update all implementing classes to implement expected methods (using existing validation behaviour)

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
