### PR TITLE
Surface 400 errors on bulk update

### DIFF
--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -238,4 +238,18 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       )
     })
   })
+
+  it('with API error response => stays on page and shows error message', function test() {
+    const userMessage = 'Invalid bulk appointment update data'
+
+    cy.task('stubBulkUpdateAppointmentOutcomeWithError', {
+      projectCode: this.project.projectCode,
+      userMessage,
+    })
+
+    const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+    page.clickSubmit('Confirm')
+
+    page.shouldShowErrorSummary(userMessage)
+  })
 })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -912,6 +912,49 @@ describe('ConfirmController', () => {
           )
           expect(response.redirect).toHaveBeenCalledWith(nextPath)
         })
+
+        it('calls catchApiValidationErrorOrPropagate when saveAppointment throws a SanitisedError', async () => {
+          jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+          const error: SanitisedError = {
+            name: 'SanitisedError',
+            message: 'API error',
+            responseStatus: 400,
+            data: {
+              userMessage: 'An error occurred',
+              developerMessage: 'Developer message',
+              status: 400,
+            },
+          }
+
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              isAlertSelected: () => true,
+              updatePath: () => '/update/path',
+            }
+          })
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointment = appointmentFactory.build({ version: appointmentVersion })
+          const contactOutcome = contactOutcomeFactory.build({ attended: true })
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome,
+            deliusVersion: formAppointmentVersion,
+          })
+
+          appointmentService.getAppointment.mockResolvedValue(appointment)
+          appointmentFormService.getForm.mockResolvedValue(form)
+          appointmentService.saveAppointment.mockRejectedValue(error)
+
+          const requestHandler = confirmController.submit()
+          await requestHandler(request, response, next)
+
+          expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
+            request,
+            response,
+            error,
+            '/update/path',
+          )
+        })
       })
     })
   })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -129,27 +129,36 @@ export default class ConfirmController implements IFormPageController {
           }),
         )
 
-        const result = await this.appointmentService.saveAppointments(
-          project.projectCode,
-          { updates },
-          res.locals.user.username,
-        )
+        try {
+          const result = await this.appointmentService.saveAppointments(
+            project.projectCode,
+            { updates },
+            res.locals.user.username,
+          )
 
-        if (result.results.every(appointmentResult => appointmentResult.result === 'SUCCESS')) {
-          let message = 'Attendance recorded for all selected people'
-          if (project.projectCode !== form.project.code) {
-            message = this.changedProjectMessage(message, form.project, appointmentOrSessionParams.date)
+          if (result.results.every(appointmentResult => appointmentResult.result === 'SUCCESS')) {
+            let message = 'Attendance recorded for all selected people'
+            if (project.projectCode !== form.project.code) {
+              message = this.changedProjectMessage(message, form.project, appointmentOrSessionParams.date)
+            }
+
+            _req.flash('success', message)
+          } else {
+            _req.flash(
+              'error',
+              'Some information could not be bulk updated. Update the missing attendance outcomes individually',
+            )
           }
 
-          _req.flash('success', message)
-        } else {
-          _req.flash(
-            'error',
-            'Some information could not be bulk updated. Update the missing attendance outcomes individually',
+          return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
+        } catch (error) {
+          return catchApiValidationErrorOrPropagate(
+            _req,
+            res,
+            error,
+            page.updatePath(appointmentOrSessionParams, formId),
           )
         }
-
-        return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
       }
     }
   }


### PR DESCRIPTION
We have a try catch statement to surface any validation errors on saving data to users. We previously removed this for bulk update as we were not expecting 400 responses on this endpoint (as we had to handle a list of different responses). 

However, this has changed and we now expect some validation errors for the whole group.

This reinstates handling of 400 validation errors on this endpoint.

We may want to consider moving surfacing of 400 errors on post requests to middleware at some point (or as an option on the router)

### Screenshots of UI changes

<img width="1544" height="964" alt="Appointment form confirm page with validation message" src="https://github.com/user-attachments/assets/482a4bd5-4bcc-4fa0-ae41-88914d074fdd" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
