### PR TITLE
Introduce FeatureFlagMiddleware

### DIFF
--- a/server/routes/featureFlagMiddleware.test.ts
+++ b/server/routes/featureFlagMiddleware.test.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+import config from '../config'
+import featureFlagMiddleware from './featureFlagMiddleware'
+
+describe('featureFlagMiddleware', () => {
+  const request = createMock<Request>({})
+  const response = createMock<Response>({ redirect: jest.fn() })
+  const next = jest.fn()
+
+  const actualConfig = config.featureFlags
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    config.featureFlags = actualConfig
+  })
+
+  it('redirects to the home page if the given feature is not enabled', () => {
+    config.featureFlags.createAppointmentEnabled = false
+
+    const middleware = featureFlagMiddleware('createAppointmentEnabled')
+
+    middleware(request, response, next)
+
+    expect(response.redirect).toHaveBeenCalledWith('/')
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('calls next when given feature is enabled', () => {
+    config.featureFlags.createAppointmentEnabled = true
+
+    const middleware = featureFlagMiddleware('createAppointmentEnabled')
+
+    middleware(request, response, next)
+
+    expect(response.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/featureFlagMiddleware.ts
+++ b/server/routes/featureFlagMiddleware.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express'
+import config from '../config'
+
+type FeatureFlagConfigParams = keyof typeof config.featureFlags
+
+export default function featureFlagMiddleware(featureFlag: FeatureFlagConfigParams) {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    if (!config.featureFlags[featureFlag]) {
+      return res.redirect('/')
+    }
+
+    return next()
+  }
+}


### PR DESCRIPTION
## Context
Redirect to the home page if a feature is disabled.

We want to hide the create appointment logic behind a feature flag, previously we added the FF for the "Add appointment" button on the group session page.

We want to also ensure the feature flag is checked when accessing a route directly. For this we introduce a feature flag middleware that can be used at the route level.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
