### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ README.md
 node_modules
 npm-debug.log
 .*
+!.allowed-scripts.mjs
+!.npmrc
 **/*.test.js
 scss-report.txt
 eslint-report.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_NUMBER
 ARG GIT_REF
 ARG GIT_BRANCH
 
-COPY package*.json ./
+COPY package*.json .allowed-scripts.mjs .npmrc ./
 RUN CYPRESS_INSTALL_BINARY=0 npm run setup
 ENV NODE_ENV='production'
 


### PR DESCRIPTION
This copies over the npm and allowed-scrips config to enforce allowedscripts whilst building environments using Docker.

Following package guidance:
https://github.com/ministryofjustice/hmpps-typescript-lib/tree/main/packages/npm-script-allowlist And example here: ministryofjustice/hmpps-template-typescript#719

These files should also be added to `.dockerignore`.