### PR TITLE
Refactor: introduce base appointment class

### DIFF
--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -1,12 +1,10 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
-
 import AttendanceOutcomeController from './attendanceOutcomeController'
 import AppointmentService from '../../services/appointmentService'
 import ReferenceDataService from '../../services/referenceDataService'
 import { contactOutcomesFactory } from '../../testutils/factories/contactOutcomeFactory'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
-import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -14,50 +12,69 @@ import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/attendanceOutcomePage')
 
-describe('attendanceOutcomeController', () => {
+describe('AttendanceOutcomeController', () => {
   const userName = 'user'
-  const appointment = appointmentFactory.build({ offender: offenderFullFactory.build() })
-
+  const appointmentId = '1'
   const contactOutcomes = contactOutcomesFactory.build()
 
-  const request = createMock<Request>({ params: { appointmentId: appointment.id.toString() } })
+  const request = createMock<Request>({ params: { appointmentId }, query: { form: 'some-id' } })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
   const attendanceOutcomePageMock: jest.Mock = AttendanceOutcomePage as unknown as jest.Mock<AttendanceOutcomePage>
   const pageViewData = {
     someKey: 'some value',
   }
 
-  let attendanceOutcomeController: AttendanceOutcomeController
+  let controller: AttendanceOutcomeController
   const appointmentService = createMock<AppointmentService>()
   const referenceDataService = createMock<ReferenceDataService>()
   const formService = createMock<AppointmentFormService>()
   const sessionService = createMock<SessionService>()
 
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    commonViewData: jest.Mock
+    viewData: jest.Mock
+    next: jest.Mock
+    updateForm: jest.Mock
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
-    attendanceOutcomeController = new AttendanceOutcomeController(
-      appointmentService,
-      referenceDataService,
-      formService,
-      sessionService,
-    )
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [],
+      }),
+      commonViewData: jest.fn().mockReturnValue(pageViewData),
+      viewData: jest.fn().mockReturnValue(pageViewData),
+      next: jest.fn(),
+      updateForm: jest.fn(),
+    }
+
+    attendanceOutcomePageMock.mockReturnValue(mockPageInstance)
+
+    controller = new AttendanceOutcomeController(appointmentService, referenceDataService, formService, sessionService)
   })
 
   describe('show', () => {
     it('should render the attendance outcome page', async () => {
-      attendanceOutcomePageMock.mockImplementationOnce(() => {
-        return {
-          viewData: () => pageViewData,
-        }
-      })
+      const appointment = appointmentFactory.build()
+
       appointmentService.getAppointment.mockResolvedValue(appointment)
       referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
+      formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
 
-      const requestHandler = attendanceOutcomeController.show()
+      const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('appointments/update/attendanceOutcome', pageViewData)
+      expect(response.render).toHaveBeenCalledWith(
+        'appointments/update/attendanceOutcome',
+        expect.objectContaining(pageViewData),
+      )
     })
   })
 
@@ -65,30 +82,34 @@ describe('attendanceOutcomeController', () => {
     describe('when a validation error occurs', () => {
       it('should render the attendance outcome page with errors', async () => {
         const errors = { someKey: { text: 'some error' } }
-        const errorSummary = [
-          { attributes: { 'data-cy-error-someKey': 'some error' }, href: '#someKey', text: 'some error' },
-        ]
-        attendanceOutcomePageMock.mockImplementationOnce(() => ({
-          viewData: () => pageViewData,
-          validationErrors: () => ({
-            hasErrors: true,
-            errors,
-            errorSummary,
-          }),
-        }))
+        const errorSummary = [{ text: 'some error', href: '#someKey' }]
+
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: true,
+          errors,
+          errorSummary,
+        })
+
+        const appointment = appointmentFactory.build()
+        const form = appointmentOutcomeFormFactory.build()
 
         appointmentService.getAppointment.mockResolvedValue(appointment)
         referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
+        formService.getForm.mockResolvedValue(form)
 
-        const requestHandler = attendanceOutcomeController.submit()
-        await requestHandler(request, response, next)
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: 'formId123' },
+        })
+
+        await requestHandler(requestWithForm, response, next)
 
         expect(response.render).toHaveBeenCalledWith(
           'appointments/update/attendanceOutcome',
           expect.objectContaining({
             errors,
             errorSummary,
-            ...pageViewData,
           }),
         )
       })
@@ -97,41 +118,48 @@ describe('attendanceOutcomeController', () => {
     describe('when there are no validation errors', () => {
       const nextPath = '/somePath'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
-      const formId = '123'
-      const submitRequest = createMock<Request>({
-        params: { appointmentId: appointment.id.toString(), projectCode: '2' },
-        body: { form: formId },
-      })
+      const formId = 'formId123'
 
       beforeEach(() => {
-        appointmentService.getAppointment.mockResolvedValue(appointment)
+        appointmentService.getAppointment.mockResolvedValue(appointmentFactory.build())
         referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
 
-        attendanceOutcomePageMock.mockImplementationOnce(() => ({
-          viewData: () => pageViewData,
-          validationErrors: () => ({
-            hasErrors: false,
-            errors: {},
-          }),
-          next: () => nextPath,
-          updateForm: () => formToSave,
-        }))
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: false,
+          errors: {},
+          errorSummary: [],
+        })
+        mockPageInstance.next.mockReturnValue(nextPath)
+        mockPageInstance.updateForm.mockReturnValue(formToSave)
       })
 
       it('should redirect to the next page', async () => {
-        const requestHandler = attendanceOutcomeController.submit()
-        await requestHandler(submitRequest, response, next)
+        const form = appointmentOutcomeFormFactory.build()
+        formService.getForm.mockResolvedValue(form)
+
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: formId },
+        })
+
+        await requestHandler(requestWithForm, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
 
       it('should handle form progress', async () => {
         const existingForm = appointmentOutcomeFormFactory.build()
-
         formService.getForm.mockResolvedValue(existingForm)
 
-        const requestHandler = attendanceOutcomeController.submit()
-        await requestHandler(submitRequest, response, next)
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
+          ...request,
+          query: {},
+          body: { form: formId },
+        })
+
+        await requestHandler(requestWithForm, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -1,81 +1,69 @@
-import type { Request, RequestHandler, Response } from 'express'
+import type { Request, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import ReferenceDataService from '../../services/referenceDataService'
 import AttendanceOutcomePage, { AttendanceOutcomeBody } from '../../pages/appointments/attendanceOutcomePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
-import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import SessionService from '../../services/sessionService'
+import BaseAppointmentController, {
+  AppointmentStepViewDataParams,
+  ContextDataParams,
+} from './baseAppointmentController'
+import { AppointmentOutcomeForm, AppointmentOrSession } from '../../@types/user-defined'
+import type { ContactOutcomeDto } from '../../@types/shared'
 
-export default class AttendanceOutcomeController implements IFormPageController {
+type AttendanceOutcomeContext = {
+  appointmentOrSession: AppointmentOrSession
+  contactOutcomes: Array<ContactOutcomeDto>
+}
+
+type AttendanceOutcomeContextData = {
+  contactOutcomes: Array<ContactOutcomeDto>
+  appointmentOrSession: AppointmentOrSession
+}
+
+export default class AttendanceOutcomeController extends BaseAppointmentController<AttendanceOutcomePage> {
   constructor(
-    private readonly appointmentService: AppointmentService,
+    appointmentService: AppointmentService,
     private readonly referenceDataService: ReferenceDataService,
-    private readonly formService: AppointmentFormService,
-    private readonly sessionService: SessionService,
-  ) {}
-
-  show(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-      const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
-
-      const formId = _req.query.form?.toString()
-      const page = new AttendanceOutcomePage()
-
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-
-      res.render(
-        'appointments/update/attendanceOutcome',
-        page.viewData(appointmentOrSession, form, outcomes.contactOutcomes, formId, _req.query),
-      )
-    }
+    appointmentFormService: AppointmentFormService,
+    sessionService: SessionService,
+  ) {
+    super(new AttendanceOutcomePage(), appointmentService, appointmentFormService, sessionService)
   }
 
-  submit(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+  protected getTemplatePath(): string {
+    return 'appointments/update/attendanceOutcome'
+  }
 
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-      const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
+  protected async getContextData({
+    res,
+    appointmentOrSession,
+  }: ContextDataParams): Promise<AttendanceOutcomeContextData> {
+    const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
+    return { contactOutcomes: outcomes.contactOutcomes, appointmentOrSession }
+  }
 
-      const formId = _req.body.form?.toString()
-      const page = new AttendanceOutcomePage()
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body, {
-        appointmentOrSession,
-        contactOutcomes: outcomes.contactOutcomes,
-      })
+  protected async getStepViewData({
+    appointmentOrSession,
+    form,
+    formId,
+    req,
+    contextData,
+  }: AppointmentStepViewDataParams): Promise<object> {
+    const { contactOutcomes } = contextData as AttendanceOutcomeContextData
+    const query = (req.method === 'GET' ? req.query : req.body) as Record<string, unknown>
 
-      if (hasErrors) {
-        return res.render('appointments/update/attendanceOutcome', {
-          ...page.viewData(
-            appointmentOrSession,
-            form,
-            outcomes.contactOutcomes,
-            formId,
-            _req.body as AttendanceOutcomeBody,
-          ),
-          errorSummary,
-          errors,
-        })
-      }
+    return this.page.viewData(appointmentOrSession, form, contactOutcomes, formId, query as AttendanceOutcomeBody)
+  }
 
-      const toSave = page.updateForm(form, outcomes.contactOutcomes, _req.body)
-      await this.formService.saveForm(formId, res.locals.user.username, toSave)
+  protected async getUpdatedForm(
+    req: Request,
+    _res: Response,
+    form: AppointmentOutcomeForm,
+    contextData?: AttendanceOutcomeContext,
+  ): Promise<AppointmentOutcomeForm> {
+    const query = (req.method === 'GET' ? req.query : req.body) as AttendanceOutcomeBody
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
-    }
+    return this.page.updateForm(form, query, contextData)
   }
 }

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -81,7 +81,7 @@ export default abstract class BaseAppointmentController<
       })
 
       const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
-      const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body)
+      const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body, contextData)
 
       if (hasErrors) {
         const viewData = {

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -1,0 +1,136 @@
+import type { Request, RequestHandler, Response } from 'express'
+import BaseAppointmentUpdatePage from '../../pages/appointments/baseAppointmentUpdatePage'
+import AppointmentService from '../../services/appointmentService'
+import AppointmentFormService from '../../services/forms/appointmentFormService'
+import SessionService from '../../services/sessionService'
+import {
+  AppointmentOrSessionParams,
+  AppointmentOrSession,
+  AppointmentOutcomeForm,
+  ValidationErrors,
+  IFormPageController,
+} from '../../@types/user-defined'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+
+export type AppointmentStepViewDataParams = {
+  req: Request
+  res: Response
+  appointmentOrSession: AppointmentOrSession
+  form: AppointmentOutcomeForm
+  formId?: string
+  errors: ValidationErrors<unknown>
+  contextData?: unknown
+}
+
+export type ContextDataParams = {
+  req: Request
+  res: Response
+  appointmentOrSession: AppointmentOrSession
+  form: AppointmentOutcomeForm
+}
+
+export default abstract class BaseAppointmentController<
+  TPage extends BaseAppointmentUpdatePage<unknown>,
+> implements IFormPageController {
+  constructor(
+    protected readonly page: TPage,
+    protected readonly appointmentService: AppointmentService,
+    protected readonly appointmentFormService: AppointmentFormService,
+    protected readonly sessionService: SessionService,
+  ) {}
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const appointmentOrSessionParams = req.params as unknown as AppointmentOrSessionParams
+
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
+      })
+
+      const { formId, form } = await this.getForm(req, res)
+      const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
+
+      const viewData = await this.getStepViewData({
+        req,
+        res,
+        appointmentOrSession,
+        form,
+        formId,
+        errors: {},
+        contextData,
+      })
+
+      res.render(this.getTemplatePath(), viewData)
+    }
+  }
+
+  submit(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const appointmentOrSessionParams = req.params as unknown as AppointmentOrSessionParams
+
+      const { formId, form } = await this.getForm(req, res)
+
+      const appointmentOrSession = await getAppointmentOrSession({
+        appointmentOrSessionParams,
+        res,
+        appointmentService: this.appointmentService,
+        sessionService: this.sessionService,
+      })
+
+      const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
+      const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body)
+
+      if (hasErrors) {
+        const viewData = {
+          ...(await this.getStepViewData({
+            req,
+            res,
+            appointmentOrSession,
+            form,
+            formId,
+            errors,
+            contextData,
+          })),
+          errorSummary,
+          errors,
+        }
+
+        return res.render(this.getTemplatePath(), viewData)
+      }
+
+      const updatedForm = await this.page.updateForm(form, req.body)
+      await this.appointmentFormService.saveForm(formId, res.locals.user.username, updatedForm)
+
+      return res.redirect(
+        this.page.next({
+          ...appointmentOrSessionParams,
+          form: updatedForm,
+          formId,
+        }),
+      )
+    }
+  }
+
+  protected abstract getStepViewData(args: AppointmentStepViewDataParams): Promise<object>
+
+  protected async getContextData(_args: ContextDataParams): Promise<unknown> {
+    return {}
+  }
+
+  protected async getForm(req: Request, res: Response): Promise<{ formId?: string; form: AppointmentOutcomeForm }> {
+    const formId = (req.query?.form || req.body?.form)?.toString()
+
+    if (!formId) {
+      throw new Error('Form ID is required')
+    }
+
+    const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
+
+    return { formId, form }
+  }
+
+  protected abstract getTemplatePath(): string
+}

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -101,7 +101,7 @@ export default abstract class BaseAppointmentController<
         return res.render(this.getTemplatePath(), viewData)
       }
 
-      const updatedForm = await this.page.updateForm(form, req.body)
+      const updatedForm = await this.page.updateForm(form, req.body, contextData)
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, updatedForm)
 
       return res.redirect(

--- a/server/controllers/appointments/chooseProjectController.test.ts
+++ b/server/controllers/appointments/chooseProjectController.test.ts
@@ -38,8 +38,25 @@ describe('ChooseProjectController', () => {
 
   let controller: ChooseProjectController
 
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    updateForm: jest.Mock
+    next: jest.Mock
+    commonViewData: jest.Mock
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] }),
+      updateForm: jest.fn(),
+      next: jest.fn(),
+      commonViewData: jest.fn().mockReturnValue({ common: 'value' }),
+    }
+
+    chooseProjectPageMock.mockReturnValue(mockPageInstance)
+
     controller = new ChooseProjectController(
       appointmentService,
       appointmentFormService,
@@ -55,25 +72,21 @@ describe('ChooseProjectController', () => {
       teamItems: [{ value: 'T1', text: 'Team 1' }],
       projectItems: [{ value: 'PR1', text: 'Project 1' }],
     })
-
-    chooseProjectPageMock.mockImplementation(() => {
-      return {
-        commonViewData: () => ({ common: 'value' }),
-      } as unknown as ChooseProjectPage
-    })
   })
 
   describe('show', () => {
     it('renders page with teamCode from query', async () => {
       const request = createMock<Request>({
         params: { projectCode: 'PROJECT-1', appointmentId: '1' },
-        query: { team: 'QUERY-TEAM' },
+        method: 'GET',
+        query: { team: 'QUERY-TEAM', form: '1' },
+        body: {},
       })
       const response = createMock<Response>({ locals: { user: { username } } })
 
       const form = appointmentOutcomeFormFactory.build({
         projectTeam: { code: 'FORM-TEAM' },
-        project: { code: 'Project' },
+        project: undefined,
       })
       appointmentFormService.getForm.mockResolvedValue(form)
 
@@ -83,7 +96,7 @@ describe('ChooseProjectController', () => {
       expect(getProjectsAndTeamsMock).toHaveBeenCalledWith(
         expect.objectContaining({
           teamCode: 'QUERY-TEAM',
-          projectCode: 'Project',
+          projectCode: undefined,
         }),
       )
     })
@@ -91,7 +104,9 @@ describe('ChooseProjectController', () => {
     it('renders page with teamCode and projectCode from form', async () => {
       const request = createMock<Request>({
         params: { projectCode: 'PROJECT-1', appointmentId: '1' },
-        query: {},
+        method: 'GET',
+        query: { form: '2' },
+        body: {},
       })
       const response = createMock<Response>({ locals: { user: { username } } })
 
@@ -108,6 +123,32 @@ describe('ChooseProjectController', () => {
         expect.objectContaining({
           teamCode: 'FORM-TEAM',
           projectCode: 'FORM-PROJECT',
+        }),
+      )
+    })
+
+    it('renders page with undefined teamCode and projectCode', async () => {
+      const request = createMock<Request>({
+        params: { projectCode: 'PROJECT-1', appointmentId: '1' },
+        method: 'GET',
+        query: { form: '2' },
+        body: {},
+      })
+      const response = createMock<Response>({ locals: { user: { username } } })
+
+      const form = appointmentOutcomeFormFactory.build({
+        projectTeam: undefined,
+        project: undefined,
+      })
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(getProjectsAndTeamsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamCode: undefined,
+          projectCode: undefined,
         }),
       )
     })
@@ -129,12 +170,7 @@ describe('ChooseProjectController', () => {
         errorSummary: [{ text: 'Select a project', href: '#project' }],
       }
 
-      chooseProjectPageMock.mockImplementationOnce(() => {
-        return {
-          commonViewData: () => ({ common: 'value' }),
-          validationErrors: () => validationErrors,
-        }
-      })
+      mockPageInstance.validationErrors.mockReturnValue(validationErrors)
 
       const requestHandler = controller.submit()
       await requestHandler(request, response, next)
@@ -159,6 +195,7 @@ describe('ChooseProjectController', () => {
     it('saves form and redirects if no errors', async () => {
       const request = createMock<Request>({
         params: { projectCode: 'PROJECT-1', appointmentId: '1' },
+        query: {},
         body: { team: 'TEAM-1', project: 'PROJECT-2', form: 'form-1' },
       })
       const response = createMock<Response>({ locals: { user: { username } } })
@@ -167,13 +204,13 @@ describe('ChooseProjectController', () => {
 
       const updatedForm = appointmentOutcomeFormFactory.build()
 
-      chooseProjectPageMock.mockImplementationOnce(() => {
-        return {
-          validationErrors: () => ({ hasErrors: false, errors: {}, errorSummary: [] as Array<ErrorSummaryItem> }),
-          updateForm: () => updatedForm,
-          next: () => '/next',
-        }
+      mockPageInstance.validationErrors.mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [] as Array<ErrorSummaryItem>,
       })
+      mockPageInstance.updateForm.mockReturnValue(updatedForm)
+      mockPageInstance.next.mockReturnValue('/next')
 
       const requestHandler = controller.submit()
       await requestHandler(request, response, next)

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -1,114 +1,60 @@
-import type { Request, RequestHandler, Response } from 'express'
-
-import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import ProjectService from '../../services/projectService'
 import ProviderService from '../../services/providerService'
 import SessionService from '../../services/sessionService'
 import ChooseProjectPage from '../../pages/appointments/chooseProjectPage'
-import getAppointmentOrSession from '../shared/getAppointmentOrSession'
-import getProjectsAndTeams from '../shared/getProjectsAndTeams'
+import getProjectsAndTeams, { ProjectsAndTeamsViewData } from '../shared/getProjectsAndTeams'
+import BaseAppointmentController, {
+  AppointmentStepViewDataParams,
+  ContextDataParams,
+} from './baseAppointmentController'
 
-export default class ChooseProjectController implements IFormPageController {
+export default class ChooseProjectController extends BaseAppointmentController<ChooseProjectPage> {
   constructor(
-    private readonly appointmentService: AppointmentService,
-    private readonly appointmentFormService: AppointmentFormService,
+    appointmentService: AppointmentService,
+    appointmentFormService: AppointmentFormService,
     private readonly providerService: ProviderService,
     private readonly projectService: ProjectService,
-    private readonly sessionService: SessionService,
-  ) {}
-
-  show(): RequestHandler {
-    return async (req: Request, res: Response) => {
-      const appointmentOrSessionParams = req.params as unknown as AppointmentOrSessionParams
-      const project = await this.projectService.getProject({
-        username: res.locals.user.username,
-        projectCode: appointmentOrSessionParams.projectCode,
-      })
-
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-
-      const page = new ChooseProjectPage()
-
-      const formId = req.query.form?.toString()
-      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
-
-      const teamCode = (req.query?.team ?? form.projectTeam?.code)?.toString()
-      const projectCode = form.project.code
-
-      const items = await getProjectsAndTeams({
-        projectService: this.projectService,
-        providerService: this.providerService,
-        projectTypeGroup: project.projectType.group,
-        providerCode: project.providerCode,
-        teamCode,
-        projectCode,
-        response: res,
-        project,
-      })
-
-      res.render('appointments/update/chooseProject', {
-        ...page.commonViewData({ appointmentOrSession, form, formId }),
-        ...items,
-      })
-    }
+    sessionService: SessionService,
+  ) {
+    super(new ChooseProjectPage(), appointmentService, appointmentFormService, sessionService)
   }
 
-  submit(): RequestHandler {
-    return async (req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ...req.params } as unknown as AppointmentOrSessionParams
+  protected getStepViewData({
+    contextData,
+    appointmentOrSession,
+    form,
+    formId,
+  }: AppointmentStepViewDataParams): Promise<ProjectsAndTeamsViewData> {
+    return Promise.resolve({
+      ...(contextData as ProjectsAndTeamsViewData),
+      ...this.page.commonViewData({ appointmentOrSession, form, formId }),
+    })
+  }
 
-      const project = await this.projectService.getProject({
-        username: res.locals.user.username,
-        projectCode: appointmentOrSessionParams.projectCode,
-      })
+  protected getTemplatePath(): string {
+    return 'appointments/update/chooseProject'
+  }
 
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
+  protected async getContextData({ req, res, form }: ContextDataParams): Promise<ProjectsAndTeamsViewData> {
+    const project = await this.projectService.getProject({
+      username: res.locals.user.username,
+      projectCode: req.params.projectCode,
+    })
 
-      const teamCode = req.body?.team?.toString()
-      const projectCode = req.body?.project?.toString()
+    const teamCode = req.method === 'GET' ? (req.query.team ?? form.projectTeam?.code) : req.body.team
+    const projectCode = (req.body?.project ?? form.project?.code)?.toString()
 
-      const page = new ChooseProjectPage()
-      const formId = req.body.form?.toString()
-      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
-
-      const items = await getProjectsAndTeams({
-        projectService: this.projectService,
-        providerService: this.providerService,
-        projectTypeGroup: project.projectType.group,
-        providerCode: project.providerCode,
-        teamCode,
-        projectCode,
-        project,
-        response: res,
-      })
-
-      const { hasErrors, errorSummary, errors } = page.validationErrors(req.body)
-
-      if (hasErrors) {
-        return res.render('appointments/update/chooseProject', {
-          ...page.commonViewData({ appointmentOrSession, form, formId }),
-          ...items,
-          errors,
-          errorSummary,
-        })
-      }
-
-      const toSave = page.updateForm(form, items.teamItems, items.projectItems, req.body)
-      await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
-
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
-    }
+    return getProjectsAndTeams({
+      projectService: this.projectService,
+      providerService: this.providerService,
+      projectTypeGroup: project.projectType.group,
+      providerCode: project.providerCode,
+      teamCode,
+      projectCode,
+      response: res,
+      project,
+    })
   }
 }

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -13,8 +13,7 @@ import ChooseSupervisorController from './chooseSupervisorController'
 import ProjectService from '../../services/projectService'
 import SessionService from '../../services/sessionService'
 
-jest.mock('../../pages/appointments/chooseSupervisorPage.ts')
-jest.mock('../../utils/errorUtils')
+jest.mock('../../pages/appointments/chooseSupervisorPage')
 
 describe('ChooseSupervisorController', () => {
   const userName = 'user'

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -5,9 +5,9 @@ import ProviderService from '../../services/providerService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
-import providerSummaryFactory from '../../testutils/factories/providerSummaryFactory'
+import projectFactory from '../../testutils/factories/projectFactory'
+import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
 import ChooseSupervisorController from './chooseSupervisorController'
 import ProjectService from '../../services/projectService'
@@ -19,12 +19,11 @@ describe('ChooseSupervisorController', () => {
   const userName = 'user'
   const appointmentId = '1'
   const projectCode = '2'
+  const providerCode = 'PROV123'
   const team = 'X123'
   const formId = '123'
-  const request: DeepMocked<Request> = createMock<Request>({
-    params: { appointmentId, projectCode },
-    query: { team, form: formId },
-  })
+  const request = createMock<Request>({ params: { appointmentId, projectCode }, query: { team, form: formId } })
+  const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const chooseSupervisorPageMock: jest.Mock = ChooseSupervisorPage as unknown as jest.Mock<ChooseSupervisorPage>
   const pageViewData = {
@@ -38,8 +37,33 @@ describe('ChooseSupervisorController', () => {
   const projectService = createMock<ProjectService>()
   const sessionService = createMock<SessionService>()
 
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    commonViewData: jest.Mock
+    viewData: jest.Mock
+    next: jest.Mock
+    updateForm: jest.Mock
+    updatePath: jest.Mock
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [],
+      }),
+      commonViewData: jest.fn().mockReturnValue(pageViewData),
+      viewData: jest.fn().mockReturnValue(pageViewData),
+      next: jest.fn(),
+      updateForm: jest.fn(),
+      updatePath: jest.fn().mockReturnValue('/update-path'),
+    }
+
+    chooseSupervisorPageMock.mockReturnValue(mockPageInstance)
+
     appointmentsController = new ChooseSupervisorController(
       appointmentService,
       formService,
@@ -51,17 +75,14 @@ describe('ChooseSupervisorController', () => {
 
   describe('show', () => {
     it('should render the choose supervisor page', async () => {
-      chooseSupervisorPageMock.mockImplementationOnce(() => {
-        return {
-          viewData: () => pageViewData,
-          updatePath: () => '/path',
-        }
-      })
       const appointment = appointmentFactory.build()
+      const project = projectFactory.build({ projectCode, providerCode })
+      const teams = providerTeamSummaryFactory.buildList(2)
       const supervisors = supervisorSummaryFactory.buildList(2)
 
-      const response = createMock<Response>()
       appointmentService.getAppointment.mockResolvedValue(appointment)
+      projectService.getProject.mockResolvedValue(project)
+      providerDataService.getTeams.mockResolvedValue({ providers: teams })
       providerDataService.getSupervisors.mockResolvedValue(supervisors)
 
       const requestHandler = appointmentsController.show()
@@ -69,66 +90,62 @@ describe('ChooseSupervisorController', () => {
 
       expect(response.render).toHaveBeenCalledWith(
         'appointments/update/chooseSupervisor',
-        expect.objectContaining({
-          ...pageViewData,
-        }),
+        expect.objectContaining(pageViewData),
       )
     })
 
     it('should fetch the in progress form if it exists', async () => {
-      const supervisorPath = '/path'
-      const viewData = {
-        someProp: '',
-        team,
-        form: formId,
-        chooseSupervisorPath: supervisorPath,
-      }
+      const form = appointmentOutcomeFormFactory.build()
+      const appointment = appointmentFactory.build()
+      const project = projectFactory.build({ projectCode, providerCode })
+      const teams = providerTeamSummaryFactory.buildList(2)
+      const supervisors = supervisorSummaryFactory.buildList(2)
 
-      chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        viewData: () => viewData,
-        updatePath: () => supervisorPath,
-      }))
-
-      formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
+      appointmentService.getAppointment.mockResolvedValue(appointment)
+      projectService.getProject.mockResolvedValue(project)
+      formService.getForm.mockResolvedValue(form)
+      providerDataService.getTeams.mockResolvedValue({ providers: teams })
+      providerDataService.getSupervisors.mockResolvedValue(supervisors)
 
       const requestHandler = appointmentsController.show()
-      const response = createMock<Response>({ locals: { user: { username: userName } } })
-
       await requestHandler(request, response, next)
 
       expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
-      expect(response.render).toHaveBeenCalledWith('appointments/update/chooseSupervisor', viewData)
+      expect(response.render).toHaveBeenCalledWith(
+        'appointments/update/chooseSupervisor',
+        expect.objectContaining(pageViewData),
+      )
     })
   })
 
   describe('submit', () => {
-    const submitRequest = createMock<Request>({
-      params: { appointmentId: '1' },
-      body: { form: formId },
-    })
-    it('should return view if errors', async () => {
-      const errors = { someKey: { text: 'some error' } }
-      const errorSummary = [{ text: 'some error', href: '#someKey' }]
-      chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        viewData: () => pageViewData,
-        validationErrors: () => ({
-          hasErrors: true,
-          errors,
-          errorSummary,
-        }),
-        updatePath: () => '/path',
-      }))
+    it('should render the choose supervisor page with errors', async () => {
+      const errors = { team: { text: 'Select a team' } }
+      const errorSummary = [{ text: 'Select a team', href: '#team' }]
+
+      mockPageInstance.validationErrors.mockReturnValue({
+        hasErrors: true,
+        errors,
+        errorSummary,
+      })
 
       const appointment = appointmentFactory.build()
-      const supervisors = supervisorSummaryFactory.buildList(2)
-      const providers = [providerSummaryFactory.build()]
+      const project = projectFactory.build({ projectCode, providerCode })
+      const teams = providerTeamSummaryFactory.buildList(2)
+      const form = appointmentOutcomeFormFactory.build()
 
-      const response = createMock<Response>()
       appointmentService.getAppointment.mockResolvedValue(appointment)
-      providerDataService.getSupervisors.mockResolvedValue(supervisors)
-      providerDataService.getProviders.mockResolvedValue(providers)
+      projectService.getProject.mockResolvedValue(project)
+      formService.getForm.mockResolvedValue(form)
+      providerDataService.getTeams.mockResolvedValue({ providers: teams })
 
       const requestHandler = appointmentsController.submit()
+
+      const submitRequest = createMock<Request>({
+        params: { appointmentId: '1' },
+        body: { form: formId },
+      })
+
       await requestHandler(submitRequest, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
@@ -136,58 +153,68 @@ describe('ChooseSupervisorController', () => {
         expect.objectContaining({
           errors,
           errorSummary,
-          ...pageViewData,
         }),
       )
     })
 
-    it('should redirect if no errors', async () => {
+    describe('when there are no validation errors', () => {
       const nextPath = '/nextPath'
-      chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        validationErrors: () => ({
+      const formToSave = { supervisor: { code: 'SUP123' } }
+      const submitRequest = createMock<Request>({
+        ...request,
+        body: { form: formId, team, supervisor: 'SUP123' },
+      })
+
+      beforeEach(() => {
+        mockPageInstance.validationErrors.mockReturnValue({
           hasErrors: false,
           errors: {},
-        }),
-        next: () => nextPath,
-        updateForm: (args: AppointmentOutcomeForm) => args,
-      }))
+          errorSummary: [],
+        })
+        mockPageInstance.next.mockReturnValue(nextPath)
+        mockPageInstance.updateForm.mockReturnValue(formToSave)
+      })
 
-      const appointment = appointmentFactory.build()
-      const supervisors = supervisorSummaryFactory.buildList(2)
-      const providers = [providerSummaryFactory.build()]
+      it('should redirect to the next page', async () => {
+        const appointment = appointmentFactory.build()
+        const project = projectFactory.build({ projectCode, providerCode })
+        const teams = providerTeamSummaryFactory.buildList(2)
+        const supervisors = supervisorSummaryFactory.buildList(2)
+        const form = appointmentOutcomeFormFactory.build()
 
-      const response = createMock<Response>()
-      appointmentService.getAppointment.mockResolvedValue(appointment)
-      providerDataService.getSupervisors.mockResolvedValue(supervisors)
-      providerDataService.getProviders.mockResolvedValue(providers)
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        projectService.getProject.mockResolvedValue(project)
+        formService.getForm.mockResolvedValue(form)
+        providerDataService.getTeams.mockResolvedValue({ providers: teams })
+        providerDataService.getSupervisors.mockResolvedValue(supervisors)
 
-      const requestHandler = appointmentsController.submit()
-      await requestHandler(submitRequest, response, next)
+        const requestHandler = appointmentsController.submit()
 
-      expect(response.redirect).toHaveBeenCalledWith(nextPath)
-    })
+        await requestHandler(submitRequest, response, next)
 
-    it('should handle form progress', async () => {
-      const existingForm = appointmentOutcomeFormFactory.build()
-      const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
-      chooseSupervisorPageMock.mockImplementationOnce(() => ({
-        validationErrors: () => ({
-          hasErrors: false,
-          errors: {},
-        }),
-        next: () => '/nextPath',
-        updateForm: () => formToSave,
-      }))
+        expect(response.redirect).toHaveBeenCalledWith(nextPath)
+      })
 
-      formService.getForm.mockResolvedValue(existingForm)
+      it('should handle form progress', async () => {
+        const existingForm = appointmentOutcomeFormFactory.build()
+        const appointment = appointmentFactory.build()
+        const project = projectFactory.build({ projectCode, providerCode })
+        const teams = providerTeamSummaryFactory.buildList(2)
+        const supervisors = supervisorSummaryFactory.buildList(2)
 
-      const requestHandler = appointmentsController.submit()
-      const response = createMock<Response>({ locals: { user: { username: userName } } })
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        projectService.getProject.mockResolvedValue(project)
+        formService.getForm.mockResolvedValue(existingForm)
+        providerDataService.getTeams.mockResolvedValue({ providers: teams })
+        providerDataService.getSupervisors.mockResolvedValue(supervisors)
 
-      await requestHandler(submitRequest, response, next)
+        const requestHandler = appointmentsController.submit()
 
-      expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
-      expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)
+        await requestHandler(submitRequest, response, next)
+
+        expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
+        expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)
+      })
     })
   })
 })

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -1,111 +1,71 @@
-import type { Request, RequestHandler, Response } from 'express'
-import ChooseSupervisorPage, { SupervisorPageBody } from '../../pages/appointments/chooseSupervisorPage'
+import ChooseSupervisorPage, {
+  SupervisorPageBody,
+  SupervisorPageContext,
+} from '../../pages/appointments/chooseSupervisorPage'
 import AppointmentService from '../../services/appointmentService'
 import ProviderService from '../../services/providerService'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
-import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import SessionService from '../../services/sessionService'
+import BaseAppointmentController, {
+  AppointmentStepViewDataParams,
+  ContextDataParams,
+} from './baseAppointmentController'
 
-export default class ChooseSupervisorController implements IFormPageController {
+export default class ChooseSupervisorController extends BaseAppointmentController<ChooseSupervisorPage> {
   constructor(
-    private readonly appointmentService: AppointmentService,
-    private readonly appointmentFormService: AppointmentFormService,
+    appointmentService: AppointmentService,
+    appointmentFormService: AppointmentFormService,
     private readonly providerService: ProviderService,
     private readonly projectService: ProjectService,
-    private readonly sessionService: SessionService,
-  ) {}
-
-  show(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = _req.params as unknown as AppointmentOrSessionParams
-      const project = await this.projectService.getProject({
-        username: res.locals.user.username,
-        projectCode: appointmentOrSessionParams.projectCode,
-      })
-
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-
-      const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
-
-      const page = new ChooseSupervisorPage()
-
-      const formId = _req.query.form?.toString()
-      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
-
-      const team = _req.query.team?.toString() || form?.supervisingTeam?.code
-
-      const supervisors = team
-        ? await this.providerService.getSupervisors({
-            providerCode: project.providerCode,
-            teamCode: team,
-            username: res.locals.user.username,
-          })
-        : []
-
-      res.render('appointments/update/chooseSupervisor', {
-        ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.query),
-        chooseSupervisorPath: page.updatePath(appointmentOrSession, formId),
-        form: formId,
-        team,
-      })
-    }
+    sessionService: SessionService,
+  ) {
+    super(new ChooseSupervisorPage(), appointmentService, appointmentFormService, sessionService)
   }
 
-  submit(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+  protected getTemplatePath(): string {
+    return 'appointments/update/chooseSupervisor'
+  }
 
-      const project = await this.projectService.getProject({
-        username: res.locals.user.username,
-        projectCode: appointmentOrSessionParams.projectCode,
-      })
+  protected async getContextData({ req, res, form }: ContextDataParams): Promise<SupervisorPageContext> {
+    const { username } = res.locals.user
+    const projectCode = req.params.projectCode as string
 
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
+    const project = await this.projectService.getProject({
+      username,
+      projectCode,
+    })
 
-      const teams = await this.providerService.getTeams(project.providerCode, res.locals.user.username)
+    const teams = await this.providerService.getTeams(project.providerCode, username)
 
-      const team = _req.body.team?.toString()
+    const query = (req.method === 'GET' ? req.query : req.body) as SupervisorPageBody
+    const teamCode = query.team?.toString() ?? form?.supervisingTeam?.code
 
-      const supervisors = team
-        ? await this.providerService.getSupervisors({
-            providerCode: project.providerCode,
-            teamCode: team,
-            username: res.locals.user.username,
-          })
-        : []
-
-      const page = new ChooseSupervisorPage()
-      const formId = _req.body.form?.toString()
-      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
-
-      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
-
-      if (hasErrors) {
-        return res.render('appointments/update/chooseSupervisor', {
-          ...page.viewData(appointmentOrSession, teams, supervisors, form, formId, _req.body as SupervisorPageBody),
-          errors,
-          errorSummary,
-          chooseSupervisorPath: page.updatePath(appointmentOrSession, formId),
-          form: formId,
+    const supervisors = teamCode
+      ? await this.providerService.getSupervisors({
+          providerCode: project.providerCode,
+          teamCode,
+          username,
         })
-      }
+      : []
+    return { teams, supervisors }
+  }
 
-      const toSave = page.updateForm(form, teams, supervisors, _req.body)
-      await this.appointmentFormService.saveForm(formId, res.locals.user.username, toSave)
+  protected async getStepViewData({
+    req,
+    appointmentOrSession,
+    form,
+    formId,
+    contextData,
+  }: AppointmentStepViewDataParams): Promise<object> {
+    const { teams, supervisors } = contextData as SupervisorPageContext
+    const query = (req.method === 'GET' ? req.query : req.body) as SupervisorPageBody
 
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
+    const stepViewData = this.page.viewData(appointmentOrSession, teams, supervisors, form, formId, query)
+
+    return {
+      ...stepViewData,
+      team: query.team?.toString() ?? form?.supervisingTeam?.code,
     }
   }
 }

--- a/server/controllers/appointments/logComplianceController.test.ts
+++ b/server/controllers/appointments/logComplianceController.test.ts
@@ -1,129 +1,132 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
-
 import AppointmentService from '../../services/appointmentService'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
-import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 import LogComplianceController from './logComplianceController'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import SessionService from '../../services/sessionService'
 
-jest.mock('../../models/offender')
 jest.mock('../../pages/appointments/logCompliancePage')
 
-describe('logComplianceController', () => {
+describe('LogComplianceController', () => {
   const userName = 'user'
-  const appointment = appointmentFactory.build({ offender: offenderFullFactory.build() })
-  const formId = '123'
+  const appointmentId = '1'
+  const appointment = appointmentFactory.build()
+  const form = appointmentOutcomeFormFactory.build()
 
-  const request = createMock<Request>({ params: { appointmentId: appointment.id.toString() }, query: { form: formId } })
+  const request = createMock<Request>({ params: { appointmentId }, query: { form: 'some-form' } })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
-  let logComplianceController: LogComplianceController
-  const appointmentService = createMock<AppointmentService>()
-  const formService = createMock<AppointmentFormService>()
-  const sessionService = createMock<SessionService>()
 
   const logCompliancePageMock: jest.Mock = LogCompliancePage as unknown as jest.Mock<LogCompliancePage>
   const pageViewData = {
     someKey: 'some value',
   }
 
+  let controller: LogComplianceController
+  const appointmentService = createMock<AppointmentService>()
+  const formService = createMock<AppointmentFormService>()
+  const sessionService = createMock<SessionService>()
+
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    commonViewData: jest.Mock
+    viewData: jest.Mock
+    next: jest.Mock
+    updateForm: jest.Mock
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
-    logComplianceController = new LogComplianceController(appointmentService, formService, sessionService)
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [],
+      }),
+      commonViewData: jest.fn().mockReturnValue(pageViewData),
+      viewData: jest.fn().mockReturnValue(pageViewData),
+      next: jest.fn(),
+      updateForm: jest.fn(),
+    }
+
+    logCompliancePageMock.mockReturnValue(mockPageInstance)
+    appointmentService.getAppointment.mockResolvedValue(appointment)
+    formService.getForm.mockResolvedValue(form)
+
+    controller = new LogComplianceController(appointmentService, formService, sessionService)
   })
 
   describe('show', () => {
     it('should render the log compliance page', async () => {
       appointmentService.getAppointment.mockResolvedValue(appointment)
-      logCompliancePageMock.mockImplementationOnce(() => {
-        return {
-          viewData: () => pageViewData,
-        }
-      })
 
-      const requestHandler = logComplianceController.show()
+      const requestHandler = controller.show()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('appointments/update/logCompliance', pageViewData)
+      expect(response.render).toHaveBeenCalledWith(
+        'appointments/update/logCompliance',
+        expect.objectContaining(pageViewData),
+      )
     })
   })
 
   describe('submit', () => {
     describe('when a validation error occurs', () => {
       it('should render the log compliance page with errors', async () => {
-        const requestWithoutFormData = createMock<Request>({
+        const errors = { field: { text: 'Enter a value for field' } }
+        const errorSummary = [{ text: 'Enter a value for field', href: '#field' }]
+
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: true,
+          errors,
+          errorSummary,
+        })
+
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
           ...request,
-          body: {},
+          body: { form: 'formId123' },
         })
 
-        appointmentService.getAppointment.mockResolvedValue(appointment)
-
-        logCompliancePageMock.mockImplementationOnce(() => {
-          return {
-            viewData: () => pageViewData,
-            validationErrors: () => ({
-              hasErrors: true,
-              errors: { field: { text: 'Enter a value for field' } },
-              errorSummary: [
-                {
-                  text: 'Enter a value for field',
-                  href: '#field',
-                  attributes: { 'data-cy-error-field': 'Enter a value for field' },
-                },
-              ],
-            }),
-          }
-        })
-
-        const requestHandler = logComplianceController.submit()
-        await requestHandler(requestWithoutFormData, response, next)
+        await requestHandler(requestWithForm, response, next)
 
         expect(response.render).toHaveBeenCalledWith(
           'appointments/update/logCompliance',
           expect.objectContaining({
-            errorSummary: [
-              {
-                text: 'Enter a value for field',
-                href: '#field',
-                attributes: { 'data-cy-error-field': 'Enter a value for field' },
-              },
-            ],
-            errors: { field: { text: 'Enter a value for field' } },
+            errors,
+            errorSummary,
           }),
         )
       })
     })
 
-    describe('when no validation errrors occur', () => {
+    describe('when there are no validation errors', () => {
       const nextPath = '/nextPath'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
-      const submitRequest = createMock<Request>({
-        params: { appointmentId: appointment.id.toString() },
-        body: { form: formId },
-      })
+      const formId = 'formId123'
 
       beforeEach(() => {
-        appointmentService.getAppointment.mockResolvedValue(appointment)
-
-        logCompliancePageMock.mockImplementationOnce(() => {
-          return {
-            validationErrors: () => ({
-              hasErrors: false,
-              errors: {},
-            }),
-            next: () => nextPath,
-            updateForm: () => formToSave,
-          }
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: false,
+          errors: {},
+          errorSummary: [],
         })
+        mockPageInstance.next.mockReturnValue(nextPath)
+        mockPageInstance.updateForm.mockReturnValue(formToSave)
       })
 
-      it('should redirect to the confirm details page', async () => {
-        const requestHandler = logComplianceController.submit()
-        await requestHandler(submitRequest, response, next)
+      it('should redirect to the next page', async () => {
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: formId },
+        })
+
+        await requestHandler(requestWithForm, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
@@ -133,8 +136,14 @@ describe('logComplianceController', () => {
 
         formService.getForm.mockResolvedValue(existingForm)
 
-        const requestHandler = logComplianceController.submit()
-        await requestHandler(submitRequest, response, next)
+        const requestHandler = controller.submit()
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: formId },
+          query: {},
+        })
+
+        await requestHandler(requestWithForm, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -1,65 +1,29 @@
-import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import LogCompliancePage from '../../pages/appointments/logCompliancePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
-import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import SessionService from '../../services/sessionService'
+import BaseAppointmentController, { AppointmentStepViewDataParams } from './baseAppointmentController'
 
-export default class LogComplianceController implements IFormPageController {
+export default class LogComplianceController extends BaseAppointmentController<LogCompliancePage> {
   constructor(
-    private readonly appointmentService: AppointmentService,
-    private readonly formService: AppointmentFormService,
-    private readonly sessionService: SessionService,
-  ) {}
-
-  show(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-
-      const formId = _req.query.form?.toString()
-      const page = new LogCompliancePage()
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-
-      res.render('appointments/update/logCompliance', page.viewData(appointmentOrSession, form, formId))
-    }
+    appointmentService: AppointmentService,
+    appointmentFormService: AppointmentFormService,
+    sessionService: SessionService,
+  ) {
+    super(new LogCompliancePage(), appointmentService, appointmentFormService, sessionService)
   }
 
-  submit(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+  protected getTemplatePath(): string {
+    return 'appointments/update/logCompliance'
+  }
 
-      const formId = _req.body.form?.toString()
-      const page = new LogCompliancePage()
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-
-      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
-
-      if (hasErrors) {
-        const appointmentOrSession = await getAppointmentOrSession({
-          appointmentOrSessionParams,
-          res,
-          appointmentService: this.appointmentService,
-          sessionService: this.sessionService,
-        })
-
-        return res.render('appointments/update/logCompliance', {
-          ...page.viewData(appointmentOrSession, form, formId, _req.body),
-          errors,
-          errorSummary,
-        })
-      }
-
-      const toSave = page.updateForm(form, _req.body)
-      await this.formService.saveForm(formId, res.locals.user.username, toSave)
-
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
-    }
+  protected async getStepViewData({
+    appointmentOrSession,
+    form,
+    formId,
+    req,
+  }: AppointmentStepViewDataParams): Promise<object> {
+    const query = req.body as Record<string, unknown>
+    return this.page.viewData(appointmentOrSession, form, formId, query)
   }
 }

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -29,22 +29,44 @@ describe('logHoursController', () => {
   const formService = createMock<AppointmentFormService>()
   const sessionService = createMock<SessionService>()
 
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    next: jest.Mock
+    updateForm: jest.Mock
+    viewData: jest.Mock
+  }
+
   beforeEach(() => {
     jest.resetAllMocks()
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [],
+      }),
+      viewData: jest.fn().mockReturnValue(pageViewData),
+      next: jest.fn(),
+      updateForm: jest.fn(),
+    }
+
+    logHoursPage.mockReturnValue(mockPageInstance)
+
     logHoursController = new LogHoursController(appointmentService, formService, sessionService)
   })
 
   describe('show', () => {
     it('should render the log hours page', async () => {
-      logHoursPage.mockImplementationOnce(() => {
-        return {
-          viewData: () => pageViewData,
-        }
-      })
       appointmentService.getAppointment.mockResolvedValue(appointment)
+      formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
+
+      const requestWithForm = createMock<Request>({
+        ...request,
+        query: { form: 'formId123' },
+      })
 
       const requestHandler = logHoursController.show()
-      await requestHandler(request, response, next)
+      await requestHandler(requestWithForm, response, next)
 
       expect(response.render).toHaveBeenCalledWith('appointments/update/logHours', pageViewData)
     })
@@ -55,64 +77,77 @@ describe('logHoursController', () => {
       it('should render the log hours page with errors', async () => {
         const errors = { someKey: { text: 'some error' } }
         const errorSummary = [{ text: 'errors', href: '#link' }]
-        logHoursPage.mockImplementationOnce(() => ({
-          viewData: () => pageViewData,
-          validationErrors: () => ({
-            hasErrors: true,
-            errors,
-            errorSummary,
-          }),
-        }))
-
-        appointmentService.getAppointment.mockResolvedValue(appointment)
-
-        const requestHandler = logHoursController.submit()
-        await requestHandler(request, response, next)
-
-        expect(response.render).toHaveBeenCalledWith('appointments/update/logHours', {
-          ...pageViewData,
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: true,
           errors,
           errorSummary,
         })
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
+
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: 'formId123' },
+        })
+
+        const requestHandler = logHoursController.submit()
+        await requestHandler(requestWithForm, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'appointments/update/logHours',
+          expect.objectContaining({
+            someKey: 'some value', // from commonViewData
+            errors,
+            errorSummary,
+          }),
+        )
       })
     })
 
     describe('when there are no validation errors', () => {
       const nextPath = '/next'
       const formToSave = { startTime: '09:00', contactOutcomeId: '1' }
-      const formId = '123'
-      const submitRequest = createMock<Request>({
-        params: { appointmentId: appointment.id.toString() },
-        body: { form: formId },
-      })
+      const formId = 'formId123'
 
       beforeEach(() => {
-        logHoursPage.mockImplementationOnce(() => ({
-          validationErrors: () => ({
-            hasErrors: false,
-            errors: {},
-          }),
-          next: () => nextPath,
-          updateForm: () => formToSave,
-        }))
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: false,
+          errors: {},
+          errorSummary: [],
+        })
+        mockPageInstance.next.mockReturnValue(nextPath)
+        mockPageInstance.updateForm.mockReturnValue(formToSave)
 
         appointmentService.getAppointment.mockResolvedValue(appointment)
+        formService.getForm.mockClear()
+        formService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
       })
 
       it('should redirect to the next page', async () => {
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: formId },
+        })
+
         const requestHandler = logHoursController.submit()
-        await requestHandler(submitRequest, response, next)
+        await requestHandler(requestWithForm, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(nextPath)
       })
 
       it('should handle form progress', async () => {
         const existingForm = appointmentOutcomeFormFactory.build({ startTime: '09:00' })
-
         formService.getForm.mockResolvedValue(existingForm)
 
+        const requestWithForm = createMock<Request>({
+          ...request,
+          body: { form: formId },
+          query: {},
+        })
+
         const requestHandler = logHoursController.submit()
-        await requestHandler(submitRequest, response, next)
+        await requestHandler(requestWithForm, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
         expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, formToSave)

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -11,7 +11,6 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import SessionService from '../../services/sessionService'
 
 jest.mock('../../pages/appointments/logHoursPage')
-jest.mock('../../utils/errorUtils')
 
 describe('logHoursController', () => {
   const userName = 'user'

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -1,68 +1,28 @@
-import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import LogHoursPage from '../../pages/appointments/logHoursPage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
-import { AppointmentOrSessionParams, IFormPageController } from '../../@types/user-defined'
-import getAppointmentOrSession from '../shared/getAppointmentOrSession'
+import BaseAppointmentController, { AppointmentStepViewDataParams } from './baseAppointmentController'
 import SessionService from '../../services/sessionService'
 
-export default class LogHoursController implements IFormPageController {
-  constructor(
-    private readonly appointmentService: AppointmentService,
-    private readonly formService: AppointmentFormService,
-    private readonly sessionService: SessionService,
-  ) {}
-
-  show(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
-      const appointment = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-
-      const formId = _req.query.form?.toString()
-      const page = new LogHoursPage()
-
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-
-      res.render('appointments/update/logHours', {
-        ...page.viewData(appointment, form, formId),
-      })
-    }
+export default class LogHoursController extends BaseAppointmentController<LogHoursPage> {
+  protected getStepViewData({
+    appointmentOrSession,
+    form,
+    formId,
+    req,
+  }: AppointmentStepViewDataParams): Promise<object> {
+    return Promise.resolve(this.page.viewData(appointmentOrSession, form, formId, req.body))
   }
 
-  submit(): RequestHandler {
-    return async (_req: Request, res: Response) => {
-      const appointmentOrSessionParams = { ..._req.params } as unknown as AppointmentOrSessionParams
+  constructor(
+    appointmentService: AppointmentService,
+    appointmentFormService: AppointmentFormService,
+    sessionService: SessionService,
+  ) {
+    super(new LogHoursPage(), appointmentService, appointmentFormService, sessionService)
+  }
 
-      const formId = _req.body.form?.toString()
-      const page = new LogHoursPage()
-      const { hasErrors, errors, errorSummary } = page.validationErrors(_req.body)
-
-      const form = await this.formService.getForm(formId, res.locals.user.username)
-
-      const appointmentOrSession = await getAppointmentOrSession({
-        appointmentOrSessionParams,
-        res,
-        appointmentService: this.appointmentService,
-        sessionService: this.sessionService,
-      })
-
-      if (hasErrors) {
-        return res.render('appointments/update/logHours', {
-          ...page.viewData(appointmentOrSession, form, formId, _req.body),
-          errors,
-          errorSummary,
-        })
-      }
-
-      const toSave = page.updateForm(form, _req.body)
-      await this.formService.saveForm(formId, res.locals.user.username, toSave)
-
-      return res.redirect(page.next({ ...appointmentOrSessionParams, formId, form: toSave }))
-    }
+  protected getTemplatePath(): string {
+    return 'appointments/update/logHours'
   }
 }

--- a/server/controllers/shared/getProjectsAndTeams.ts
+++ b/server/controllers/shared/getProjectsAndTeams.ts
@@ -6,7 +6,7 @@ import ProjectService from '../../services/projectService'
 import { ProjectDto, ProjectTypeDto } from '../../@types/shared'
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
 
-interface ViewData {
+export interface ProjectsAndTeamsViewData {
   projectItems?: Array<GovUkSelectOption>
   teamItems: Array<GovUkSelectOption>
   teamCode?: string
@@ -29,7 +29,7 @@ export default async ({
   projectCode?: string
   project?: ProjectDto
   response: Response
-}): Promise<ViewData> => {
+}): Promise<ProjectsAndTeamsViewData> => {
   const teamItems = await getTeams({
     providerService,
     providerCode,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -573,12 +573,11 @@ describe('AttendanceOutcomePage', () => {
       const queryNotes = 'New notes'
       const form = appointmentOutcomeFormFactory.build({ notes: appointmentNotes })
       const page = new AttendanceOutcomePage()
-
-      const result = page.updateForm(form, contactOutcomes, {
-        attendanceOutcome: contactOutcomes[0].code,
-        notes: queryNotes,
-        isSensitive: 'yes',
-      })
+      const result = page.updateForm(
+        form,
+        { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes, isSensitive: 'yes' },
+        { contactOutcomes, appointmentOrSession: appointment },
+      )
       expect(result).toEqual({
         ...form,
         contactOutcome: contactOutcomes[0],

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -35,14 +35,13 @@ type AttendanceOutcomeContext = {
 }
 
 export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
-  AttendanceOutcomeBody,
+  AttendanceOutcomeQuery,
   AttendanceOutcomeContext
 > {
   protected page: AppointmentFormPage = 'attendance-outcome'
 
   protected getForm(
     data: AppointmentOutcomeForm,
-    outcomes: ContactOutcomeDto[],
     query: AttendanceOutcomeQuery,
     { contactOutcomes }: AttendanceOutcomeContext,
   ): AppointmentOutcomeForm {
@@ -104,12 +103,11 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     return 'choose-project'
   }
 
-  protected nextPage(form?: AppointmentOutcomeForm): AppointmentFormPage {
-    if (!form?.contactOutcome?.attended) {
-      return 'confirm-details'
+  protected nextPage(form: AppointmentOutcomeForm): AppointmentFormPage {
+    if (form.contactOutcome?.attended) {
+      return 'log-hours'
     }
-
-    return 'log-hours'
+    return 'confirm-details'
   }
 
   private items(

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -44,8 +44,9 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     data: AppointmentOutcomeForm,
     outcomes: ContactOutcomeDto[],
     query: AttendanceOutcomeQuery,
+    { contactOutcomes }: AttendanceOutcomeContext,
   ): AppointmentOutcomeForm {
-    const contactOutcome = outcomes.find(outcome => outcome.code === query.attendanceOutcome)
+    const contactOutcome = contactOutcomes.find(outcome => outcome.code === query.attendanceOutcome)
 
     return {
       ...data,

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -21,7 +21,7 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     form?: AppointmentOutcomeForm,
   ): AppointmentFormPage | undefined
 
-  protected abstract getForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm
+  protected abstract getForm(form: AppointmentOutcomeForm, query: TBody, context: TContext): AppointmentOutcomeForm
 
   exitForm(
     appointmentOrSession: AppointmentOrSession,
@@ -78,8 +78,8 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     throw new Error('Path must have an appointment ID or session date')
   }
 
-  updateForm(form: AppointmentOutcomeForm, ...args: Array<unknown>): AppointmentOutcomeForm {
-    return this.getForm(form, ...args)
+  updateForm(form: AppointmentOutcomeForm, query: TBody, context: TContext): AppointmentOutcomeForm {
+    return this.getForm(form, query, context)
   }
 
   updatePath(appointmentOrSession: AppointmentOrSession, formId?: string) {

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -561,7 +561,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const form = appointmentOutcomeFormFactory.build()
       const page = new CheckAppointmentDetailsPage()
 
-      const result = page.updateForm(form)
+      const result = page.updateForm(form, {}, {})
       expect(result).toEqual(form)
     })
   })

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -117,7 +117,11 @@ describe('ChooseProjectPage', () => {
         { value: 'PROJECT-1', text: 'Project 1' },
       ]
 
-      const result = page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' })
+      const result = page.updateForm(
+        form,
+        { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' },
+        { teamItems: teams, projectItems: projects },
+      )
 
       expect(result).toEqual({
         ...form,
@@ -133,7 +137,11 @@ describe('ChooseProjectPage', () => {
       const projects = [{ value: 'PROJECT-1', text: 'Project 1' }]
 
       expect(() =>
-        page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' }),
+        page.updateForm(
+          form,
+          { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' },
+          { teamItems: teams, projectItems: projects },
+        ),
       ).toThrow('Selected team with code TEAM-1 was not found.')
     })
 
@@ -144,7 +152,11 @@ describe('ChooseProjectPage', () => {
       const projects = [{ value: 'PROJECT-2', text: 'Project 2' }]
 
       expect(() =>
-        page.updateForm(form, teams, projects, { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' }),
+        page.updateForm(
+          form,
+          { form: 'F1', team: 'TEAM-1', project: 'PROJECT-1' },
+          { teamItems: teams, projectItems: projects },
+        ),
       ).toThrow('Selected project with code PROJECT-1 was not found.')
     })
   })

--- a/server/pages/appointments/chooseProjectPage.ts
+++ b/server/pages/appointments/chooseProjectPage.ts
@@ -2,16 +2,16 @@ import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
-  GovUkSelectOption,
   ValidationErrors,
 } from '../../@types/user-defined'
+import { ProjectsAndTeamsViewData } from '../../controllers/shared/getProjectsAndTeams'
 import SelectProjectComponent, { ProjectQuestionsBody } from '../../utils/components/projectQuestions'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
 type Query = AppointmentUpdateQuery & ProjectQuestionsBody
 
-export default class ChooseProjectPage extends BaseAppointmentUpdatePage<Query> {
+export default class ChooseProjectPage extends BaseAppointmentUpdatePage<Query, ProjectsAndTeamsViewData> {
   protected page: AppointmentFormPage = 'choose-project'
 
   protected nextPage(): AppointmentFormPage | undefined {
@@ -24,12 +24,11 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage<Query> 
 
   getForm(
     form: AppointmentOutcomeForm,
-    teams: Array<GovUkSelectOption>,
-    projects: Array<GovUkSelectOption>,
     query: Query,
+    { teamItems, projectItems }: ProjectsAndTeamsViewData,
   ): AppointmentOutcomeForm {
-    const selectedTeam = teams.find(team => team.value === query.team)
-    const selectedProject = projects.find(project => project.value === query.project)
+    const selectedTeam = teamItems.find(team => team.value === query.team)
+    const selectedProject = projectItems.find(project => project.value === query.project)
 
     if (!selectedTeam) {
       throw new Error(`Selected team with code ${query.team} was not found.`)

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -222,10 +222,14 @@ describe('ChooseSupervisorPage', () => {
       const [selectedTeam] = teams
       const page = new ChooseSupervisorPage()
 
-      const result = page.updateForm(form, { providers: teams }, supervisors, {
-        supervisor: selectedSupervisor.code,
-        team: selectedTeam.code,
-      })
+      const result = page.updateForm(
+        form,
+        {
+          supervisor: selectedSupervisor.code,
+          team: selectedTeam.code,
+        },
+        { teams: { providers: teams }, supervisors },
+      )
       expect(result).toEqual({ ...form, supervisor: selectedSupervisor, supervisingTeam: selectedTeam })
     })
   })

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -16,6 +16,11 @@ interface ViewData extends AppointmentUpdatePageViewData {
   supervisorItems: GovUkSelectOption[]
 }
 
+export interface SupervisorPageContext {
+  teams: ProviderTeamSummariesDto
+  supervisors: Array<SupervisorSummaryDto>
+}
+
 export interface SupervisorPageBody {
   supervisor: string
   team: string
@@ -26,14 +31,13 @@ interface AppointmentDetailsQuery extends AppointmentUpdateQuery {
   team?: string
 }
 
-export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<SupervisorPageBody> {
+export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<SupervisorPageBody, SupervisorPageContext> {
   protected page: AppointmentFormPage = 'choose-supervisor'
 
   protected getForm(
     data: AppointmentOutcomeForm,
-    teams: ProviderTeamSummariesDto,
-    supervisors: SupervisorSummaryDto[],
     query: AppointmentDetailsQuery,
+    { teams, supervisors }: SupervisorPageContext,
   ): AppointmentOutcomeForm {
     const selectedTeam = teams.providers.find(team => team.code === query.team)
     const selectedSupervisor = supervisors.find(supervisor => supervisor.code === query.supervisor)
@@ -47,7 +51,7 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<Supe
   viewData(
     appointmentOrSession: AppointmentOrSession,
     teams: ProviderTeamSummariesDto,
-    supervisors: SupervisorSummaryDto[],
+    supervisors: Array<SupervisorSummaryDto>,
     form: AppointmentOutcomeForm,
     formId?: string,
     query?: AppointmentDetailsQuery,

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -1,10 +1,10 @@
-import { AppointmentDto } from '../../@types/shared'
+import { AppointmentDto, AttendanceDataDto } from '../../@types/shared'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
-import LogCompliancePage, { LogComplianceQuery } from './logCompliancePage'
+import LogCompliancePage from './logCompliancePage'
 import * as Utils from '../../utils/utils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import attendanceDataFactory from '../../testutils/factories/attendanceDataFactory'
@@ -239,14 +239,14 @@ describe('LogCompliancePage', () => {
 
     it('updates and returns data from query given object with existing data', () => {
       const form = appointmentOutcomeFormFactory.build({ startTime: '10:00', attendanceData: { penaltyMinutes: 60 } })
-      const query: LogComplianceQuery = {
-        workQuality: 'EXCELLENT',
-        behaviour: 'GOOD',
+      const query = {
+        workQuality: 'EXCELLENT' as AttendanceDataDto['workQuality'],
+        behaviour: 'GOOD' as AttendanceDataDto['behaviour'],
       }
 
       page = new LogCompliancePage()
 
-      const result = page.updateForm(form, query)
+      const result = page.updateForm(form, query, {})
 
       const expected = {
         ...form,

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -225,11 +225,9 @@ describe('LogCompliancePage', () => {
       const existingForm = appointmentOutcomeFormFactory.build()
 
       page = new LogCompliancePage()
-      page.updateForm(existingForm, {})
-
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId, form: existingForm })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'confirm-details' })
     })
   })

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -218,11 +218,10 @@ describe('LogHoursPage', () => {
       const projectCode = '2'
       const nextPath = '/path'
       page = new LogHoursPage()
-      page.updateForm(form, {})
 
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
 
-      expect(page.next({ projectCode, appointmentId })).toBe(pathWithQuery)
+      expect(page.next({ projectCode, appointmentId, form })).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({ projectCode, appointmentId, page: 'log-compliance' })
     })
   })

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -236,7 +236,7 @@ describe('LogHoursPage', () => {
 
       page = new LogHoursPage()
 
-      const result = page.updateForm(form, query)
+      const result = page.updateForm(form, query, {})
 
       const expected = {
         ...form,


### PR DESCRIPTION
## Context

Here, we introduce a base controller implementation for appointment form changes, similar to that in the [course completions](https://github.com/ministryofjustice/hmpps-community-payback-ui/blob/main/server/controllers/courseCompletions/process/baseController.ts) journey.

This has two advantages:
- Easier to make changes to the whole journey
- Easier to introduce new changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
