### PR TITLE
CPB-1124: Refactor use of appointment or session objects

### DIFF
--- a/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/updateAttendanceOutcome.cy.ts
@@ -105,13 +105,13 @@ context('Attendance outcome', () => {
     cy.task('stubGetContactOutcomes', { contactOutcomes })
 
     // Given I am on the attendance outcome page for an appointment in the future
-    const appointmentInTheFuture = appointmentFactory.build({
+    const appointmentInTheFuture = appointmentOutcomeFormFactory.build({
       date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
-      sensitive: undefined,
+      isSensitive: undefined,
     })
 
-    cy.task('stubFindAppointment', { appointment: appointmentInTheFuture })
-    const page = AttendanceOutcomePage.visit(appointmentInTheFuture)
+    cy.task('stubGetAppointmentForm', appointmentInTheFuture)
+    const page = AttendanceOutcomePage.visit(this.appointment)
 
     // And I complete the form with an outcome that is attended
     const attendedOutcomeCode = contactOutcomes.contactOutcomes.filter((o: ContactOutcomeDto) => o.attended)[0].code
@@ -132,13 +132,13 @@ context('Attendance outcome', () => {
     cy.task('stubGetContactOutcomes', { contactOutcomes })
 
     // Given I am on the attendance outcome page for an appointment in the future
-    const appointmentInTheFuture = appointmentFactory.build({
+    const appointmentInTheFuture = appointmentOutcomeFormFactory.build({
       date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
-      sensitive: undefined,
+      isSensitive: undefined,
     })
 
-    cy.task('stubFindAppointment', { appointment: appointmentInTheFuture })
-    const page = AttendanceOutcomePage.visit(appointmentInTheFuture)
+    cy.task('stubGetAppointmentForm', appointmentInTheFuture)
+    const page = AttendanceOutcomePage.visit(this.appointment)
 
     // And I complete the form with an outcome that is enforceable
     const enforceableOutcomeCode = contactOutcomes.contactOutcomes.filter((o: ContactOutcomeDto) => o.enforceable)[0]

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -12,9 +12,7 @@ import ReferenceDataService from '../../services/referenceDataService'
 
 type PageHeader = { title: string; caption: string; description?: string }
 
-export type AppointmentUpdatePageViewData = {
-  selectedPeopleCard?: GovUkSummaryList
-  heading: PageHeader
+export type AppointmentUpdatePagePathData = {
   backLink: string
   updatePath: string
   form?: string

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -49,6 +49,7 @@ export type AppointmentOutcomeForm = {
     code: string
     name: string
   }
+  date: string
 } & BodyWithNotes
 
 export interface AuditParams {

--- a/server/controllers/appointments/appointmentDetailsController.test.ts
+++ b/server/controllers/appointments/appointmentDetailsController.test.ts
@@ -47,6 +47,7 @@ describe('AppointmentsController', () => {
     it('should render the check appointment details page', async () => {
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => {
         return {
+          commonViewData: () => ({}),
           viewData: () => pageViewData,
         }
       })
@@ -72,7 +73,8 @@ describe('AppointmentsController', () => {
       const newFormId = 'some-id'
       const newForm = { key: { id: newFormId, type: 'some type' }, data: appointmentOutcomeFormFactory.build() }
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
-        viewData: () => {},
+        commonViewData: () => ({}),
+        viewData: () => ({}),
       }))
 
       formService.createForm.mockResolvedValue(newForm)
@@ -91,6 +93,7 @@ describe('AppointmentsController', () => {
       }
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
+        commonViewData: () => ({}),
         viewData: () => viewData,
       }))
 
@@ -114,6 +117,7 @@ describe('AppointmentsController', () => {
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
         viewData: () => ({}),
+        commonViewData: () => ({}),
       }))
 
       appointmentService.getAppointment.mockResolvedValue(appointment)
@@ -133,6 +137,7 @@ describe('AppointmentsController', () => {
 
       checkAppointmentDetailsPageMock.mockImplementationOnce(() => ({
         viewData: () => ({}),
+        commonViewData: () => ({}),
       }))
 
       appointmentService.getAppointment.mockResolvedValue(appointment)

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -56,6 +56,7 @@ export default class AppointmentDetailsController {
 
       res.render('appointments/update/appointmentDetails', {
         ...page.commonViewData({
+          pathData: { ...appointmentParams, date: appointment.date },
           appointmentOrSession: appointment,
           originalSearch: form.originalSearch,
           project,

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -55,7 +55,14 @@ export default class AppointmentDetailsController {
       }
 
       res.render('appointments/update/appointmentDetails', {
-        ...page.viewData({ appointment, project, originalSearch: form.originalSearch, contactOutcome, formId }),
+        ...page.commonViewData({
+          appointmentOrSession: appointment,
+          originalSearch: form.originalSearch,
+          project,
+          form: {} as AppointmentOutcomeForm,
+          formId,
+        }),
+        ...page.viewData({ appointment, project, contactOutcome, formId }),
       })
     }
   }

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -35,14 +35,13 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
   protected async getStepViewData({
     appointmentOrSession,
     form,
-    formId,
     req,
     contextData,
   }: AppointmentStepViewDataParams): Promise<object> {
     const { contactOutcomes } = contextData as AttendanceOutcomeContext
     const query = (req.method === 'GET' ? req.query : req.body) as Record<string, unknown>
 
-    return this.page.viewData(appointmentOrSession, form, contactOutcomes, formId, query as AttendanceOutcomeBody)
+    return this.page.viewData(appointmentOrSession, form, contactOutcomes, query as AttendanceOutcomeBody)
   }
 
   protected async getUpdatedForm(

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -1,25 +1,17 @@
 import type { Request, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import ReferenceDataService from '../../services/referenceDataService'
-import AttendanceOutcomePage, { AttendanceOutcomeBody } from '../../pages/appointments/attendanceOutcomePage'
+import AttendanceOutcomePage, {
+  AttendanceOutcomeBody,
+  AttendanceOutcomeContext,
+} from '../../pages/appointments/attendanceOutcomePage'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import SessionService from '../../services/sessionService'
 import BaseAppointmentController, {
   AppointmentStepViewDataParams,
   ContextDataParams,
 } from './baseAppointmentController'
-import { AppointmentOutcomeForm, AppointmentOrSession } from '../../@types/user-defined'
-import type { ContactOutcomeDto } from '../../@types/shared'
-
-type AttendanceOutcomeContext = {
-  appointmentOrSession: AppointmentOrSession
-  contactOutcomes: Array<ContactOutcomeDto>
-}
-
-type AttendanceOutcomeContextData = {
-  contactOutcomes: Array<ContactOutcomeDto>
-  appointmentOrSession: AppointmentOrSession
-}
+import { AppointmentOutcomeForm } from '../../@types/user-defined'
 
 export default class AttendanceOutcomeController extends BaseAppointmentController<AttendanceOutcomePage> {
   constructor(
@@ -35,12 +27,9 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
     return 'appointments/update/attendanceOutcome'
   }
 
-  protected async getContextData({
-    res,
-    appointmentOrSession,
-  }: ContextDataParams): Promise<AttendanceOutcomeContextData> {
+  protected async getContextData({ res, form }: ContextDataParams): Promise<AttendanceOutcomeContext> {
     const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
-    return { contactOutcomes: outcomes.contactOutcomes, appointmentOrSession }
+    return { contactOutcomes: outcomes.contactOutcomes, form }
   }
 
   protected async getStepViewData({
@@ -50,7 +39,7 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
     req,
     contextData,
   }: AppointmentStepViewDataParams): Promise<object> {
-    const { contactOutcomes } = contextData as AttendanceOutcomeContextData
+    const { contactOutcomes } = contextData as AttendanceOutcomeContext
     const query = (req.method === 'GET' ? req.query : req.body) as Record<string, unknown>
 
     return this.page.viewData(appointmentOrSession, form, contactOutcomes, formId, query as AttendanceOutcomeBody)

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -52,9 +52,10 @@ export default abstract class BaseAppointmentController<
 
       const { formId, form } = await this.getForm(req, res)
       const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
+      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
 
       const viewData = {
-        ...this.page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
+        ...this.page.commonViewData({ pathData, appointmentOrSession, form, formId }),
         ...(await this.getStepViewData({
           req,
           res,
@@ -85,10 +86,11 @@ export default abstract class BaseAppointmentController<
 
       const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
       const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body, contextData)
+      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
 
       if (hasErrors) {
         const viewData = {
-          ...this.page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
+          ...this.page.commonViewData({ pathData, appointmentOrSession, form, formId }),
           ...(await this.getStepViewData({
             req,
             res,

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -54,7 +54,7 @@ export default abstract class BaseAppointmentController<
       const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
 
       const viewData = {
-        ...this.page.commonViewData({ appointmentOrSession, form, formId }),
+        ...this.page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
         ...(await this.getStepViewData({
           req,
           res,
@@ -88,7 +88,7 @@ export default abstract class BaseAppointmentController<
 
       if (hasErrors) {
         const viewData = {
-          ...this.page.commonViewData({ appointmentOrSession, form, formId }),
+          ...this.page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
           ...(await this.getStepViewData({
             req,
             res,

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -25,7 +25,7 @@ export type AppointmentStepViewDataParams = {
 export type ContextDataParams = {
   req: Request
   res: Response
-  appointmentOrSession: AppointmentOrSession
+  appointmentOrSession?: AppointmentOrSession
   form: AppointmentOutcomeForm
 }
 

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -53,15 +53,18 @@ export default abstract class BaseAppointmentController<
       const { formId, form } = await this.getForm(req, res)
       const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
 
-      const viewData = await this.getStepViewData({
-        req,
-        res,
-        appointmentOrSession,
-        form,
-        formId,
-        errors: {},
-        contextData,
-      })
+      const viewData = {
+        ...this.page.commonViewData({ appointmentOrSession, form, formId }),
+        ...(await this.getStepViewData({
+          req,
+          res,
+          appointmentOrSession,
+          form,
+          formId,
+          errors: {},
+          contextData,
+        })),
+      }
 
       res.render(this.getTemplatePath(), viewData)
     }
@@ -85,6 +88,7 @@ export default abstract class BaseAppointmentController<
 
       if (hasErrors) {
         const viewData = {
+          ...this.page.commonViewData({ appointmentOrSession, form, formId }),
           ...(await this.getStepViewData({
             req,
             res,

--- a/server/controllers/appointments/bulkUpdateController.test.ts
+++ b/server/controllers/appointments/bulkUpdateController.test.ts
@@ -67,7 +67,7 @@ describe('BulkUpdateController', () => {
       const query = { search: 'something' }
       await requestHandler(createMock<Request>({ query, params: { projectCode, date } }), response, next)
 
-      expect(appointmentFormService.createBulkForm).toHaveBeenCalledWith(project, username, query)
+      expect(appointmentFormService.createBulkForm).toHaveBeenCalledWith(project, date, username, query)
       expect(response.render).toHaveBeenCalledWith('appointments/update/bulk', viewData)
     })
 

--- a/server/controllers/appointments/bulkUpdateController.ts
+++ b/server/controllers/appointments/bulkUpdateController.ts
@@ -39,6 +39,7 @@ export default class BulkUpdateController implements IFormPageController {
       } else {
         const { data, key } = await this.appointmentFormService.createBulkForm(
           project,
+          date,
           res.locals.user.username,
           req.query as Record<string, string>,
         )

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -21,16 +21,8 @@ export default class ChooseProjectController extends BaseAppointmentController<C
     super(new ChooseProjectPage(), appointmentService, appointmentFormService, sessionService)
   }
 
-  protected getStepViewData({
-    contextData,
-    appointmentOrSession,
-    form,
-    formId,
-  }: AppointmentStepViewDataParams): Promise<ProjectsAndTeamsViewData> {
-    return Promise.resolve({
-      ...(contextData as ProjectsAndTeamsViewData),
-      ...this.page.commonViewData({ appointmentOrSession, form, formId }),
-    })
+  protected getStepViewData({ contextData }: AppointmentStepViewDataParams): Promise<ProjectsAndTeamsViewData> {
+    return Promise.resolve(contextData as ProjectsAndTeamsViewData)
   }
 
   protected getTemplatePath(): string {

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -51,17 +51,11 @@ export default class ChooseSupervisorController extends BaseAppointmentControlle
     return { teams, supervisors }
   }
 
-  protected async getStepViewData({
-    req,
-    appointmentOrSession,
-    form,
-    formId,
-    contextData,
-  }: AppointmentStepViewDataParams): Promise<object> {
+  protected async getStepViewData({ req, form, contextData }: AppointmentStepViewDataParams): Promise<object> {
     const { teams, supervisors } = contextData as SupervisorPageContext
     const query = (req.method === 'GET' ? req.query : req.body) as SupervisorPageBody
 
-    const stepViewData = this.page.viewData(appointmentOrSession, teams, supervisors, form, formId, query)
+    const stepViewData = this.page.viewData(teams, supervisors, form, query)
 
     return {
       ...stepViewData,

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -56,6 +56,7 @@ describe('ConfirmController', () => {
 
       confirmPageMock.mockImplementationOnce(() => {
         return {
+          commonViewData: () => ({}),
           viewData: () => pageViewData,
         }
       })
@@ -82,6 +83,7 @@ describe('ConfirmController', () => {
 
       confirmPageMock.mockImplementationOnce(() => {
         return {
+          commonViewData: () => ({}),
           viewData: () => pageViewData,
         }
       })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -35,9 +35,10 @@ export default class ConfirmController implements IFormPageController {
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
+      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
 
       res.render('appointments/update/confirm', {
-        ...page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
+        ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
         ...page.viewData(appointmentOrSession, form, formId),
         errorList,
         preventDoubleClick,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -37,6 +37,7 @@ export default class ConfirmController implements IFormPageController {
       const preventDoubleClick = true
 
       res.render('appointments/update/confirm', {
+        ...page.commonViewData({ appointmentOrSession, form, formId }),
         ...page.viewData(appointmentOrSession, form, formId),
         errorList,
         preventDoubleClick,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -37,7 +37,7 @@ export default class ConfirmController implements IFormPageController {
       const preventDoubleClick = true
 
       res.render('appointments/update/confirm', {
-        ...page.commonViewData({ appointmentOrSession, form, formId }),
+        ...page.commonViewData({ pathData: appointmentOrSessionParams, appointmentOrSession, form, formId }),
         ...page.viewData(appointmentOrSession, form, formId),
         errorList,
         preventDoubleClick,
@@ -101,7 +101,12 @@ export default class ConfirmController implements IFormPageController {
           _req.flash('success', message)
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
         } catch (error) {
-          return catchApiValidationErrorOrPropagate(_req, res, error, page.updatePath(appointment, formId))
+          return catchApiValidationErrorOrPropagate(
+            _req,
+            res,
+            error,
+            page.updatePath(appointmentOrSessionParams, formId),
+          )
         }
       } else {
         const updates = await Promise.all(

--- a/server/controllers/appointments/logComplianceController.ts
+++ b/server/controllers/appointments/logComplianceController.ts
@@ -17,13 +17,8 @@ export default class LogComplianceController extends BaseAppointmentController<L
     return 'appointments/update/logCompliance'
   }
 
-  protected async getStepViewData({
-    appointmentOrSession,
-    form,
-    formId,
-    req,
-  }: AppointmentStepViewDataParams): Promise<object> {
+  protected async getStepViewData({ form, req }: AppointmentStepViewDataParams): Promise<object> {
     const query = req.body as Record<string, unknown>
-    return this.page.viewData(appointmentOrSession, form, formId, query)
+    return this.page.viewData(form, query)
   }
 }

--- a/server/controllers/appointments/logHoursController.test.ts
+++ b/server/controllers/appointments/logHoursController.test.ts
@@ -33,6 +33,7 @@ describe('logHoursController', () => {
     validationErrors: jest.Mock
     next: jest.Mock
     updateForm: jest.Mock
+    commonViewData: jest.Mock
     viewData: jest.Mock
   }
 
@@ -45,6 +46,7 @@ describe('logHoursController', () => {
         errors: {},
         errorSummary: [],
       }),
+      commonViewData: jest.fn().mockReturnValue({}),
       viewData: jest.fn().mockReturnValue(pageViewData),
       next: jest.fn(),
       updateForm: jest.fn(),

--- a/server/controllers/appointments/logHoursController.ts
+++ b/server/controllers/appointments/logHoursController.ts
@@ -5,13 +5,8 @@ import BaseAppointmentController, { AppointmentStepViewDataParams } from './base
 import SessionService from '../../services/sessionService'
 
 export default class LogHoursController extends BaseAppointmentController<LogHoursPage> {
-  protected getStepViewData({
-    appointmentOrSession,
-    form,
-    formId,
-    req,
-  }: AppointmentStepViewDataParams): Promise<object> {
-    return Promise.resolve(this.page.viewData(appointmentOrSession, form, formId, req.body))
+  protected getStepViewData({ form, req }: AppointmentStepViewDataParams): Promise<object> {
+    return Promise.resolve(this.page.viewData(form, req.body))
   }
 
   constructor(

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -509,7 +509,11 @@ describe('AttendanceOutcomePage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',
@@ -528,7 +532,11 @@ describe('AttendanceOutcomePage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -30,7 +30,7 @@ describe('AttendanceOutcomePage', () => {
       const { errors } = page.validationErrors(
         { attendanceOutcome: '', notes: 'some note' },
         {
-          appointmentOrSession: appointment,
+          form: appointmentOutcomeFormFactory.build(),
           contactOutcomes,
         },
       )
@@ -40,7 +40,7 @@ describe('AttendanceOutcomePage', () => {
     })
 
     describe('when the appointment date is in the future', () => {
-      const appointmentInTheFuture = appointmentFactory.build({
+      const appointmentFormInTheFuture = appointmentOutcomeFormFactory.build({
         date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
       })
 
@@ -51,7 +51,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: attendedContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentInTheFuture,
+            form: appointmentFormInTheFuture,
             contactOutcomes: [...contactOutcomes, attendedContactOutcome],
           },
         )
@@ -69,7 +69,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: enforceableContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentInTheFuture,
+            form: appointmentFormInTheFuture,
             contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
           },
         )
@@ -87,7 +87,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentInTheFuture,
+            form: appointmentFormInTheFuture,
             contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
           },
         )
@@ -95,7 +95,7 @@ describe('AttendanceOutcomePage', () => {
       })
 
       it('returns error if appointmentOrSession is a session and contact outcome is attended', () => {
-        const sessionInTheFuture = sessionFactory.build({
+        const sessionFormInTheFuture = appointmentOutcomeFormFactory.build({
           date: DateTimeFormats.getTodaysDatePlusDays(1).formattedDate,
         })
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
@@ -103,7 +103,7 @@ describe('AttendanceOutcomePage', () => {
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: attendedContactOutcome.code, notes: '' },
-          { appointmentOrSession: sessionInTheFuture, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+          { form: sessionFormInTheFuture, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
         )
         expect(errors).toEqual({
           attendanceOutcome: {
@@ -114,7 +114,7 @@ describe('AttendanceOutcomePage', () => {
     })
 
     describe('when the appointment date is today', () => {
-      const appointmentToday = appointmentFactory.build({
+      const appointmentFormToday = appointmentOutcomeFormFactory.build({
         date: DateTimeFormats.getTodaysDatePlusDays(0).formattedDate,
       })
 
@@ -124,7 +124,7 @@ describe('AttendanceOutcomePage', () => {
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: attendedContactOutcome.code, notes: '' },
-          { appointmentOrSession: appointmentToday, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+          { form: appointmentFormToday, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
         )
         expect(errors).toEqual({})
       })
@@ -135,7 +135,7 @@ describe('AttendanceOutcomePage', () => {
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: enforceableContactOutcome.code, notes: 'note' },
-          { appointmentOrSession: appointmentToday, contactOutcomes: [...contactOutcomes, enforceableContactOutcome] },
+          { form: appointmentFormToday, contactOutcomes: [...contactOutcomes, enforceableContactOutcome] },
         )
         expect(errors).toEqual({})
       })
@@ -147,7 +147,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentToday,
+            form: appointmentFormToday,
             contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
           },
         )
@@ -156,7 +156,7 @@ describe('AttendanceOutcomePage', () => {
     })
 
     describe('when the appointment date is in the past', () => {
-      const appointmentInThePast = appointmentFactory.build({ date: '2020-10-23' })
+      const appointmentFormInThePast = appointmentOutcomeFormFactory.build({ date: '2020-10-23' })
 
       it('does not return error if contact outcome is an attended outcome', () => {
         const attendedContactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
@@ -164,7 +164,10 @@ describe('AttendanceOutcomePage', () => {
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: attendedContactOutcome.code, notes: '' },
-          { appointmentOrSession: appointmentInThePast, contactOutcomes: [...contactOutcomes, attendedContactOutcome] },
+          {
+            form: appointmentFormInThePast,
+            contactOutcomes: [...contactOutcomes, attendedContactOutcome],
+          },
         )
         expect(errors).toEqual({})
       })
@@ -176,7 +179,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: enforceableContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentInThePast,
+            form: appointmentOutcomeFormFactory.build(),
             contactOutcomes: [...contactOutcomes, enforceableContactOutcome],
           },
         )
@@ -190,7 +193,7 @@ describe('AttendanceOutcomePage', () => {
         const { errors } = page.validationErrors(
           { attendanceOutcome: acceptableAbsenceContactOutcome.code, notes: '' },
           {
-            appointmentOrSession: appointmentInThePast,
+            form: appointmentOutcomeFormFactory.build(),
             contactOutcomes: [...contactOutcomes, acceptableAbsenceContactOutcome],
           },
         )
@@ -201,12 +204,11 @@ describe('AttendanceOutcomePage', () => {
     describe('notes', () => {
       it('should not have any errors if no notes value', () => {
         const page = new AttendanceOutcomePage()
-        page.validationErrors({} as AttendanceOutcomeBody, { appointmentOrSession: appointment, contactOutcomes })
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: contactOutcomes[0].code, notes: '' },
           {
-            appointmentOrSession: appointment,
+            form: appointmentOutcomeFormFactory.build(),
             contactOutcomes,
           },
         )
@@ -216,15 +218,11 @@ describe('AttendanceOutcomePage', () => {
       it.each([4000, 3999, 0])('should not have any errors if notes count is less than 4000', (count: number) => {
         const notes = faker.string.alpha(count)
         const page = new AttendanceOutcomePage()
-        page.validationErrors({ notes } as AttendanceOutcomeBody, {
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: contactOutcomes[0].code, notes },
           {
-            appointmentOrSession: appointment,
+            form: appointmentOutcomeFormFactory.build(),
             contactOutcomes,
           },
         )
@@ -234,15 +232,11 @@ describe('AttendanceOutcomePage', () => {
       it('should have errors if the notes count is greater than 4000', () => {
         const notes = faker.string.alpha(4001)
         const page = new AttendanceOutcomePage()
-        page.validationErrors({ notes } as AttendanceOutcomeBody, {
-          appointmentOrSession: appointment,
-          contactOutcomes,
-        })
 
         const { errors } = page.validationErrors(
           { attendanceOutcome: contactOutcomes[0].code, notes },
           {
-            appointmentOrSession: appointment,
+            form: appointmentOutcomeFormFactory.build(),
             contactOutcomes,
           },
         )
@@ -493,7 +487,10 @@ describe('AttendanceOutcomePage', () => {
 
       it('should return items if page has Errors and contact outcome is undefined', () => {
         const page = new AttendanceOutcomePage()
-        page.validationErrors({} as AttendanceOutcomeBody, { appointmentOrSession: appointment, contactOutcomes })
+        page.validationErrors({} as AttendanceOutcomeBody, {
+          form: appointmentOutcomeFormFactory.build(),
+          contactOutcomes,
+        })
 
         const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), contactOutcomes)
 
@@ -576,7 +573,7 @@ describe('AttendanceOutcomePage', () => {
       const result = page.updateForm(
         form,
         { attendanceOutcome: contactOutcomes[0].code, notes: queryNotes, isSensitive: 'yes' },
-        { contactOutcomes, appointmentOrSession: appointment },
+        { contactOutcomes, form },
       )
       expect(result).toEqual({
         ...form,

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -5,6 +5,7 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import { contactOutcomeFactory, contactOutcomesFactory } from '../../testutils/factories/contactOutcomeFactory'
 import AttendanceOutcomePage, { AttendanceOutcomeBody } from './attendanceOutcomePage'
+import { AppointmentOutcomeForm } from '../../@types/user-defined'
 import * as Utils from '../../utils/utils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
@@ -296,29 +297,12 @@ describe('AttendanceOutcomePage', () => {
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, undefined, {})
-
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'attendance-outcome',
-      })
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'choose-project',
-      })
+      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, {} as AttendanceOutcomeBody)
 
       expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment, true)
 
       expect(result).toEqual({
-        heading: {
-          title: offender.name,
-          caption: offender.crn,
-        },
         items: expectedItems,
-        updatePath: pathWithQuery,
-        backLink: pathWithQuery,
         notes: 'Test notes',
         isSensitiveItems: expectedSensitiveItems,
         showIsSensitiveQuestion: true,
@@ -346,12 +330,11 @@ describe('AttendanceOutcomePage', () => {
         })
         const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
 
-        jest.spyOn(paths.sessions, 'update')
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
         const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(session, form, contactOutcomes)
+        const result = page.viewData(session, form, contactOutcomes, {} as AttendanceOutcomeBody)
 
         const expectedItems = [
           {
@@ -371,21 +354,8 @@ describe('AttendanceOutcomePage', () => {
           },
         ]
 
-        expect(paths.sessions.update).toHaveBeenCalledWith({
-          projectCode: session.projectCode,
-          date: session.date,
-          page: 'attendance-outcome',
-        })
-        expect(paths.sessions.update).toHaveBeenCalledWith({
-          projectCode: session.projectCode,
-          date: session.date,
-          page: 'choose-project',
-        })
-
         expect(result).toEqual(
           expect.objectContaining({
-            backLink: pathWithQuery,
-            updatePath: pathWithQuery,
             ...notesItems,
             items: expectedItems,
           }),
@@ -400,7 +370,7 @@ describe('AttendanceOutcomePage', () => {
 
         const page = new AttendanceOutcomePage()
 
-        const viewData = page.viewData(session, form, contactOutcomes)
+        const viewData = page.viewData(session, form, contactOutcomes, {} as AttendanceOutcomeBody)
 
         expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
         expect(viewData).toEqual(expect.objectContaining(notesItems))
@@ -414,7 +384,7 @@ describe('AttendanceOutcomePage', () => {
         })
         const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(appointment, form, contactOutcomes)
+        const result = page.viewData(appointment, form, contactOutcomes, {} as AttendanceOutcomeBody)
 
         const expectedItems = [
           {
@@ -443,7 +413,12 @@ describe('AttendanceOutcomePage', () => {
         })
         const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), [hintedOutcome])
+        const result = page.viewData(
+          appointment,
+          appointmentOutcomeFormFactory.build(),
+          [hintedOutcome],
+          {} as AttendanceOutcomeBody,
+        )
 
         expect(result.items[0]).toEqual({
           text: hintedOutcome.name,
@@ -456,11 +431,11 @@ describe('AttendanceOutcomePage', () => {
       it('should return query values if there are errors', () => {
         const notesItems = { notes: 'Test', showIsSensitiveQuestion: true }
         jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
-        const query = { notes: notesItems.notes }
+        const query = { notes: notesItems.notes } as AttendanceOutcomeBody
         const page = new AttendanceOutcomePage()
 
         const form = appointmentOutcomeFormFactory.build()
-        const result = page.viewData(appointment, form, contactOutcomes, undefined, query)
+        const result = page.viewData(appointment, form, contactOutcomes, query)
 
         const expectedItems = [
           {
@@ -492,7 +467,12 @@ describe('AttendanceOutcomePage', () => {
           contactOutcomes,
         })
 
-        const result = page.viewData(appointment, appointmentOutcomeFormFactory.build(), contactOutcomes)
+        const result = page.viewData(
+          appointment,
+          appointmentOutcomeFormFactory.build(),
+          contactOutcomes,
+          {} as AttendanceOutcomeBody,
+        )
 
         const expectedItems = [
           {
@@ -514,6 +494,66 @@ describe('AttendanceOutcomePage', () => {
 
         expect(result.items).toEqual(expectedItems)
       })
+    })
+  })
+
+  describe('commonViewData', () => {
+    let form: AppointmentOutcomeForm
+
+    beforeEach(() => {
+      form = appointmentOutcomeFormFactory.build()
+    })
+
+    it('should return a back link to the choose supervisor page', () => {
+      const page = new AttendanceOutcomePage()
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'choose-project',
+      })
+    })
+
+    it('should return an update path for the attendance outcome page', () => {
+      const page = new AttendanceOutcomePage()
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        appointmentId: appointment.id.toString(),
+        projectCode: appointment.projectCode,
+        page: 'attendance-outcome',
+      })
+    })
+
+    it('should use session paths when appointmentOrSession is a session', () => {
+      const page = new AttendanceOutcomePage()
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'choose-project',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'attendance-outcome',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
     })
   })
 

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -508,7 +508,12 @@ describe('AttendanceOutcomePage', () => {
       const page = new AttendanceOutcomePage()
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -522,7 +527,12 @@ describe('AttendanceOutcomePage', () => {
       const page = new AttendanceOutcomePage()
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.updatePath).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -534,12 +544,13 @@ describe('AttendanceOutcomePage', () => {
 
     it('should use session paths when appointmentOrSession is a session', () => {
       const page = new AttendanceOutcomePage()
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const pathData = { projectCode: 'P123', date: '2026-06-10' }
+      const session = sessionFactory.build(pathData)
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -1,5 +1,6 @@
 import {
   AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   BodyWithNotes,
@@ -95,7 +96,7 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     }
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
+  protected backPage(_params: AppointmentOrSessionParams): AppointmentFormPage {
     return 'choose-project'
   }
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -1,7 +1,6 @@
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
   BodyWithNotes,
   GovUkRadioOrCheckboxOption,
@@ -26,8 +25,7 @@ type AttendanceOutcomeQuery = {
 
 type ViewData = {
   items: Array<GovUkRadioOrCheckboxOption>
-} & ViewDataWithNotes &
-  AppointmentUpdatePageViewData
+} & ViewDataWithNotes
 
 export type AttendanceOutcomeContext = {
   form: AppointmentOutcomeForm
@@ -87,14 +85,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     appointmentOrSession: AppointmentOrSession,
     form: AppointmentOutcomeForm,
     contactOutcomes: ContactOutcomeDto[],
-    formId?: string,
-    query?: AttendanceOutcomeQuery,
+    query: AttendanceOutcomeBody,
   ): ViewData {
     const isSingleAppointment = this.isSingleAppointment(appointmentOrSession)
     const appointment = isSingleAppointment ? (appointmentOrSession as AppointmentDto) : undefined
     return {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
-      ...NotesUtils.questionItems(query ?? {}, form, appointment, isSingleAppointment),
+      ...NotesUtils.questionItems(query, form, appointment, isSingleAppointment),
       items: this.items(form, contactOutcomes, query),
     }
   }

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -29,8 +29,8 @@ type ViewData = {
 } & ViewDataWithNotes &
   AppointmentUpdatePageViewData
 
-type AttendanceOutcomeContext = {
-  appointmentOrSession: AppointmentOrSession
+export type AttendanceOutcomeContext = {
+  form: AppointmentOutcomeForm
   contactOutcomes: ContactOutcomeDto[]
 }
 
@@ -65,10 +65,10 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
     }
 
     if (additionalParams) {
-      const { appointmentOrSession, contactOutcomes } = additionalParams
+      const { form, contactOutcomes } = additionalParams
       if (
         this.outcomeIsAttendedOrEnforceable(body.attendanceOutcome, contactOutcomes) &&
-        DateTimeFormats.dateIsInFuture(appointmentOrSession.date)
+        DateTimeFormats.dateIsInFuture(form.date)
       ) {
         validationErrors.attendanceOutcome = {
           text: 'The outcome entered must be: acceptable absence',

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -1,8 +1,7 @@
 /* eslint max-classes-per-file: "off" -- need multiple classes to test different implementations of this abstract class */
-
-import { ProjectDto } from '../../@types/shared'
-import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
+import { AppointmentOrSession, AppointmentOutcomeForm } from '../../@types/user-defined'
 import Offender from '../../models/offender'
+import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
@@ -50,7 +49,8 @@ describe('BaseAppointmentUpdatePage', () => {
       it('returns heading containing offender details when appointment is provided', () => {
         const page = new PageWithNextPage()
 
-        const result = page.getCommonViewDataForTest({
+        const result = page.commonViewData({
+          pathData: { projectCode: '', date: '' },
           appointmentOrSession: appointmentFactory.build(),
           form,
           formId: '1',
@@ -69,7 +69,8 @@ describe('BaseAppointmentUpdatePage', () => {
 
         jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(formattedDate)
 
-        const result = page.getCommonViewDataForTest({
+        const result = page.commonViewData({
+          pathData: { projectCode: '', date: '' },
           appointmentOrSession: session,
           form,
           formId: '1',
@@ -87,7 +88,8 @@ describe('BaseAppointmentUpdatePage', () => {
       it('should be undefined given appointment', () => {
         const page = new PageWithNextPage()
 
-        const result = page.getCommonViewDataForTest({
+        const result = page.commonViewData({
+          pathData: { projectCode: '', date: '' },
           appointmentOrSession: appointmentFactory.build(),
           form,
           formId: '1',
@@ -98,7 +100,8 @@ describe('BaseAppointmentUpdatePage', () => {
 
       it('should return card given session', () => {
         const page = new PageWithNextPage()
-        const session = sessionFactory.build({ projectName: 'Project Name', date: '2026-06-10' })
+        const pathData = { projectCode: 'Project', date: '2026-06-10' }
+        const session = sessionFactory.build(pathData)
 
         const selectedPeopleCard = {
           rows: [{ key: { text: 'person 1' }, value: { text: '09:00 - 13:00' } }],
@@ -106,11 +109,59 @@ describe('BaseAppointmentUpdatePage', () => {
 
         jest.spyOn(SessionUtils, 'selectedPeopleCard').mockReturnValue(selectedPeopleCard)
 
-        const result = page.getCommonViewDataForTest({ appointmentOrSession: session, form, formId: '1' })
+        const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: '1' })
 
         expect(result.selectedPeopleCard).toEqual(selectedPeopleCard)
         expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(session, form.appointments, '1')
       })
+    })
+  })
+
+  describe('paths', () => {
+    it('returns backLink, updatePath and form for an appointment', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', appointmentId: '1' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result).toEqual({
+        backLink: `${paths.appointments.update({ projectCode: 'P123', appointmentId: '1', page: 'choose-supervisor' })}?form=form-1`,
+        updatePath: `${paths.appointments.update({ projectCode: 'P123', appointmentId: '1', page: 'attendance-outcome' })}?form=form-1`,
+        form: 'form-1',
+      })
+    })
+
+    it('returns backLink, updatePath and form for a session', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', date: '2026-06-10' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result).toEqual({
+        backLink: `${paths.sessions.update({ projectCode: 'P123', date: '2026-06-10', page: 'choose-supervisor' })}?form=form-1`,
+        updatePath: `${paths.sessions.update({ projectCode: 'P123', date: '2026-06-10', page: 'attendance-outcome' })}?form=form-1`,
+        form: 'form-1',
+      })
+    })
+
+    it('includes original search params in the back link', () => {
+      const page = new PageWithNextPage()
+      const originalSearch = { provider: 'provider', team: 'team' }
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', appointmentId: '1' },
+        form,
+        formId: 'form-1',
+        originalSearch,
+      })
+
+      expect(result.backLink).toBe('/appointments/P123/1/choose-supervisor?form=form-1&provider=provider&team=team')
     })
   })
 })
@@ -124,16 +175,6 @@ class PageWithNextPage extends BaseAppointmentUpdatePage<unknown> {
   }
 
   protected page: AppointmentFormPage = 'attendance-outcome'
-
-  public getCommonViewDataForTest(args: {
-    appointmentOrSession: AppointmentOrSession
-    originalSearch?: Record<string, string>
-    project?: ProjectDto
-    form: AppointmentOutcomeForm
-    formId: string
-  }): AppointmentUpdatePageViewData {
-    return this.commonViewData(args)
-  }
 
   protected nextPage(): AppointmentFormPage {
     return 'confirm-details'

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -4,6 +4,8 @@ import Offender from '../../models/offender'
 import paths from '../../paths'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import projectFactory from '../../testutils/factories/projectFactory'
+import projectTypeFactory from '../../testutils/factories/projectTypeFactory'
 import sessionFactory from '../../testutils/factories/sessionFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import SessionUtils from '../../utils/sessionUtils'
@@ -32,7 +34,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
   describe('next()', () => {
     it('throws an error when nextPage returns undefined', () => {
-      const page = new PageWithoutNextPage()
+      const page = new PageWithoutNavigationPages()
 
       expect(() => page.next({ projectCode: 'P123', appointmentId: '1' })).toThrow('No next page configured')
     })
@@ -164,6 +166,45 @@ describe('BaseAppointmentUpdatePage', () => {
       expect(result.backLink).toBe('/appointments/P123/1/choose-supervisor?form=form-1&provider=provider&team=team')
     })
   })
+
+  describe('paths with an exitForm back link', () => {
+    it('returns a session back link when a GROUP project is provided', () => {
+      const page = new PageWithoutNavigationPages()
+      const project = projectFactory.build({ projectType: projectTypeFactory.build({ group: 'GROUP' }) })
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', date: '2026-06-10' },
+        form,
+        project,
+      })
+
+      expect(result.backLink).toBe(paths.sessions.show({ projectCode: 'P123', date: '2026-06-10' }))
+    })
+
+    it('returns a project back link when a non-GROUP project is provided', () => {
+      const page = new PageWithoutNavigationPages()
+      const project = projectFactory.build({ projectType: projectTypeFactory.build({ group: 'INDIVIDUAL' }) })
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', appointmentId: '1' },
+        form,
+        project,
+      })
+
+      expect(result.backLink).toBe(paths.projects.show({ projectCode: 'P123' }))
+    })
+
+    it('returns a project back link when no project is provided', () => {
+      const page = new PageWithoutNavigationPages()
+
+      const result = page.paths({
+        pathData: { projectCode: 'P123', appointmentId: '1' },
+        form,
+      })
+
+      expect(result.backLink).toBe(paths.projects.show({ projectCode: 'P123' }))
+    })
+  })
 })
 
 class PageWithNextPage extends BaseAppointmentUpdatePage<unknown> {
@@ -189,7 +230,7 @@ class PageWithNextPage extends BaseAppointmentUpdatePage<unknown> {
   }
 }
 
-class PageWithoutNextPage extends BaseAppointmentUpdatePage<unknown> {
+class PageWithoutNavigationPages extends BaseAppointmentUpdatePage<unknown> {
   protected getValidationErrors(
     _query: unknown,
     _additionalParams?: unknown,
@@ -203,8 +244,8 @@ class PageWithoutNextPage extends BaseAppointmentUpdatePage<unknown> {
     return undefined
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
-    return 'choose-supervisor'
+  protected backPage(_appointmentOrSession: AppointmentOrSession): undefined {
+    return undefined
   }
 
   protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -20,6 +20,12 @@ type AppointmentUpdateViewData = AppointmentUpdatePagePathData & {
   heading: PageHeader
 }
 
+type PathData = {
+  projectCode: string
+  date: string
+  appointmentId?: string
+}
+
 export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContext = unknown> extends PageWithValidation<
   TBody,
   TContext
@@ -130,7 +136,7 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     project?: ProjectDto
     form: AppointmentOutcomeForm
     formId?: string
-    pathData: AppointmentOrSessionParams
+    pathData: PathData
   }): AppointmentUpdateViewData {
     const viewData: AppointmentUpdateViewData = {
       ...this.paths({ pathData, originalSearch, form, formId, project }),

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -1,5 +1,12 @@
 import { ProjectDto } from '../../@types/shared'
-import { AppointmentOrSession, AppointmentOutcomeForm, AppointmentUpdatePageViewData } from '../../@types/user-defined'
+import {
+  AppointmentOrSession,
+  AppointmentOrSessionParams,
+  AppointmentOutcomeForm,
+  AppointmentUpdatePagePathData,
+  GovUkSummaryList,
+  PageHeader,
+} from '../../@types/user-defined'
 import Offender from '../../models/offender'
 import paths from '../../paths'
 import SessionUtils from '../../utils/sessionUtils'
@@ -7,6 +14,11 @@ import { pathWithQuery } from '../../utils/utils'
 import { AppointmentFormPage } from './pathMap'
 import PageWithValidation from '../pageWithValidation'
 import DateTimeFormats from '../../utils/dateTimeUtils'
+
+type AppointmentUpdateViewData = AppointmentUpdatePagePathData & {
+  selectedPeopleCard?: GovUkSummaryList
+  heading: PageHeader
+}
 
 export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContext = unknown> extends PageWithValidation<
   TBody,
@@ -17,21 +29,21 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
   protected abstract nextPage(form?: AppointmentOutcomeForm): AppointmentFormPage | undefined
 
   protected abstract backPage(
-    appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
     form?: AppointmentOutcomeForm,
   ): AppointmentFormPage | undefined
 
   protected abstract getForm(form: AppointmentOutcomeForm, query: TBody, context: TContext): AppointmentOutcomeForm
 
   exitForm(
-    appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
     project?: ProjectDto,
     originalSearch?: Record<string, string>,
   ): string {
     if (project?.projectType.group === 'GROUP') {
-      return SessionUtils.getSessionPath(appointmentOrSession, originalSearch)
+      return SessionUtils.getSessionPath(pathData, originalSearch)
     }
-    return pathWithQuery(paths.projects.show({ projectCode: appointmentOrSession.projectCode }), originalSearch)
+    return pathWithQuery(paths.projects.show({ projectCode: pathData.projectCode }), originalSearch)
   }
 
   next({
@@ -82,27 +94,27 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     return this.getForm(form, query, context)
   }
 
-  updatePath(appointmentOrSession: AppointmentOrSession, formId?: string) {
-    return this.buildPath(appointmentOrSession, this.page, formId)
+  updatePath(pathData: AppointmentOrSessionParams, formId?: string) {
+    return this.buildPath(pathData, this.page, formId)
   }
 
   protected isSingleAppointment = (appointmentOrSession: AppointmentOrSession) =>
     'deliusEventNumber' in appointmentOrSession
 
   protected backPath(
-    appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
     originalSearch?: Record<string, string>,
     project?: ProjectDto,
     formId?: string,
     form?: AppointmentOutcomeForm,
   ) {
-    const backPage = this.backPage(appointmentOrSession, form)
+    const backPage = this.backPage(pathData, form)
 
     if (!backPage) {
-      return this.exitForm(appointmentOrSession, project, originalSearch)
+      return this.exitForm(pathData, project, originalSearch)
     }
 
-    return this.buildPath(appointmentOrSession, backPage, formId, originalSearch)
+    return this.buildPath(pathData, backPage, formId, originalSearch)
   }
 
   commonViewData({
@@ -111,17 +123,17 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     project,
     form,
     formId,
+    pathData,
   }: {
     appointmentOrSession: AppointmentOrSession
     originalSearch?: Record<string, string>
     project?: ProjectDto
     form: AppointmentOutcomeForm
     formId?: string
-  }): AppointmentUpdatePageViewData {
-    const viewData: AppointmentUpdatePageViewData = {
-      backLink: this.backPath(appointmentOrSession, originalSearch, project, formId, form),
-      updatePath: this.updatePath(appointmentOrSession, formId),
-      form: formId,
+    pathData: AppointmentOrSessionParams
+  }): AppointmentUpdateViewData {
+    const viewData: AppointmentUpdateViewData = {
+      ...this.paths({ pathData, originalSearch, form, formId, project }),
       heading: this.buildHeading(appointmentOrSession),
     }
 
@@ -134,6 +146,26 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     }
 
     return viewData
+  }
+
+  paths({
+    pathData,
+    originalSearch,
+    form,
+    formId,
+    project,
+  }: {
+    pathData: AppointmentOrSessionParams
+    form: AppointmentOutcomeForm
+    originalSearch?: Record<string, string>
+    formId?: string
+    project?: ProjectDto
+  }): AppointmentUpdatePagePathData {
+    return {
+      backLink: this.backPath(pathData, originalSearch, project, formId, form),
+      updatePath: this.updatePath(pathData, formId),
+      form: formId,
+    }
   }
 
   private buildHeading(appointmentOrSession: AppointmentOrSession) {
@@ -156,17 +188,17 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
   }
 
   private buildPath(
-    appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
     page: AppointmentFormPage,
     formId?: string,
     originalSearch?: Record<string, string>,
   ): string {
-    if (this.isSingleAppointment(appointmentOrSession)) {
+    if (pathData.appointmentId) {
       return pathWithQuery(
         this.pathWithFormId(
           paths.appointments.update({
-            projectCode: appointmentOrSession.projectCode,
-            appointmentId: appointmentOrSession.id.toString(),
+            projectCode: pathData.projectCode,
+            appointmentId: pathData.appointmentId,
             page,
           }),
           formId,
@@ -178,8 +210,8 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     return pathWithQuery(
       this.pathWithFormId(
         paths.sessions.update({
-          projectCode: appointmentOrSession.projectCode,
-          date: appointmentOrSession.date,
+          projectCode: pathData.projectCode,
+          date: pathData.date,
           page,
         }),
         formId,

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -460,18 +460,20 @@ describe('CheckAppointmentDetailsPage', () => {
     })
 
     it('should return a back link to the session page for GROUP projects', async () => {
+      const pathData = { appointmentId: '1', projectCode: appointment.projectCode }
       const backLink = '/session/1'
       const originalSearch = { provider: 'provider' }
       jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
 
       const result = page.commonViewData({
+        pathData,
         appointmentOrSession: appointment,
-        project: projectFactory.build(),
+        project: projectFactory.build({ projectType: { group: 'GROUP' } }),
         originalSearch,
         form: {} as AppointmentOutcomeForm,
         formId: 'formId',
       })
-      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, originalSearch)
+      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(pathData, originalSearch)
       expect(result.backLink).toBe(backLink)
     })
 
@@ -483,6 +485,7 @@ describe('CheckAppointmentDetailsPage', () => {
       const search = { provider: 'provider' }
 
       const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
         appointmentOrSession: appointment,
         project,
         originalSearch: search,
@@ -496,6 +499,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
     it('should return an update path for the appointment details page', async () => {
       const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
         appointmentOrSession: appointment,
         project: projectFactory.build(),
         originalSearch: {},

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -13,6 +13,7 @@ import attendanceDataFactory from '../../testutils/factories/attendanceDataFacto
 import enforcementDataFactory from '../../testutils/factories/enforcementDataFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import HtmlUtils from '../../utils/htmlUtils'
+import { AppointmentOutcomeForm } from '../../@types/user-defined'
 
 describe('CheckAppointmentDetailsPage', () => {
   const pathWithQuery = '/path?'
@@ -53,7 +54,10 @@ describe('CheckAppointmentDetailsPage', () => {
         return pickUpTime
       })
 
-      const result = page.viewData({ appointment, project: projectDto, originalSearch: {} })
+      const result = page.viewData({
+        appointment,
+        project: projectDto,
+      })
 
       expect(result.projectItems).toEqual([
         { key: { text: 'Region' }, value: { text: projectDto.providerName } },
@@ -93,7 +97,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment: appointmentWithoutPickUp,
         project: projectDto,
-        originalSearch: {},
       })
 
       expect(result.projectItems).toEqual([
@@ -116,7 +119,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.appointmentItems).toEqual([
@@ -138,7 +140,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        originalSearch: {},
         contactOutcome,
       })
 
@@ -150,46 +151,6 @@ describe('CheckAppointmentDetailsPage', () => {
       expect(HtmlUtils.getStatusTagClass).toHaveBeenCalledWith(statusColour)
     })
 
-    it('should return an object containing a back link to the session page', async () => {
-      const backLink = '/session/1'
-      const originalSearch = { provider: 'provider' }
-      jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
-
-      const result = page.viewData({
-        appointment,
-        project: projectFactory.build(),
-        originalSearch,
-      })
-      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, originalSearch)
-      expect(result.backLink).toBe(backLink)
-    })
-
-    it('should return an object containing a back link to the project page if appointment type is INDIVIDUAL', async () => {
-      const backLink = '/project/1'
-      jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
-      const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
-      page = new CheckAppointmentDetailsPage()
-      const search = { provider: 'provider' }
-      const result = page.viewData({ appointment, project, originalSearch: search })
-      expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
-      expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, search)
-      expect(result.backLink).toBe(pathWithQuery)
-    })
-
-    it('should return an object containing an update link for the form', async () => {
-      const result = page.viewData({
-        appointment,
-        project: projectFactory.build(),
-        originalSearch: {},
-      })
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'appointment-details',
-      })
-      expect(result.updatePath).toBe(pathWithQuery)
-    })
-
     it('should return an object containing the next path', () => {
       const nextPath = '/appointments/choose-supervisor'
       jest.spyOn(paths.appointments, 'update').mockReturnValue(nextPath)
@@ -197,7 +158,6 @@ describe('CheckAppointmentDetailsPage', () => {
       const result = page.viewData({
         appointment,
         project: projectFactory.build(),
-        originalSearch: {},
       })
 
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -230,7 +190,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithAttendance,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.complianceItems).toEqual([
@@ -247,7 +206,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithoutAttendance,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.complianceItems).toEqual([])
@@ -271,7 +229,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithAllTimeValues,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.timeItems).toEqual([
@@ -295,7 +252,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithOnlyCredited,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.timeItems).toEqual([
@@ -318,7 +274,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithOnlyPenalty,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.timeItems).toEqual([
@@ -336,7 +291,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithNoTime,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.timeItems).toEqual([])
@@ -356,7 +310,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithoutAttendance,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.timeItems).toEqual([
@@ -380,7 +333,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithEnforcement,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.sharedItems).toEqual([
@@ -401,7 +353,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithoutEnforcement,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.sharedItems).toEqual([{ key: { text: 'Alert sent' }, value: { text: 'Yes' } }])
@@ -422,7 +373,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithPartialEnforcement,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.sharedItems).toEqual([
@@ -443,7 +393,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithNoAlert,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.sharedItems).toEqual([
@@ -460,7 +409,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithOutcome,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(result.showMissingOutcomeMessage).toBe(false)
@@ -473,7 +421,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithNoOutcome,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(DateTimeFormats.dateTimeIsInFuture).toHaveBeenCalledWith(
@@ -490,7 +437,6 @@ describe('CheckAppointmentDetailsPage', () => {
         const result = page.viewData({
           appointment: appointmentWithNoOutcome,
           project: projectFactory.build(),
-          originalSearch: {},
         })
 
         expect(DateTimeFormats.dateTimeIsInFuture).toHaveBeenCalledWith(
@@ -499,6 +445,69 @@ describe('CheckAppointmentDetailsPage', () => {
         )
         expect(result.showMissingOutcomeMessage).toBe(true)
       })
+    })
+  })
+
+  describe('commonViewData', () => {
+    let page: CheckAppointmentDetailsPage
+    let appointment: AppointmentDto
+    const updatePath = '/update'
+
+    beforeEach(() => {
+      page = new CheckAppointmentDetailsPage()
+      appointment = appointmentFactory.build({ sensitive: false })
+      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
+    })
+
+    it('should return a back link to the session page for GROUP projects', async () => {
+      const backLink = '/session/1'
+      const originalSearch = { provider: 'provider' }
+      jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
+
+      const result = page.commonViewData({
+        appointmentOrSession: appointment,
+        project: projectFactory.build(),
+        originalSearch,
+        form: {} as AppointmentOutcomeForm,
+        formId: 'formId',
+      })
+      expect(SessionUtils.getSessionPath).toHaveBeenCalledWith(appointment, originalSearch)
+      expect(result.backLink).toBe(backLink)
+    })
+
+    it('should return a back link to the project page for INDIVIDUAL projects', async () => {
+      const backLink = '/project/1'
+      jest.spyOn(paths.projects, 'show').mockReturnValue(backLink)
+      const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
+      page = new CheckAppointmentDetailsPage()
+      const search = { provider: 'provider' }
+
+      const result = page.commonViewData({
+        appointmentOrSession: appointment,
+        project,
+        originalSearch: search,
+        form: {} as AppointmentOutcomeForm,
+        formId: 'formId',
+      })
+      expect(paths.projects.show).toHaveBeenCalledWith({ projectCode: appointment.projectCode })
+      expect(Utils.pathWithQuery).toHaveBeenCalledWith(backLink, search)
+      expect(result.backLink).toBe(pathWithQuery)
+    })
+
+    it('should return an update path for the appointment details page', async () => {
+      const result = page.commonViewData({
+        appointmentOrSession: appointment,
+        project: projectFactory.build(),
+        originalSearch: {},
+        form: {} as AppointmentOutcomeForm,
+        formId: 'formId',
+      })
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'appointment-details',
+      })
+      expect(result.updatePath).toBe(pathWithQuery)
     })
   })
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -460,7 +460,7 @@ describe('CheckAppointmentDetailsPage', () => {
     })
 
     it('should return a back link to the session page for GROUP projects', async () => {
-      const pathData = { appointmentId: '1', projectCode: appointment.projectCode }
+      const pathData = { appointmentId: '1', projectCode: appointment.projectCode, date: '2026-01-20' }
       const backLink = '/session/1'
       const originalSearch = { provider: 'provider' }
       jest.spyOn(SessionUtils, 'getSessionPath').mockReturnValue(backLink)
@@ -485,7 +485,11 @@ describe('CheckAppointmentDetailsPage', () => {
       const search = { provider: 'provider' }
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         project,
         originalSearch: search,
@@ -499,7 +503,11 @@ describe('CheckAppointmentDetailsPage', () => {
 
     it('should return an update path for the appointment details page', async () => {
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         project: projectFactory.build(),
         originalSearch: {},

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -1,8 +1,7 @@
 import { AppointmentDto, ContactOutcomeDto, ProjectDto } from '../../@types/shared'
 import {
-  AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   GovUkSummaryListItem,
   ValidationErrors,
 } from '../../@types/user-defined'
@@ -191,7 +190,7 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
     return GovUKComponentUtils.buildSummaryListItems(items, true)
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined {
+  protected backPage(_params: AppointmentOrSessionParams): AppointmentFormPage | undefined {
     return undefined
   }
 

--- a/server/pages/appointments/checkAppointmentDetailsPage.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.ts
@@ -15,7 +15,7 @@ import { yesNoDisplayValue } from '../../utils/utils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
-interface ViewData extends AppointmentUpdatePageViewData {
+interface ViewData {
   projectItems: Array<GovUkSummaryListItem>
   showMissingOutcomeMessage: boolean
   appointmentItems: Array<GovUkSummaryListItem>
@@ -43,24 +43,15 @@ export default class CheckAppointmentDetailsPage extends BaseAppointmentUpdatePa
   viewData({
     appointment,
     project,
-    originalSearch,
     contactOutcome,
     formId,
   }: {
     appointment: AppointmentDto
     project: ProjectDto
-    originalSearch: Record<string, string>
     contactOutcome?: ContactOutcomeDto
     formId?: string
   }): ViewData {
     return {
-      ...this.commonViewData({
-        appointmentOrSession: appointment,
-        originalSearch,
-        project,
-        form: {} as AppointmentOutcomeForm,
-        formId,
-      }),
       projectItems: this.buildProjectDetails(project, appointment),
       appointmentItems: this.buildAppointmentDetails(appointment),
       complianceItems: this.buildComplianceDetails(appointment),

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -17,7 +17,12 @@ describe('ChooseProjectPage', () => {
       const form = appointmentOutcomeFormFactory.build()
       const page = new ChooseProjectPage()
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'F1' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'F1',
+      })
 
       expect(result.backLink).toBe(
         pathWithQuery(

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -18,7 +18,11 @@ describe('ChooseProjectPage', () => {
       const page = new ChooseProjectPage()
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'F1',

--- a/server/pages/appointments/chooseProjectPage.ts
+++ b/server/pages/appointments/chooseProjectPage.ts
@@ -1,5 +1,5 @@
 import {
-  AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   ValidationErrors,
@@ -18,7 +18,7 @@ export default class ChooseProjectPage extends BaseAppointmentUpdatePage<Query, 
     return 'attendance-outcome'
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage | undefined {
+  protected backPage(_params: AppointmentOrSessionParams): AppointmentFormPage | undefined {
     return 'choose-supervisor'
   }
 

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -161,7 +161,11 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',
@@ -179,7 +183,11 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -160,7 +160,12 @@ describe('ChooseSupervisorPage', () => {
     it('should return a back link to the appointment details page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -173,7 +178,12 @@ describe('ChooseSupervisorPage', () => {
     it('should return an update path for the choose supervisor page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.updatePath).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -184,12 +194,13 @@ describe('ChooseSupervisorPage', () => {
     })
 
     it('should use session paths when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const pathData = { projectCode: 'P123', date: '2026-06-10' }
+      const session = sessionFactory.build(pathData)
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -22,33 +22,24 @@ describe('ChooseSupervisorPage', () => {
 
   describe('viewData', () => {
     let page: ChooseSupervisorPage
-    let appointment: AppointmentDto
     let supervisors: SupervisorSummaryDto[]
     let form: AppointmentOutcomeForm
     let teams: ProviderTeamSummariesDto
     const updatePath = '/update'
 
     beforeEach(() => {
-      appointment = appointmentFactory.build()
       page = new ChooseSupervisorPage()
       supervisors = supervisorSummaryFactory.buildList(2)
-      form = appointmentOutcomeFormFactory.build()
+      form = appointmentOutcomeFormFactory.build({ supervisingTeam: { code: 'some-code' } })
       teams = { providers: providerTeamSummaryFactory.buildList(3) }
       jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
 
-    it('should return an object containing an update link for the form', async () => {
-      const result = page.viewData(appointment, teams, supervisors, form)
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'choose-supervisor',
-      })
-      expect(result.updatePath).toBe(pathWithQuery)
-    })
-
     it('should return an object containing supervisorItems', async () => {
-      form = appointmentOutcomeFormFactory.build({ supervisor: supervisorSummaryFactory.build({ code: undefined }) })
+      form = appointmentOutcomeFormFactory.build({
+        supervisor: supervisorSummaryFactory.build({ code: undefined }),
+        supervisingTeam: { code: 'code' },
+      })
       const supervisorItems = [
         { text: 'Gwen', value: '1 ' },
         { text: 'Harry', value: '2' },
@@ -57,7 +48,7 @@ describe('ChooseSupervisorPage', () => {
 
       page = new ChooseSupervisorPage()
 
-      const result = page.viewData(appointment, teams, supervisors, form, undefined, { team: '1234' })
+      const result = page.viewData(teams, supervisors, form, {})
 
       expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
@@ -72,7 +63,7 @@ describe('ChooseSupervisorPage', () => {
 
     it('should pass the supervisor to the select input options formatter if any value', async () => {
       const code = 'supervisor'
-      form = appointmentOutcomeFormFactory.build({ supervisor: { code } })
+      form = appointmentOutcomeFormFactory.build({ supervisor: { code }, supervisingTeam: { code } })
       const supervisorItems = [
         { text: 'Gwen', value: '1 ' },
         { text: 'Harry', value: '2' },
@@ -81,9 +72,9 @@ describe('ChooseSupervisorPage', () => {
 
       page = new ChooseSupervisorPage()
 
-      const result = page.viewData(appointmentFactory.build(), teams, supervisors, form, undefined, { team: '1234' })
+      const result = page.viewData(teams, supervisors, form, {})
 
-      expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
+      expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
         supervisors,
         'fullName',
         'code',
@@ -103,12 +94,12 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(GovUkSelectInput, 'getOptions').mockReturnValue(supervisorItems)
 
       page = new ChooseSupervisorPage()
-      const result = page.viewData(appointment, teams, supervisors, appointmentOutcomeFormFactory.build(), '1', {
+      const result = page.viewData(teams, supervisors, appointmentOutcomeFormFactory.build(), {
         supervisor,
         team: teams.providers[0].code,
       })
 
-      expect(GovUkSelectInput.getOptions).toHaveBeenCalledWith(
+      expect(GovUkSelectInput.getOptions).toHaveBeenLastCalledWith(
         supervisors,
         'fullName',
         'code',
@@ -130,7 +121,6 @@ describe('ChooseSupervisorPage', () => {
         },
       }))
 
-      const session = sessionFactory.build()
       const teamItems = [
         { text: 'Choose team', value: '' },
         { text: 'Team 1', value: 'T1' },
@@ -145,7 +135,61 @@ describe('ChooseSupervisorPage', () => {
 
       page = new ChooseSupervisorPage()
 
-      const result = page.viewData(session, teams, supervisors, form, undefined, { team: 'T1' })
+      const result = page.viewData(teams, supervisors, form, {})
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          teamItems,
+          supervisorItems,
+        }),
+      )
+    })
+  })
+
+  describe('commonViewData', () => {
+    let page: ChooseSupervisorPage
+    let appointment: AppointmentDto
+    let form: AppointmentOutcomeForm
+
+    beforeEach(() => {
+      page = new ChooseSupervisorPage()
+      appointment = appointmentFactory.build()
+      form = appointmentOutcomeFormFactory.build()
+    })
+
+    it('should return a back link to the appointment details page', () => {
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'appointment-details',
+      })
+    })
+
+    it('should return an update path for the choose supervisor page', () => {
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        appointmentId: appointment.id.toString(),
+        projectCode: appointment.projectCode,
+        page: 'choose-supervisor',
+      })
+    })
+
+    it('should use session paths when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,
@@ -157,15 +201,9 @@ describe('ChooseSupervisorPage', () => {
         date: session.date,
         page: 'select-people',
       })
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          backLink: pathWithQuery,
-          updatePath: pathWithQuery,
-          teamItems,
-          supervisorItems,
-        }),
-      )
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
     })
   })
 

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -2,7 +2,6 @@ import { ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/sha
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
   GovUkSelectOption,
   ValidationErrors,
@@ -11,7 +10,7 @@ import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
-interface ViewData extends AppointmentUpdatePageViewData {
+interface ViewData {
   teamItems: GovUkSelectOption[]
   supervisorItems: GovUkSelectOption[]
 }
@@ -49,18 +48,15 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<Supe
   }
 
   viewData(
-    appointmentOrSession: AppointmentOrSession,
     teams: ProviderTeamSummariesDto,
     supervisors: Array<SupervisorSummaryDto>,
     form: AppointmentOutcomeForm,
-    formId?: string,
-    query?: AppointmentDetailsQuery,
+    query: AppointmentDetailsQuery,
   ): ViewData {
     const teamCode = query?.team || form.supervisingTeam?.code
     const supervisorCode = query?.supervisor ?? form.supervisor?.code
 
     return {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
       teamItems: GovUkSelectInput.getOptions(teams.providers, 'name', 'code', 'Choose team', teamCode),
       supervisorItems: teamCode
         ? GovUkSelectInput.getOptions(supervisors, 'fullName', 'code', 'Choose supervisor', supervisorCode)

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -1,6 +1,6 @@
 import { ProviderTeamSummariesDto, SupervisorSummaryDto } from '../../@types/shared'
 import {
-  AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   GovUkSelectOption,
@@ -79,8 +79,8 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<Supe
     return errors
   }
 
-  protected backPage(appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
-    if (this.isSingleAppointment(appointmentOrSession)) {
+  protected backPage(params: AppointmentOrSessionParams): AppointmentFormPage {
+    if (params.appointmentId) {
       return 'appointment-details'
     }
     return 'select-people'

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -31,78 +31,6 @@ describe('ConfirmPage', () => {
       jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
     })
 
-    describe('back link', () => {
-      it('should return an object containing a back link to the compliance page if attended', async () => {
-        jest.spyOn(paths.appointments, 'update')
-        const formWithoutEnforcement = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: true }),
-        })
-
-        const result = page.viewData(appointment, formWithoutEnforcement)
-        expect(paths.appointments.update).toHaveBeenCalledWith({
-          projectCode: appointment.projectCode,
-          appointmentId: appointment.id.toString(),
-          page: 'log-compliance',
-        })
-        expect(result.backLink).toBe(pathWithQuery)
-      })
-
-      it('should return an object containing a back link to the attendance outcome page if did not attend', async () => {
-        jest.spyOn(paths.appointments, 'update')
-        const formWithoutEnforcement = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: false }),
-        })
-
-        const result = page.viewData(appointment, formWithoutEnforcement)
-        expect(paths.appointments.update).toHaveBeenCalledWith({
-          projectCode: appointment.projectCode,
-          appointmentId: appointment.id.toString(),
-          page: 'attendance-outcome',
-        })
-        expect(result.backLink).toBe(pathWithQuery)
-      })
-    })
-
-    it('should return an object containing an update link for the form', async () => {
-      jest.spyOn(paths.appointments, 'update')
-
-      const result = page.viewData(appointment, form)
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'confirm-details',
-      })
-      expect(result.updatePath).toBe(pathWithQuery)
-    })
-
-    it('should return expected commonViewData when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
-      const submitted = appointmentOutcomeFormFactory.build({
-        contactOutcome: contactOutcomeFactory.build({ attended: false }),
-      })
-
-      jest.spyOn(paths.sessions, 'update')
-      jest.spyOn(paths.appointments, 'update')
-
-      const result = page.viewData(session, submitted)
-
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'confirm-details',
-      })
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'attendance-outcome',
-      })
-      expect(paths.appointments.update).not.toHaveBeenCalled()
-
-      expect(result.backLink).toBe(pathWithQuery)
-      expect(result.updatePath).toBe(pathWithQuery)
-      expect(result.selectedPeopleCard).toBeUndefined()
-    })
-
     describe('alertPractitionerItems', () => {
       it('should return an object containing alert practitioner question items if contact outcome will alert', () => {
         form = appointmentOutcomeFormFactory.build({
@@ -615,6 +543,100 @@ describe('ConfirmPage', () => {
           }),
         )
       })
+    })
+  })
+
+  describe('commonViewData', () => {
+    let page: ConfirmPage
+    let appointment: AppointmentDto
+    let form: AppointmentOutcomeForm
+    const pathWithQuery = '/path?'
+
+    beforeEach(() => {
+      page = new ConfirmPage()
+      appointment = appointmentFactory.build({ sensitive: false })
+      form = appointmentOutcomeFormFactory.build()
+      jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
+    })
+
+    describe('back link', () => {
+      it('should return a back link to the log compliance page if attended', async () => {
+        jest.spyOn(paths.appointments, 'update')
+        const formWithAttendance = appointmentOutcomeFormFactory.build({
+          contactOutcome: contactOutcomeFactory.build({ attended: true }),
+        })
+
+        const result = page.commonViewData({
+          appointmentOrSession: appointment,
+          form: formWithAttendance,
+          formId: 'formId',
+        })
+        expect(paths.appointments.update).toHaveBeenCalledWith({
+          projectCode: appointment.projectCode,
+          appointmentId: appointment.id.toString(),
+          page: 'log-compliance',
+        })
+        expect(result.backLink).toBe(pathWithQuery)
+      })
+
+      it('should return a back link to the attendance outcome page if did not attend', async () => {
+        jest.spyOn(paths.appointments, 'update')
+        const formWithoutAttendance = appointmentOutcomeFormFactory.build({
+          contactOutcome: contactOutcomeFactory.build({ attended: false }),
+        })
+
+        const result = page.commonViewData({
+          appointmentOrSession: appointment,
+          form: formWithoutAttendance,
+          formId: 'formId',
+        })
+        expect(paths.appointments.update).toHaveBeenCalledWith({
+          projectCode: appointment.projectCode,
+          appointmentId: appointment.id.toString(),
+          page: 'attendance-outcome',
+        })
+        expect(result.backLink).toBe(pathWithQuery)
+      })
+    })
+
+    it('should return an update path for the confirm details page', async () => {
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'confirm-details',
+      })
+      expect(result.updatePath).toBe(pathWithQuery)
+    })
+
+    it('should use session paths when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: session, form: submitted, formId: 'formId' })
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'confirm-details',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'attendance-outcome',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(result.selectedPeopleCard).toBeUndefined()
     })
   })
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -567,7 +567,11 @@ describe('ConfirmPage', () => {
         })
 
         const result = page.commonViewData({
-          pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+          pathData: {
+            appointmentId: appointment.id.toString(),
+            projectCode: appointment.projectCode,
+            date: '2026-01-20',
+          },
           appointmentOrSession: appointment,
           form: formWithAttendance,
           formId: 'formId',
@@ -587,7 +591,11 @@ describe('ConfirmPage', () => {
         })
 
         const result = page.commonViewData({
-          pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+          pathData: {
+            appointmentId: appointment.id.toString(),
+            projectCode: appointment.projectCode,
+            date: '2026-01-20',
+          },
           appointmentOrSession: appointment,
           form: formWithoutAttendance,
           formId: 'formId',
@@ -605,7 +613,11 @@ describe('ConfirmPage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -567,6 +567,7 @@ describe('ConfirmPage', () => {
         })
 
         const result = page.commonViewData({
+          pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
           appointmentOrSession: appointment,
           form: formWithAttendance,
           formId: 'formId',
@@ -586,6 +587,7 @@ describe('ConfirmPage', () => {
         })
 
         const result = page.commonViewData({
+          pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
           appointmentOrSession: appointment,
           form: formWithoutAttendance,
           formId: 'formId',
@@ -602,7 +604,12 @@ describe('ConfirmPage', () => {
     it('should return an update path for the confirm details page', async () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
@@ -612,7 +619,8 @@ describe('ConfirmPage', () => {
     })
 
     it('should use session paths when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const pathData = { projectCode: 'P123', date: '2026-06-10' }
+      const session = sessionFactory.build(pathData)
       const submitted = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ attended: false }),
       })
@@ -620,7 +628,7 @@ describe('ConfirmPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: session, form: submitted, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: session, form: submitted, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,6 +1,7 @@
 import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   GovUkRadioOrCheckboxOption,
   GovUkSummaryListItem,
@@ -71,7 +72,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     return undefined
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession, form?: AppointmentOutcomeForm): AppointmentFormPage {
+  protected backPage(_params: AppointmentOrSessionParams, form?: AppointmentOutcomeForm): AppointmentFormPage {
     if (form && form.contactOutcome?.attended) {
       return 'log-compliance'
     }

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -2,7 +2,6 @@ import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   GovUkRadioOrCheckboxOption,
   GovUkSummaryListItem,
   ValidationErrors,
@@ -18,7 +17,7 @@ import NotesUtils from '../../utils/components/notesUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
-interface ViewData extends AppointmentUpdatePageViewData {
+interface ViewData {
   alertPractitionerItems: GovUkRadioOrCheckboxOption[]
   showWillAlertPractitionerMessage: boolean
   alertDiaryText: string
@@ -45,7 +44,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
 
     return {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
       submittedItems: this.formItems(form, appointmentOrSession, formId),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -134,7 +134,11 @@ describe('LogCompliancePage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',
@@ -152,7 +156,11 @@ describe('LogCompliancePage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -28,56 +28,6 @@ describe('LogCompliancePage', () => {
       form = appointmentOutcomeFormFactory.build()
     })
 
-    it('should return an object containing a back link to the session page', async () => {
-      const backLink = '/appointment/1'
-      jest.spyOn(paths.appointments, 'update').mockReturnValue(backLink)
-
-      const result = page.viewData(appointment, form)
-      expect(result.backLink).toBe(pathWithQuery)
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
-        appointmentId: appointment.id.toString(),
-        page: 'log-hours',
-      })
-    })
-
-    it('should return an object containing an update link for the form', async () => {
-      const updatePath = '/update'
-      jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
-
-      const result = page.viewData(appointment, form)
-      expect(paths.appointments.update).toHaveBeenCalledWith({
-        appointmentId: appointment.id.toString(),
-        projectCode: appointment.projectCode,
-        page: 'log-compliance',
-      })
-      expect(result.updatePath).toBe(pathWithQuery)
-    })
-
-    it('should return expected commonViewData when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
-
-      jest.spyOn(paths.sessions, 'update')
-      jest.spyOn(paths.appointments, 'update')
-
-      const result = page.viewData(session, form)
-
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'log-compliance',
-      })
-      expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
-        page: 'log-hours',
-      })
-      expect(paths.appointments.update).not.toHaveBeenCalled()
-
-      expect(result.backLink).toBe(pathWithQuery)
-      expect(result.updatePath).toBe(pathWithQuery)
-    })
-
     describe('items', () => {
       describe('workQuality', () => {
         it('should return items for workQuality without checked answer from form', async () => {
@@ -85,7 +35,7 @@ describe('LogCompliancePage', () => {
             attendanceData: attendanceDataFactory.build({ workQuality: null }),
           })
 
-          const result = page.viewData(appointment, form)
+          const result = page.viewData(form, {})
           expect(result.workQualityItems).toEqual([
             { text: 'Excellent', value: 'EXCELLENT', checked: false },
             { text: 'Good', value: 'GOOD', checked: false },
@@ -101,7 +51,7 @@ describe('LogCompliancePage', () => {
             attendanceData: attendanceDataFactory.build({ workQuality: 'GOOD' }),
           })
 
-          const result = page.viewData(appointment, form)
+          const result = page.viewData(form, {})
           expect(result.workQualityItems).toEqual([
             { text: 'Excellent', value: 'EXCELLENT', checked: false },
             { text: 'Good', value: 'GOOD', checked: true },
@@ -117,7 +67,7 @@ describe('LogCompliancePage', () => {
         it('should return items for behaviour without checked answer from form', async () => {
           form = appointmentOutcomeFormFactory.build({ attendanceData: { behaviour: null } })
 
-          const result = page.viewData(appointment, form)
+          const result = page.viewData(form, {})
           expect(result.behaviourItems).toEqual([
             { text: 'Excellent', value: 'EXCELLENT', checked: false },
             { text: 'Good', value: 'GOOD', checked: false },
@@ -133,7 +83,7 @@ describe('LogCompliancePage', () => {
             attendanceData: attendanceDataFactory.build({ behaviour: 'UNSATISFACTORY' }),
           })
 
-          const result = page.viewData(appointment, form)
+          const result = page.viewData(form)
           expect(result.behaviourItems).toEqual([
             { text: 'Excellent', value: 'EXCELLENT', checked: false },
             { text: 'Good', value: 'GOOD', checked: false },
@@ -145,7 +95,7 @@ describe('LogCompliancePage', () => {
         })
       })
 
-      it('should return items from form if page has errors', () => {
+      it('should return items from query if page has errors', () => {
         const formData = appointmentOutcomeFormFactory.build({
           attendanceData: {
             workQuality: 'POOR',
@@ -153,15 +103,7 @@ describe('LogCompliancePage', () => {
           },
         })
         page = new LogCompliancePage()
-        page.validationErrors({
-          behaviour: null,
-          workQuality: 'EXCELLENT',
-        })
-
-        const result = page.viewData(appointment, formData, undefined, {
-          behaviour: null,
-          workQuality: 'EXCELLENT',
-        })
+        const result = page.viewData(formData, { workQuality: 'EXCELLENT' })
 
         expect(result).toEqual(
           expect.objectContaining({
@@ -176,6 +118,65 @@ describe('LogCompliancePage', () => {
           }),
         )
       })
+    })
+  })
+
+  describe('commonViewData', () => {
+    let form: AppointmentOutcomeForm
+
+    beforeEach(() => {
+      page = new LogCompliancePage()
+      appointment = appointmentFactory.build()
+      form = appointmentOutcomeFormFactory.build()
+    })
+
+    it('should return a back link to the log hours page', () => {
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        projectCode: appointment.projectCode,
+        appointmentId: appointment.id.toString(),
+        page: 'log-hours',
+      })
+    })
+
+    it('should return an update path for the log compliance page', () => {
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.updatePath).toBe(pathWithQuery)
+      expect(paths.appointments.update).toHaveBeenCalledWith({
+        appointmentId: appointment.id.toString(),
+        projectCode: appointment.projectCode,
+        page: 'log-compliance',
+      })
+    })
+
+    it('should use session paths when appointmentOrSession is a session', () => {
+      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'log-compliance',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        projectCode: session.projectCode,
+        date: session.date,
+        page: 'log-hours',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(result.updatePath).toBe(pathWithQuery)
     })
   })
 

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -133,7 +133,12 @@ describe('LogCompliancePage', () => {
     it('should return a back link to the log hours page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -146,7 +151,12 @@ describe('LogCompliancePage', () => {
     it('should return an update path for the log compliance page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.updatePath).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -157,12 +167,13 @@ describe('LogCompliancePage', () => {
     })
 
     it('should use session paths when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const pathData = { projectCode: 'P123', date: '2026-06-10' }
+      const session = sessionFactory.build(pathData)
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -1,6 +1,6 @@
 import { AttendanceDataDto } from '../../@types/shared'
 import {
-  AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   GovUkRadioOrCheckboxOption,
@@ -61,7 +61,7 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage<Body> {
     return errors
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
+  protected backPage(_params: AppointmentOrSessionParams): AppointmentFormPage {
     return 'log-hours'
   }
 

--- a/server/pages/appointments/logCompliancePage.ts
+++ b/server/pages/appointments/logCompliancePage.ts
@@ -2,7 +2,6 @@ import { AttendanceDataDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
   GovUkRadioOrCheckboxOption,
   ValidationErrors,
@@ -10,7 +9,7 @@ import {
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
-interface ViewData extends AppointmentUpdatePageViewData {
+interface ViewData {
   workQualityItems: GovUkRadioOrCheckboxOption[]
   behaviourItems: GovUkRadioOrCheckboxOption[]
 }
@@ -40,15 +39,9 @@ export default class LogCompliancePage extends BaseAppointmentUpdatePage<Body> {
     }
   }
 
-  viewData(
-    appointmentOrSession: AppointmentOrSession,
-    form: AppointmentOutcomeForm,
-    formId?: string,
-    query?: LogComplianceQuery,
-  ): ViewData {
+  viewData(form: AppointmentOutcomeForm, query: LogComplianceQuery = {}): ViewData {
     const formValues = this.getFormDisplayValues(form, query)
     return {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
       workQualityItems: this.getItems(formValues.workQuality),
       behaviourItems: this.getItems(formValues.behaviour),
     }

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -108,19 +108,17 @@ describe('LogHoursPage', () => {
   })
 
   describe('viewData', () => {
-    let appointment: AppointmentDto
     let form: AppointmentOutcomeForm
     const updatePath = '/update'
 
     beforeEach(() => {
       page = new LogHoursPage()
-      appointment = appointmentFactory.build()
       form = appointmentOutcomeFormFactory.build({ contactOutcome: contactOutcomeFactory.build({ attended: true }) })
       jest.spyOn(paths.appointments, 'update').mockReturnValue(updatePath)
     })
 
     it('should return an object containing start time and end time', () => {
-      const result = page.viewData(appointment, form)
+      const result = page.viewData(form)
       expect(result).toEqual(
         expect.objectContaining({
           startTime: form.startTime,
@@ -136,7 +134,7 @@ describe('LogHoursPage', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
 
-      const result = page.viewData(appointment, updatedForm)
+      const result = page.viewData(updatedForm)
       expect(result).toEqual(
         expect.objectContaining({
           startTime: updatedForm.startTime,
@@ -152,7 +150,7 @@ describe('LogHoursPage', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
 
-      const result = page.viewData(appointment, updatedForm)
+      const result = page.viewData(updatedForm)
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -161,37 +159,51 @@ describe('LogHoursPage', () => {
         }),
       )
     })
+  })
 
-    it('should return an object containing a back link to the attendance outcome page', async () => {
+  describe('commonViewData', () => {
+    let appointment: AppointmentDto
+    let form: AppointmentOutcomeForm
+
+    beforeEach(() => {
+      page = new LogHoursPage()
+      appointment = appointmentFactory.build()
+      form = appointmentOutcomeFormFactory.build({ contactOutcome: contactOutcomeFactory.build({ attended: true }) })
+    })
+
+    it('should return a back link to the attendance outcome page', () => {
       jest.spyOn(paths.appointments, 'update')
-      const result = page.viewData(appointment, form)
 
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.backLink).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
         projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
         page: 'attendance-outcome',
       })
-      expect(result.backLink).toBe(pathWithQuery)
     })
 
-    it('should return the update path for the page', () => {
+    it('should return an update path for the log hours page', () => {
       jest.spyOn(paths.appointments, 'update')
-      const result = page.viewData(appointment, form)
+
+      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+
+      expect(result.updatePath).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
-        projectCode: appointment.projectCode,
         appointmentId: appointment.id.toString(),
+        projectCode: appointment.projectCode,
         page: 'log-hours',
       })
-      expect(result.updatePath).toBe(pathWithQuery)
     })
 
-    it('should return expected commonViewData when appointmentOrSession is a session', () => {
+    it('should use session paths when appointmentOrSession is a session', () => {
       const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.viewData(session, form)
+      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,
@@ -204,7 +216,6 @@ describe('LogHoursPage', () => {
         page: 'attendance-outcome',
       })
       expect(paths.appointments.update).not.toHaveBeenCalled()
-
       expect(result.backLink).toBe(pathWithQuery)
       expect(result.updatePath).toBe(pathWithQuery)
     })

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -174,7 +174,12 @@ describe('LogHoursPage', () => {
     it('should return a back link to the attendance outcome page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.backLink).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -187,7 +192,12 @@ describe('LogHoursPage', () => {
     it('should return an update path for the log hours page', () => {
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: appointment, form, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        appointmentOrSession: appointment,
+        form,
+        formId: 'formId',
+      })
 
       expect(result.updatePath).toBe(pathWithQuery)
       expect(paths.appointments.update).toHaveBeenCalledWith({
@@ -198,12 +208,13 @@ describe('LogHoursPage', () => {
     })
 
     it('should use session paths when appointmentOrSession is a session', () => {
-      const session = sessionFactory.build({ projectCode: 'P123', date: '2026-06-10' })
+      const pathData = { projectCode: 'P123', date: '2026-06-10' }
+      const session = sessionFactory.build(pathData)
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -175,7 +175,11 @@ describe('LogHoursPage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',
@@ -193,7 +197,11 @@ describe('LogHoursPage', () => {
       jest.spyOn(paths.appointments, 'update')
 
       const result = page.commonViewData({
-        pathData: { appointmentId: appointment.id.toString(), projectCode: appointment.projectCode },
+        pathData: {
+          appointmentId: appointment.id.toString(),
+          projectCode: appointment.projectCode,
+          date: '2026-01-20',
+        },
         appointmentOrSession: appointment,
         form,
         formId: 'formId',

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -1,7 +1,6 @@
 import {
   AppointmentOrSession,
   AppointmentOutcomeForm,
-  AppointmentUpdatePageViewData,
   AppointmentUpdateQuery,
   ValidationErrors,
 } from '../../@types/user-defined'
@@ -9,7 +8,7 @@ import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentFormPage } from './pathMap'
 
-interface ViewData extends AppointmentUpdatePageViewData {
+interface ViewData {
   startTime: string
   endTime: string
 }
@@ -59,14 +58,8 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage<LogHoursBody
     return errors
   }
 
-  viewData(
-    appointmentOrSession: AppointmentOrSession,
-    form: AppointmentOutcomeForm,
-    formId?: string,
-    query: LogHoursQuery = {},
-  ): ViewData {
+  viewData(form: AppointmentOutcomeForm, query: LogHoursQuery = {}): ViewData {
     return {
-      ...this.commonViewData({ appointmentOrSession, form, formId }),
       startTime: query.startTime ?? (form.startTime ? DateTimeFormats.stripTime(form.startTime) : ''),
       endTime: query.endTime ?? (form.endTime ? DateTimeFormats.stripTime(form.endTime) : ''),
     }

--- a/server/pages/appointments/logHoursPage.ts
+++ b/server/pages/appointments/logHoursPage.ts
@@ -1,5 +1,5 @@
 import {
-  AppointmentOrSession,
+  AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
   ValidationErrors,
@@ -65,7 +65,7 @@ export default class LogHoursPage extends BaseAppointmentUpdatePage<LogHoursBody
     }
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentFormPage {
+  protected backPage(_params: AppointmentOrSessionParams): AppointmentFormPage {
     return 'attendance-outcome'
   }
 

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -74,6 +74,7 @@ describe('AppointmentFormService', () => {
           code: project.teamCode,
           name: project.teamName,
         },
+        date: appointment.date,
       }
 
       expect(formClient.save).toHaveBeenCalledWith(
@@ -93,8 +94,9 @@ describe('AppointmentFormService', () => {
       const user = 'some-user'
       const query = { provider: 'provider-code', team: 'team-code' }
       const project = projectFactory.build()
+      const date = '2026-01-01'
 
-      const result = await appointmentFormService.createBulkForm(project, user, query)
+      const result = await appointmentFormService.createBulkForm(project, date, user, query)
 
       const expectedForm = {
         originalSearch: query,
@@ -103,6 +105,7 @@ describe('AppointmentFormService', () => {
           name: project.teamName,
         },
         project: { code: project.projectCode, name: project.projectName },
+        date,
       }
 
       expect(formClient.save).toHaveBeenCalledWith(

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -22,13 +22,19 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
     super(formClient, APPOINTMENT_UPDATE_FORM_TYPE)
   }
 
-  async createBulkForm(project: ProjectDto, username: string, query: Record<string, string>): Promise<Form> {
+  async createBulkForm(
+    project: ProjectDto,
+    date: string,
+    username: string,
+    query: Record<string, string>,
+  ): Promise<Form> {
     const form = {
       key: this.getFormKey(randomUUID()),
       data: {
         originalSearch: query,
         projectTeam: { code: project.teamCode, name: project.teamName },
         project: { code: project.projectCode, name: project.projectName },
+        date,
       },
     }
 
@@ -63,6 +69,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
         originalSearch: query,
         projectTeam: { code: project.teamCode, name: project.teamName },
         project: { code: project.projectCode, name: project.projectName },
+        date: appointment.date,
       },
     }
 

--- a/server/testutils/factories/appointmentOutcomeFormFactory.ts
+++ b/server/testutils/factories/appointmentOutcomeFormFactory.ts
@@ -28,5 +28,6 @@ export default Factory.define<AppointmentOutcomeForm>(
       appointments: selectedAppointmentFactory.buildList(1),
       projectTeam: providerTeamSummaryFactory.build(),
       project: { code: faker.string.alphanumeric(8), name: faker.company.name() },
+      date: faker.date.recent().toISOString().split('T')[0],
     }) satisfies AppointmentOutcomeForm,
 )

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -374,6 +374,14 @@ describe('SessionUtils', () => {
       expect(path).toBe(`/sessions/${appointment.projectCode}/${appointment.date}`)
     })
 
+    it('returns expected path given an AppointmentOrSessionParams object', () => {
+      const params = { projectCode: 'PROJ1', date: '2026-07-20' }
+      const path = SessionUtils.getSessionPath(params, {})
+
+      expect(paths.sessions.show).toHaveBeenCalledWith({ projectCode: params.projectCode, date: params.date })
+      expect(path).toBe(`/sessions/${params.projectCode}/${params.date}`)
+    })
+
     it('returns expected path when query parameter is not provided', () => {
       const session = sessionSummaryFactory.build()
       const path = SessionUtils.getSessionPath(session)

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -3,7 +3,12 @@ import Offender from '../models/offender'
 import paths from '../paths'
 import DateTimeFormats from './dateTimeUtils'
 import HtmlUtils from './htmlUtils'
-import { AppointmentOutcomeForm, GovUkSummaryList, GovUKValue } from '../@types/user-defined'
+import {
+  AppointmentOrSessionParams,
+  AppointmentOutcomeForm,
+  GovUkSummaryList,
+  GovUKValue,
+} from '../@types/user-defined'
 import { pathWithQuery } from './utils'
 import { GroupSessionIndexPageInput } from '../pages/groupSessionIndexPage'
 import AppointmentUtils from './appointmentUtils'
@@ -56,7 +61,10 @@ export default class SessionUtils {
   }
 
   static getSessionPath(
-    appointmentOrSession: SessionSummaryDto | SessionDto | AppointmentDto,
+    appointmentOrSession: Pick<
+      SessionSummaryDto | SessionDto | AppointmentDto | AppointmentOrSessionParams,
+      'date' | 'projectCode'
+    >,
     query?: Record<string, string>,
   ) {
     const { date, projectCode } = appointmentOrSession


### PR DESCRIPTION
## Context

We currently use a appointment or session object to determine the next and previous paths to render in an appointment form page template.

This updates that logic by instead passing the current path params - in order to make way for new appointments, where we won't have an existing object.

Also, remove the need for an appointment object in the validation for attendance outcomes - by saving date to the form object. We will be introducing a date question, so it is relevant to save this value anyway.

This is preparing for work to introduce a Create an appointment journey: [CPB-1124](https://dsdmoj.atlassian.net/browse/CPB-1124)

## Changes in this PR

- Decouple page and common data view methods, and move these to the common controller methods
- Update path building methods to take `pathData` object matching the existing path params
- Introduce dedicated paths method to fetch paths for each form step, which can be used for create appointment

### Screenshots of UI changes

N/A

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1124]: https://dsdmoj.atlassian.net/browse/CPB-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ