### PR TITLE
Improve e2e test assertions

### DIFF
--- a/e2e-tests/steps/delius.ts
+++ b/e2e-tests/steps/delius.ts
@@ -18,12 +18,16 @@ export const checkAppointmentOnDelius = async ({
   person,
   project,
   contactOutcome,
+  hoursCredited,
+  outStanding,
 }: {
   page: Page
   team: Team
   person: PersonOnProbation
   project: Project
   contactOutcome: ContactOutcome
+  hoursCredited?: string
+  outStanding?: string
 }) => {
   await deliusLogin(page)
   await page.getByRole('link', { name: 'UPW Project Diary' }).click()
@@ -37,5 +41,7 @@ export const checkAppointmentOnDelius = async ({
     startTime: contactOutcome.startTime ?? project.availability.startTime,
     endTime: contactOutcome.endTime ?? project.availability.endTime,
     outcome: contactOutcome.outcome,
+    hoursCredited,
+    outStanding,
   })
 }

--- a/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
+++ b/e2e-tests/tests/group-placements/01_update_appointment.spec.ts
@@ -54,5 +54,7 @@ test('Update a session appointment', async ({ page, deliusUser, team, project, p
     person: personOnProbation,
     project,
     contactOutcome: { outcome: 'Attended - Complied' },
+    hoursCredited: '4:00',
+    outStanding: '0:00',
   })
 })

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -50,6 +50,8 @@ test('Update a session appointment with an enforceable outcome', async ({
     person: personOnProbation,
     project,
     contactOutcome: { outcome: 'Unacceptable Absence (CP Only)' },
+    hoursCredited: '',
+    outStanding: '4:00',
   })
 
   await homePage.visit()

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -56,5 +56,7 @@ test('Update a session appointment with an attended but enforceable outcome', as
     person: personOnProbation,
     project,
     contactOutcome: { outcome: 'Attended - Failed to Comply' },
+    hoursCredited: '4:00',
+    outStanding: '0:00',
   })
 })

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -52,6 +52,8 @@ test('Update a session appointment with a not attended but not enforceable outco
     person: personOnProbation,
     project,
     contactOutcome: { outcome: 'Rescheduled - Service Request' },
+    hoursCredited: '',
+    outStanding: '4:00',
   })
 
   await homePage.visit()

--- a/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/05_bulk_update_attended.spec.ts
@@ -77,6 +77,7 @@ test('Bulk update a group session => attended', async ({ page, deliusUser, team,
       endTime: project.availability.endTime,
       outcome: 'Attended - Complied',
       hoursCredited: '4:00',
+      outStanding: '0:00',
     })
   }
   /* eslint-enable no-plusplus, no-await-in-loop */

--- a/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
+++ b/e2e-tests/tests/group-placements/06_bulk_update_not_attended.spec.ts
@@ -70,6 +70,7 @@ test('Bulk update a group session => not attended', async ({ page, deliusUser, t
       endTime: project.availability.endTime,
       outcome: 'Rescheduled - Service Request',
       hoursCredited: '',
+      outStanding: '4:00',
     })
   }
   /* eslint-enable no-plusplus, no-await-in-loop */

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -57,5 +57,7 @@ test('Update an individual placement appointment with attended complied', async 
     person: personOnProbation,
     project,
     contactOutcome: { outcome: 'Attended - Complied' },
+    hoursCredited: '4:00',
+    outStanding: '0:00',
   })
 })


### PR DESCRIPTION
## Context

This update makes our e2e test verifications in delius more complete by verifying that the correct time has been credited, and the correct time has been deducted from the requirement.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
