### PR TITLE
CPB-1124: Handle undefined appointments

### DIFF
--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -9,6 +9,7 @@ import AttendanceOutcomePage from '../../pages/appointments/attendanceOutcomePag
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import SessionService from '../../services/sessionService'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 
 jest.mock('../../pages/appointments/attendanceOutcomePage')
 
@@ -17,7 +18,7 @@ describe('AttendanceOutcomeController', () => {
   const appointmentId = '1'
   const contactOutcomes = contactOutcomesFactory.build()
 
-  const request = createMock<Request>({ params: { appointmentId }, query: { form: 'some-id' } })
+  const request = createMock<Request>({ params: { appointmentId }, query: { form: 'some-id' }, body: undefined })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
@@ -38,6 +39,8 @@ describe('AttendanceOutcomeController', () => {
     viewData: jest.Mock
     next: jest.Mock
     updateForm: jest.Mock
+    offenderHeading: jest.Mock
+    paths: jest.Mock
   }
 
   beforeEach(() => {
@@ -53,6 +56,8 @@ describe('AttendanceOutcomeController', () => {
       viewData: jest.fn().mockReturnValue(pageViewData),
       next: jest.fn(),
       updateForm: jest.fn(),
+      offenderHeading: jest.fn().mockReturnValue({ title: 'Some Name', caption: 'X123456' }),
+      paths: jest.fn().mockReturnValue({}),
     }
 
     attendanceOutcomePageMock.mockReturnValue(mockPageInstance)
@@ -75,6 +80,57 @@ describe('AttendanceOutcomeController', () => {
         'appointments/update/attendanceOutcome',
         expect.objectContaining(pageViewData),
       )
+    })
+
+    describe('given a single appointment route', () => {
+      it('should pass the appointment to page.viewData with isSingleAppointment true', async () => {
+        const appointment = appointmentFactory.build()
+        const form = appointmentOutcomeFormFactory.build()
+
+        appointmentService.getAppointment.mockResolvedValue(appointment)
+        referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
+        formService.getForm.mockResolvedValue(form)
+
+        const requestHandler = controller.show()
+        await requestHandler(request, response, next)
+
+        expect(mockPageInstance.viewData).toHaveBeenCalledWith(
+          appointment,
+          form,
+          contactOutcomes.contactOutcomes,
+          undefined,
+          true,
+        )
+      })
+    })
+
+    describe('given a session (bulk) route', () => {
+      const sessionDate = '2026-06-01'
+      const bulkRequest = createMock<Request>({
+        params: { projectCode: '2', date: sessionDate },
+        query: { form: 'some-id' },
+        body: {},
+      })
+
+      it('should pass undefined instead of the session to page.viewData, with isSingleAppointment false', async () => {
+        const session = sessionFactory.build({ date: sessionDate })
+        const form = appointmentOutcomeFormFactory.build()
+
+        sessionService.getSession.mockResolvedValue(session)
+        referenceDataService.getAvailableContactOutcomes.mockResolvedValue(contactOutcomes)
+        formService.getForm.mockResolvedValue(form)
+
+        const requestHandler = controller.show()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(mockPageInstance.viewData).toHaveBeenCalledWith(
+          undefined,
+          form,
+          contactOutcomes.contactOutcomes,
+          {},
+          false,
+        )
+      })
     })
   })
 

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -12,6 +12,7 @@ import BaseAppointmentController, {
   ContextDataParams,
 } from './baseAppointmentController'
 import { AppointmentOutcomeForm } from '../../@types/user-defined'
+import { AppointmentDto } from '../../@types/shared'
 
 export default class AttendanceOutcomeController extends BaseAppointmentController<AttendanceOutcomePage> {
   constructor(
@@ -37,11 +38,13 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
     form,
     req,
     contextData,
+    isSingleAppointment,
   }: AppointmentStepViewDataParams): Promise<object> {
     const { contactOutcomes } = contextData as AttendanceOutcomeContext
-    const query = (req.method === 'GET' ? req.query : req.body) as Record<string, unknown>
-
-    return this.page.viewData(appointmentOrSession, form, contactOutcomes, query as AttendanceOutcomeBody)
+    const query = req.body as Record<string, unknown>
+    const appointment =
+      appointmentOrSession && isSingleAppointment ? (appointmentOrSession as AppointmentDto) : undefined
+    return this.page.viewData(appointment, form, contactOutcomes, query as AttendanceOutcomeBody, isSingleAppointment)
   }
 
   protected async getUpdatedForm(

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -20,6 +20,7 @@ export type AppointmentStepViewDataParams = {
   formId?: string
   errors: ValidationErrors<unknown>
   contextData?: unknown
+  isSingleAppointment: boolean
 }
 
 export type ContextDataParams = {
@@ -64,6 +65,7 @@ export default abstract class BaseAppointmentController<
           formId,
           errors: {},
           contextData,
+          isSingleAppointment: this.isSingleAppointment(appointmentOrSessionParams),
         })),
       }
 
@@ -99,6 +101,7 @@ export default abstract class BaseAppointmentController<
             formId,
             errors,
             contextData,
+            isSingleAppointment: this.isSingleAppointment(appointmentOrSessionParams),
           })),
           errorSummary,
           errors,
@@ -139,4 +142,8 @@ export default abstract class BaseAppointmentController<
   }
 
   protected abstract getTemplatePath(): string
+
+  private isSingleAppointment(params: AppointmentOrSessionParams): boolean {
+    return !params.date
+  }
 }

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -39,7 +39,7 @@ export default class ConfirmController implements IFormPageController {
 
       res.render('appointments/update/confirm', {
         ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
-        ...page.viewData(appointmentOrSession, form, formId),
+        ...page.viewData(appointmentOrSession, pathData, form, formId),
         errorList,
         preventDoubleClick,
       })

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -297,7 +297,7 @@ describe('AttendanceOutcomePage', () => {
       }
       jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
 
-      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, {} as AttendanceOutcomeBody)
+      const result = page.viewData(appointment, formWithOutcomes, contactOutcomes, {} as AttendanceOutcomeBody, true)
 
       expect(NotesUtils.questionItems).toHaveBeenCalledWith({}, formWithOutcomes, appointment, true)
 
@@ -309,74 +309,6 @@ describe('AttendanceOutcomePage', () => {
       })
     })
 
-    describe('given a session', () => {
-      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
-      const offender = {
-        name: 'Sam Smith',
-        crn: 'CRN123',
-        isLimited: false,
-        details: {
-          description: 'description',
-        },
-      }
-      beforeEach(() => {
-        offenderMock.mockImplementation(() => offender)
-      })
-
-      it('returns view data for a session', () => {
-        const session = sessionFactory.build()
-        const form = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ code: contactOutcomes[1].code }),
-        })
-        const notesItems = { notes: 'Test notes', showIsSensitiveQuestion: false }
-
-        jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
-
-        const page = new AttendanceOutcomePage()
-
-        const result = page.viewData(session, form, contactOutcomes, {} as AttendanceOutcomeBody)
-
-        const expectedItems = [
-          {
-            text: contactOutcomes[0].name,
-            value: contactOutcomes[0].code,
-            checked: false,
-          },
-          {
-            text: contactOutcomes[1].name,
-            value: contactOutcomes[1].code,
-            checked: true,
-          },
-          {
-            text: contactOutcomes[2].name,
-            value: contactOutcomes[2].code,
-            checked: false,
-          },
-        ]
-
-        expect(result).toEqual(
-          expect.objectContaining({
-            ...notesItems,
-            items: expectedItems,
-          }),
-        )
-      })
-
-      it('passes undefined appointment to questionItems when appointmentOrSession is a session', () => {
-        const session = sessionFactory.build()
-        const form = appointmentOutcomeFormFactory.build()
-        const notesItems = { notes: 'some note', showIsSensitiveQuestion: false }
-        const questionItemsSpy = jest.spyOn(NotesUtils, 'questionItems').mockReturnValue(notesItems)
-
-        const page = new AttendanceOutcomePage()
-
-        const viewData = page.viewData(session, form, contactOutcomes, {} as AttendanceOutcomeBody)
-
-        expect(questionItemsSpy).toHaveBeenCalledWith({}, form, undefined, false)
-        expect(viewData).toEqual(expect.objectContaining(notesItems))
-      })
-    })
-
     describe('items', () => {
       it('should map contact outcome value as selected if no errors', () => {
         const form = appointmentOutcomeFormFactory.build({
@@ -384,7 +316,7 @@ describe('AttendanceOutcomePage', () => {
         })
         const page = new AttendanceOutcomePage()
 
-        const result = page.viewData(appointment, form, contactOutcomes, {} as AttendanceOutcomeBody)
+        const result = page.viewData(appointment, form, contactOutcomes, {} as AttendanceOutcomeBody, true)
 
         const expectedItems = [
           {
@@ -418,6 +350,7 @@ describe('AttendanceOutcomePage', () => {
           appointmentOutcomeFormFactory.build(),
           [hintedOutcome],
           {} as AttendanceOutcomeBody,
+          true,
         )
 
         expect(result.items[0]).toEqual({
@@ -435,7 +368,7 @@ describe('AttendanceOutcomePage', () => {
         const page = new AttendanceOutcomePage()
 
         const form = appointmentOutcomeFormFactory.build()
-        const result = page.viewData(appointment, form, contactOutcomes, query)
+        const result = page.viewData(appointment, form, contactOutcomes, query, true)
 
         const expectedItems = [
           {
@@ -472,6 +405,7 @@ describe('AttendanceOutcomePage', () => {
           appointmentOutcomeFormFactory.build(),
           contactOutcomes,
           {} as AttendanceOutcomeBody,
+          true,
         )
 
         const expectedItems = [

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -1,5 +1,4 @@
 import {
-  AppointmentOrSession,
   AppointmentOrSessionParams,
   AppointmentOutcomeForm,
   AppointmentUpdateQuery,
@@ -83,15 +82,14 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
   }
 
   viewData(
-    appointmentOrSession: AppointmentOrSession,
+    appointment: AppointmentDto | undefined,
     form: AppointmentOutcomeForm,
     contactOutcomes: ContactOutcomeDto[],
-    query: AttendanceOutcomeBody,
+    query: AttendanceOutcomeBody | undefined,
+    isSingleAppointment: boolean,
   ): ViewData {
-    const isSingleAppointment = this.isSingleAppointment(appointmentOrSession)
-    const appointment = isSingleAppointment ? (appointmentOrSession as AppointmentDto) : undefined
     return {
-      ...NotesUtils.questionItems(query, form, appointment, isSingleAppointment),
+      ...NotesUtils.questionItems(query ?? {}, form, appointment, isSingleAppointment),
       items: this.items(form, contactOutcomes, query),
     }
   }

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -193,7 +193,7 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     return pathWithQuery(path, { form: formId })
   }
 
-  private buildPath(
+  protected buildPath(
     pathData: AppointmentOrSessionParams,
     page: AppointmentFormPage,
     formId?: string,

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -38,7 +38,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData(appointment, form)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -48,7 +48,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData(appointment, form)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -62,7 +62,7 @@ describe('ConfirmPage', () => {
 
         const determineCheckedValueSpy = jest.spyOn(GovUkRadioGroup, 'determineCheckedValue')
 
-        const result = page.viewData(session, formWithSession)
+        const result = page.viewData(session, { projectCode: 'XY', date: '2026-01-02' }, formWithSession)
 
         expect(determineCheckedValueSpy).toHaveBeenCalledWith(undefined)
         expect(result.alertPractitionerItems).toEqual(items)
@@ -74,7 +74,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: true },
         })
-        const result = page.viewData(appointment, form)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertDiaryText).toContain('also')
       })
 
@@ -82,7 +82,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: false },
         })
-        const result = page.viewData(appointment, form)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertDiaryText).not.toContain('also')
       })
     })
@@ -91,7 +91,7 @@ describe('ConfirmPage', () => {
       form = appointmentOutcomeFormFactory.build({
         contactOutcome: { code: 'some-code', willAlertEnforcementDiary: value },
       })
-      const result = page.viewData(appointment, form)
+      const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
       expect(result.showWillAlertPractitionerMessage).toEqual(value)
     })
 
@@ -112,7 +112,7 @@ describe('ConfirmPage', () => {
           notes,
           isSensitive: undefined,
         })
-        const result = page.viewData(appointment, submitted)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
         expect(result.submittedItems).toEqual([
           {
             key: {
@@ -227,7 +227,7 @@ describe('ConfirmPage', () => {
         const submitted = appointmentOutcomeFormFactory.build({
           contactOutcome,
         })
-        const result = page.viewData(appointment, submitted)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
             key: {
@@ -255,7 +255,7 @@ describe('ConfirmPage', () => {
           contactOutcome,
         })
 
-        const result = page.viewData(appointment, submitted)
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
 
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
@@ -328,7 +328,7 @@ describe('ConfirmPage', () => {
           contactOutcome,
           attendanceData: { workQuality: 'GOOD', behaviour: 'NOT_APPLICABLE' },
         })
-        const result = page.viewData(appointment, submitted).submittedItems
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted).submittedItems
 
         expect(result).toContainEqual({
           key: {
@@ -355,7 +355,7 @@ describe('ConfirmPage', () => {
           contactOutcome,
           notes: 'test',
         })
-        const result = page.viewData(appointment, submitted).submittedItems
+        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted).submittedItems
 
         expect(result).toContainEqual({
           key: {
@@ -402,7 +402,8 @@ describe('ConfirmPage', () => {
           ],
         })
 
-        const result = page.viewData(session, submitted)
+        const pathData = { projectCode: 'XY', date: '2026-01-01' }
+        const result = page.viewData(session, pathData, submitted)
         const expectedPeople = 'Sam Jones (CRN002) <br/>Alex Smith (CRN001)'
 
         expect(result.submittedItems).toEqual([
@@ -511,13 +512,11 @@ describe('ConfirmPage', () => {
         ])
 
         expect(paths.sessions.update).toHaveBeenCalledWith({
-          projectCode: session.projectCode,
-          date: session.date,
+          ...pathData,
           page: 'choose-supervisor',
         })
         expect(paths.sessions.update).toHaveBeenCalledWith({
-          projectCode: session.projectCode,
-          date: session.date,
+          ...pathData,
           page: 'attendance-outcome',
         })
         expect(paths.appointments.update).not.toHaveBeenCalled()
@@ -534,7 +533,7 @@ describe('ConfirmPage', () => {
           ],
         })
 
-        const result = page.viewData(session, submitted)
+        const result = page.viewData(session, { projectCode: '', date: '' }, submitted)
 
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -12,6 +12,7 @@ import projectFactory from '../../testutils/factories/projectFactory'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 import appointmentSummaryFactory from '../../testutils/factories/appointmentSummaryFactory'
+import NotesUtils from '../../utils/components/notesUtils'
 
 describe('ConfirmPage', () => {
   beforeEach(() => {
@@ -66,6 +67,15 @@ describe('ConfirmPage', () => {
 
         expect(determineCheckedValueSpy).toHaveBeenCalledWith(undefined)
         expect(result.alertPractitionerItems).toEqual(items)
+      })
+
+      it('should call yesNoItems with undefined checked value when appointmentOrSession is undefined', () => {
+        const yesNoItemsSpy = jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue([])
+        jest.spyOn(GovUkRadioGroup, 'determineCheckedValue').mockReturnValue(undefined)
+
+        page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, form)
+
+        expect(yesNoItemsSpy).toHaveBeenCalledWith({ checkedValue: undefined })
       })
     })
 
@@ -541,6 +551,23 @@ describe('ConfirmPage', () => {
             value: { html: '' },
           }),
         )
+      })
+
+      it('should return an empty array from buildOffenderItem when appointmentOrSession is undefined', () => {
+        const submitted = appointmentOutcomeFormFactory.build()
+
+        const result = page.buildOffenderItem(submitted, undefined, { projectCode: 'XY', appointmentId: '1' }, '')
+
+        expect(result).toEqual([])
+      })
+
+      it('should pass undefined appointment  when appointmentOrSession is undefined', () => {
+        const checkYourAnswersRowsSpy = jest.spyOn(NotesUtils, 'checkYourAnswersRows').mockReturnValue([])
+        const submitted = appointmentOutcomeFormFactory.build()
+
+        page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, submitted)
+
+        expect(checkYourAnswersRowsSpy).toHaveBeenCalledWith(submitted, expect.any(String), undefined, true)
       })
     })
   })

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -40,12 +40,17 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     return {}
   }
 
-  viewData(appointmentOrSession: AppointmentOrSession, form: AppointmentOutcomeForm, formId?: string): ViewData {
+  viewData(
+    appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
+    form: AppointmentOutcomeForm,
+    formId?: string,
+  ): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
     const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
 
     return {
-      submittedItems: this.formItems(form, appointmentOrSession, formId),
+      submittedItems: this.formItems(form, pathData, appointmentOrSession, formId),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({
         checkedValue: GovUkRadioGroup.determineCheckedValue(alertValue),
@@ -95,12 +100,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
 
   private formItems(
     form: AppointmentOutcomeForm,
+    pathData: AppointmentOrSessionParams,
     appointment: AppointmentOrSession,
     formId: string,
   ): GovUkSummaryListItem[] {
     const isSingleAppointment = this.isSingleAppointment(appointment)
     const items = [
-      ...this.buildOffenderItem(form, appointment, formId),
+      ...this.buildOffenderItem(form, appointment, pathData, formId),
       {
         key: {
           text: 'Supervising officer',
@@ -111,7 +117,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-supervisor', formId),
+              href: this.buildPath(pathData, 'choose-supervisor', formId),
               text: 'Change',
               visuallyHiddenText: 'supervising officer',
             },
@@ -128,7 +134,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-project', formId),
+              href: this.buildPath(pathData, 'choose-project', formId),
               text: 'Change',
               visuallyHiddenText: 'project team',
             },
@@ -145,7 +151,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'choose-project', formId),
+              href: this.buildPath(pathData, 'choose-project', formId),
               text: 'Change',
               visuallyHiddenText: 'project',
             },
@@ -160,7 +166,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         actions: {
           items: [
             {
-              href: this.changePath(appointment, 'attendance-outcome', formId),
+              href: this.buildPath(pathData, 'attendance-outcome', formId),
               text: 'Change',
               visuallyHiddenText: 'attendance outcome',
             },
@@ -182,7 +188,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
             actions: {
               items: [
                 {
-                  href: this.changePath(appointment, 'log-hours', formId),
+                  href: this.buildPath(pathData, 'log-hours', formId),
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
                 },
@@ -199,7 +205,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
             actions: {
               items: [
                 {
-                  href: this.changePath(appointment, 'log-compliance', formId),
+                  href: this.buildPath(pathData, 'log-compliance', formId),
                   text: 'Change',
                   visuallyHiddenText: 'compliance',
                 },
@@ -213,7 +219,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     items.push(
       ...NotesUtils.checkYourAnswersRows(
         form,
-        this.changePath(appointment, 'attendance-outcome', formId),
+        this.buildPath(pathData, 'attendance-outcome', formId),
         isSingleAppointment ? appointment : undefined,
         isSingleAppointment,
       ),
@@ -235,6 +241,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
   buildOffenderItem(
     form: AppointmentOutcomeForm,
     appointmentOrSession: AppointmentOrSession,
+    pathData: AppointmentOrSessionParams,
     formId: string,
   ): Array<GovUkSummaryListItem> {
     if (this.isSingleAppointment(appointmentOrSession)) {
@@ -266,7 +273,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         actions: {
           items: [
             {
-              href: this.changePath(appointmentOrSession, 'select-people', formId),
+              href: this.buildPath(pathData, 'select-people', formId),
               text: 'Change',
               visuallyHiddenText: 'people',
             },
@@ -274,28 +281,6 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
         },
       },
     ]
-  }
-
-  private changePath(appointmentOrSession: AppointmentOrSession, page: AppointmentFormPage, formId: string) {
-    if ('deliusEventNumber' in appointmentOrSession) {
-      return this.pathWithFormId(
-        paths.appointments.update({
-          projectCode: appointmentOrSession.projectCode,
-          appointmentId: appointmentOrSession.id.toString(),
-          page,
-        }),
-        formId,
-      )
-    }
-
-    return this.pathWithFormId(
-      paths.sessions.update({
-        projectCode: appointmentOrSession.projectCode,
-        date: appointmentOrSession.date,
-        page,
-      }),
-      formId,
-    )
   }
 
   getComplianceAnswers(form: AppointmentOutcomeForm): string {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -10,7 +10,6 @@ import {
 } from '../../@types/user-defined'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import Offender from '../../models/offender'
-import paths from '../../paths'
 import AppointmentUtils from '../../utils/appointmentUtils'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import HtmlUtils from '../../utils/htmlUtils'
@@ -41,13 +40,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
   }
 
   viewData(
-    appointmentOrSession: AppointmentOrSession,
+    appointmentOrSession: AppointmentOrSession | undefined,
     pathData: AppointmentOrSessionParams,
     form: AppointmentOutcomeForm,
     formId?: string,
   ): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
-    const alertValue = this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
+    const alertValue = this.appointmentAlertValue(appointmentOrSession)
 
     return {
       submittedItems: this.formItems(form, pathData, appointmentOrSession, formId),
@@ -57,6 +56,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
       }),
       alertDiaryText: `Would you ${showWillAlertPractitionerMessage ? 'also' : ''} like this to be sent to the alert diary?`,
     }
+  }
+
+  private appointmentAlertValue(appointmentOrSession: AppointmentOrSession | undefined) {
+    if (!appointmentOrSession) {
+      return undefined
+    }
+    return this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
   }
 
   isAlertSelected(query: Query): boolean | null {
@@ -101,12 +107,12 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
   private formItems(
     form: AppointmentOutcomeForm,
     pathData: AppointmentOrSessionParams,
-    appointment: AppointmentOrSession,
-    formId: string,
+    appointmentOrSession: AppointmentOrSession | undefined,
+    formId?: string,
   ): GovUkSummaryListItem[] {
-    const isSingleAppointment = this.isSingleAppointment(appointment)
+    const isSession = appointmentOrSession !== undefined && 'appointmentSummaries' in appointmentOrSession
     const items = [
-      ...this.buildOffenderItem(form, appointment, pathData, formId),
+      ...this.buildOffenderItem(form, appointmentOrSession, pathData, formId),
       {
         key: {
           text: 'Supervising officer',
@@ -216,12 +222,17 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
       )
     }
 
+    const appointment =
+      appointmentOrSession !== undefined && this.isSingleAppointment(appointmentOrSession)
+        ? appointmentOrSession
+        : undefined
+
     items.push(
       ...NotesUtils.checkYourAnswersRows(
         form,
         this.buildPath(pathData, 'attendance-outcome', formId),
-        isSingleAppointment ? appointment : undefined,
-        isSingleAppointment,
+        appointment,
+        !isSession,
       ),
     )
 
@@ -240,11 +251,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
 
   buildOffenderItem(
     form: AppointmentOutcomeForm,
-    appointmentOrSession: AppointmentOrSession,
+    appointmentOrSession: AppointmentOrSession | undefined,
     pathData: AppointmentOrSessionParams,
     formId: string,
   ): Array<GovUkSummaryListItem> {
-    if (this.isSingleAppointment(appointmentOrSession)) {
+    if (!appointmentOrSession || this.isSingleAppointment(appointmentOrSession)) {
       return []
     }
 


### PR DESCRIPTION
## Context

In #668 I removed the dependency on an appointment or session object when navigating through the appointment journey, so that we can introduce a journey to create a new appointment using the same page models.

This handles the outstanding cases where an appointment or session is expected on single pages:

- attendance outcome page (to determine whether an appointment was previously marked as sensitive)
- confirm page:
  - to build change links
  - to determine whether the appointment was previously marked as sensitive

[CPB-1124](https://dsdmoj.atlassian.net/browse/CPB-1124)

## Changes in this PR

- Remove logic to calculate whether an update is single or multiple from the attendance outcome page, and instead pass from the controller, so that the page only needs to handle a possibly undefined appointment object
- Use `pathData` object and existing shared `buildPath` method to build change links
- Handle undefined in offender section and notes questions

### Screenshots of UI changes

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1124]: https://dsdmoj.atlassian.net/browse/CPB-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ