### PR TITLE
CPB-760: Dynamically resolve course completion queue URL for e2e tests

### DIFF
--- a/e2e-tests/steps/sendCourseCompletionMessage.ts
+++ b/e2e-tests/steps/sendCourseCompletionMessage.ts
@@ -1,7 +1,7 @@
 import request from 'superagent'
 import { faker } from '@faker-js/faker'
 import { randomUUID } from 'node:crypto'
-import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
+import { GetQueueUrlCommand, SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
 import { Team } from '../fixtures/testOptions'
 import PersonOnProbation from '../delius/personOnProbation'
 import { EteCourseCompletionEventDto } from '../../server/@types/shared'
@@ -87,12 +87,16 @@ export default async ({
         secretAccessKey: 'doesntmatterforlocalstack',
       },
     })
+    const { QueueUrl: queueUrl } = await sqsClient.send(
+      new GetQueueUrlCommand({ QueueName: 'cp_stack_course_completion_events' }),
+    )
+
     const payload = CourseCompletionMessageBuilder.toSqsMessage(messageContent)
 
     await sqsClient.send(
       new SendMessageCommand({
         MessageBody: payload,
-        QueueUrl: 'http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/cp_stack_course_completion_events',
+        QueueUrl: queueUrl,
       }),
     )
   }


### PR DESCRIPTION
## Context

The cp-stack script is moving away from LocalStack to Floci, which changes how SQS queues are assigned URLs when they get created.

See https://github.com/ministryofjustice/hmpps-community-payback-api/pull/756

## Changes in this PR

To make sending a course completion implementation agnostic, the `SqsClient` is first sent a `GetQueueUrl` command in order to get the correct URL for the `cp_stack_course_completion_events` queue, and then this is used when sending the message to the queue using the `SendMessageCommand`.

### Screenshots of UI changes

No visual changes have been introduced.

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
