### PR TITLE
CPB-1144: Handle submit of new appointments

### DIFF
--- a/integration_tests/mockApis/appointments.ts
+++ b/integration_tests/mockApis/appointments.ts
@@ -52,6 +52,37 @@ export default {
     })
   },
 
+  stubCreateAppointment: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPath: paths.appointments.create.pattern,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    })
+  },
+
+  stubCreateAppointmentWithError: ({ userMessage }: { userMessage: string }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPath: paths.appointments.create.pattern,
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          status: 400,
+          userMessage,
+          developerMessage: 'Bad request',
+        },
+      },
+    })
+  },
+
   stubUpdateAppointmentOutcome: ({ appointment }: { appointment: AppointmentDto }): SuperAgentRequest => {
     const pattern = paths.appointments.outcome({
       projectCode: appointment.projectCode,

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -28,7 +28,13 @@
 //    When I click the date change link
 //    Then I see the date page with the entered date
 
-// Scenario: submitting a new appointment
+// Scenario: submitting a new appointment - attended
+//    Given I am on the confirm page for a new appointment
+//    When I click confirm
+//    Then the appointment is created
+//    And I see the session page with a success message
+
+// Scenario: submitting a new appointment - not attended
 //    Given I am on the confirm page for a new appointment
 //    When I click confirm
 //    Then the appointment is created
@@ -358,6 +364,35 @@ context('Create appointment - Confirm details', () => {
         crn: this.offender.crn,
         project: { code: this.project.projectCode, name: this.project.projectName },
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubFindProject', { project: this.project })
+      cy.task('stubCreateAppointment')
+
+      const session = sessionFactory.build({
+        date: form.date,
+        projectCode: this.project.projectCode,
+        projectName: this.project.projectName,
+      })
+      cy.task('stubFindSession', { session })
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I click confirm
+      page.clickSubmit('Confirm')
+
+      // Then the appointment is created
+      // And I see the session page with a success message
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
+      viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+    })
+
+    it('creates the appointment for a non-attended outcome and shows the session page with a success message', function test() {
+      const form = createAppointmentFormFactory.build({
+        crn: this.offender.crn,
+        project: { code: this.project.projectCode, name: this.project.projectName },
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
       })
       cy.task('stubGetAppointmentForm', form)
       cy.task('stubFindProject', { project: this.project })

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -28,8 +28,17 @@
 //    When I click the date change link
 //    Then I see the date page with the entered date
 
-// Note: submitting the create-appointment confirm page is not yet implemented, so those
-// scenarios are intentionally excluded from this suite.
+// Scenario: submitting a new appointment
+//    Given I am on the confirm page for a new appointment
+//    When I click confirm
+//    Then the appointment is created
+//    And I see the session page with a success message
+
+// Scenario: submitting a new appointment that fails validation
+//    Given I am on the confirm page for a new appointment
+//    And the API returns a 400 error
+//    When I click confirm
+//    Then I see the error message
 
 import attendanceDataFactory from '../../../../server/testutils/factories/attendanceDataFactory'
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
@@ -41,6 +50,7 @@ import createAppointmentFormFactory from '../../../../server/testutils/factories
 import offenderFullFactory from '../../../../server/testutils/factories/offenderFullFactory'
 import projectFactory from '../../../../server/testutils/factories/projectFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
 import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
 import ChooseProjectPage from '../../../pages/appointments/chooseProjectPage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
@@ -49,6 +59,7 @@ import DatePage from '../../../pages/appointments/datePage'
 import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
 import Page from '../../../pages/page'
+import ViewSessionPage from '../../../pages/viewSessionPage'
 
 context('Create appointment - Confirm details', () => {
   beforeEach(() => {
@@ -337,6 +348,62 @@ context('Create appointment - Confirm details', () => {
       // Then I see the date page with the entered date
       const datePage = Page.verifyOnPage(DatePage, { offender: this.offender })
       datePage.shouldHaveValue('18/09/2025')
+    })
+  })
+
+  describe('submitting the appointment', function describe() {
+    // Scenario: submitting a new appointment
+    it('creates the appointment for an attended outcome and shows the session page with a success message', function test() {
+      const form = createAppointmentFormFactory.build({
+        crn: this.offender.crn,
+        project: { code: this.project.projectCode, name: this.project.projectName },
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubFindProject', { project: this.project })
+      cy.task('stubCreateAppointment')
+
+      const session = sessionFactory.build({
+        date: form.date,
+        projectCode: this.project.projectCode,
+        projectName: this.project.projectName,
+      })
+      cy.task('stubFindSession', { session })
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I click confirm
+      page.clickSubmit('Confirm')
+
+      // Then the appointment is created
+      // And I see the session page with a success message
+      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
+      viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+    })
+
+    // Scenario: submitting a new appointment that fails validation
+    it('shows an error message when submission fails with a 400 error', function test() {
+      const form = createAppointmentFormFactory.build({
+        crn: this.offender.crn,
+        project: { code: this.project.projectCode, name: this.project.projectName },
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubFindProject', { project: this.project })
+
+      // And the API returns a 400 error
+      const userMessage = 'Invalid appointment data'
+      cy.task('stubCreateAppointmentWithError', { userMessage })
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I click confirm
+      page.clickSubmit('Confirm')
+
+      // Then I see the error message
+      page.shouldShowErrorSummary(userMessage)
     })
   })
 })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -18,6 +18,7 @@ import HtmlUtils from '../../utils/htmlUtils'
 import paths from '../../paths'
 import OffenderService from '../../services/offenderService'
 import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
+import createAppointmentFormFactory from '../../testutils/factories/createAppointmentFormFactory'
 
 jest.mock('../../pages/appointments/confirmPage')
 
@@ -185,6 +186,216 @@ describe('ConfirmController', () => {
       expect(responseWithErrors.render).toHaveBeenCalledWith(
         'appointments/update/confirm',
         expect.objectContaining({ errorList: expectedErrorList }),
+      )
+    })
+  })
+
+  describe('submitCreate', () => {
+    it('should create appointment data and redirect to checkAppointmentDetails page', async () => {
+      const project = projectFactory.build({ projectCode })
+      const nextPath = 'next'
+      const exitFormSpy = jest.fn().mockReturnValue(nextPath)
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          exitForm: exitFormSpy,
+          isAlertSelected: () => true,
+        }
+      })
+
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const requestWithNewAppointment = createMock<Request>({
+        params: { projectCode },
+        query: { form: formId },
+        flash: jest.fn(),
+      })
+
+      const form = createAppointmentFormFactory.build({
+        project: { code: projectCode, name: 'Project name' },
+        date: '2026-06-09',
+        requirement: '1001',
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+        originalSearch: { provider: 'provider' },
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = confirmController.submitCreate()
+      await requestHandler(requestWithNewAppointment, response, next)
+
+      expect(appointmentService.createAppointment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          crn: form.crn,
+          deliusEventNumber: 1001,
+          projectCode,
+          date: form.date,
+          startTime: form.startTime,
+          endTime: form.endTime,
+          contactOutcomeCode: form.contactOutcome.code,
+          attendanceData: form.attendanceData,
+          supervisorOfficerCode: form.supervisor.code,
+          alertActive: true,
+        }),
+        'user-name',
+      )
+      expect(exitFormSpy).toHaveBeenCalledWith(
+        { projectCode, appointmentId: 'create', date: form.date },
+        project,
+        form.originalSearch,
+      )
+      expect(response.redirect).toHaveBeenCalledWith(nextPath)
+      expect(requestWithNewAppointment.flash).toHaveBeenCalledWith('success', 'Attendance recorded')
+    })
+
+    it('should create appointment data without attendance data if did not attend', async () => {
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          exitForm: () => 'next',
+          isAlertSelected: () => true,
+        }
+      })
+
+      const project = projectFactory.build({ projectCode })
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const requestWithNewAppointment = createMock<Request>({
+        params: { projectCode },
+        query: { form: formId },
+        flash: jest.fn(),
+      })
+
+      const form = createAppointmentFormFactory.build({
+        project: { code: projectCode, name: 'Project name' },
+        date: '2026-06-09',
+        deliusEventNumber: '1001',
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = confirmController.submitCreate()
+      await requestHandler(requestWithNewAppointment, response, next)
+
+      expect(appointmentService.createAppointment).toHaveBeenCalledWith(
+        expect.objectContaining({ attendanceData: undefined }),
+        'user-name',
+      )
+    })
+
+    it('should set the audit subject to the CRN', async () => {
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          exitForm: () => 'next',
+          isAlertSelected: () => true,
+        }
+      })
+
+      const project = projectFactory.build({ projectCode })
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const requestWithNewAppointment = createMock<Request>({
+        params: { projectCode },
+        query: { form: formId },
+        flash: jest.fn(),
+      })
+
+      const form = createAppointmentFormFactory.build({
+        project: { code: projectCode, name: 'Project name' },
+        date: '2026-06-09',
+        deliusEventNumber: '1001',
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = confirmController.submitCreate()
+      await requestHandler(requestWithNewAppointment, response, next)
+
+      expect(response.locals.audit).toEqual({ subjectType: 'CRN', subjectId: form.crn })
+    })
+
+    it.each([true, false])('uses the alert value selected by the user', async (userSelectedValue: boolean) => {
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          exitForm: () => 'next',
+          isAlertSelected: () => userSelectedValue,
+        }
+      })
+
+      const project = projectFactory.build({ projectCode })
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const requestWithNewAppointment = createMock<Request>({
+        params: { projectCode },
+        query: { form: formId },
+        flash: jest.fn(),
+      })
+
+      const form = createAppointmentFormFactory.build({
+        project: { code: projectCode, name: 'Project name' },
+        date: '2026-06-09',
+        deliusEventNumber: '1001',
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      appointmentFormService.getForm.mockResolvedValue(form)
+
+      const requestHandler = confirmController.submitCreate()
+      await requestHandler(requestWithNewAppointment, response, next)
+
+      expect(appointmentService.createAppointment).toHaveBeenCalledWith(
+        expect.objectContaining({ alertActive: userSelectedValue }),
+        'user-name',
+      )
+    })
+
+    it('calls catchApiValidationErrorOrPropagate when createAppointment throws a SanitisedError', async () => {
+      jest.spyOn(ErrorUtils, 'catchApiValidationErrorOrPropagate')
+      const error: SanitisedError = {
+        name: 'SanitisedError',
+        message: 'API error',
+        responseStatus: 400,
+        data: {
+          userMessage: 'An error occurred',
+          developerMessage: 'Developer message',
+          status: 400,
+        },
+      }
+
+      confirmPageMock.mockImplementationOnce(() => {
+        return {
+          isAlertSelected: () => true,
+          updatePath: () => '/update/path',
+        }
+      })
+
+      const project = projectFactory.build({ projectCode })
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const requestWithNewAppointment = createMock<Request>({
+        params: { projectCode },
+        query: { form: formId },
+        flash: jest.fn(),
+      })
+
+      const form = createAppointmentFormFactory.build({
+        project: { code: projectCode, name: 'Project name' },
+        date: '2026-06-09',
+        deliusEventNumber: '1001',
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      appointmentFormService.getForm.mockResolvedValue(form)
+      appointmentService.createAppointment.mockRejectedValue(error)
+
+      const requestHandler = confirmController.submitCreate()
+      await requestHandler(requestWithNewAppointment, response, next)
+
+      expect(ErrorUtils.catchApiValidationErrorOrPropagate).toHaveBeenCalledWith(
+        requestWithNewAppointment,
+        response,
+        error,
+        '/update/path',
       )
     })
   })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { Request, RequestHandler, Response } from 'express'
 import AppointmentService from '../../services/appointmentService'
 import AppointmentFormService, {
   AppointmentOutcomeForm,
@@ -87,8 +87,55 @@ export default class ConfirmController implements IAppointmentFormPageController
   }
 
   submitCreate(): RequestHandler {
-    return async (_req: Request, _res: Response, next: NextFunction) => {
-      return next()
+    return async (req: Request, res: Response) => {
+      const formId = req.query.form?.toString()
+      const form = (await this.appointmentFormService.getForm(
+        formId,
+        res.locals.user.username,
+      )) as CreateAppointmentForm
+
+      const appointmentParams = {
+        projectCode: req.params.projectCode.toString(),
+        appointmentId: 'create',
+        date: form.date,
+      }
+
+      const page = new ConfirmPage()
+
+      const project = await this.projectService.getProject({
+        username: res.locals.user.username,
+        projectCode: appointmentParams.projectCode,
+      })
+
+      const didAttend = form.contactOutcome.attended
+
+      const payload = {
+        ...NotesUtils.requestBody(form, undefined, true),
+        alertActive: page.isAlertSelected(req.body),
+        startTime: form.startTime,
+        endTime: form.endTime,
+        contactOutcomeCode: form.contactOutcome.code,
+        attendanceData: didAttend ? form.attendanceData : undefined,
+        supervisorOfficerCode: form.supervisor.code,
+        date: form.date,
+        crn: form.crn,
+        deliusEventNumber: Number(form.requirement),
+        projectCode: form.project.code,
+      }
+
+      try {
+        await this.appointmentService.createAppointment(payload, res.locals.user.username)
+
+        res.locals.audit = {
+          subjectType: 'CRN',
+          subjectId: form.crn,
+        }
+
+        req.flash('success', 'Attendance recorded')
+        return res.redirect(page.exitForm(appointmentParams, project, form.originalSearch))
+      } catch (error) {
+        return catchApiValidationErrorOrPropagate(req, res, error, page.updatePath(appointmentParams, formId))
+      }
     }
   }
 

--- a/server/data/appointmentClient.test.ts
+++ b/server/data/appointmentClient.test.ts
@@ -8,6 +8,7 @@ import updateAppointmentOutcomeFactory from '../testutils/factories/updateAppoin
 import pagedModelAppointmentSummaryFactory from '../testutils/factories/pagedModelAppointmentSummaryFactory'
 import pagedModelAppointmentTaskSummaryFactory from '../testutils/factories/pagedModelAppointmentTaskSummaryFactory'
 import updateAppointmentOutcomeResultFactory from '../testutils/factories/updateAppointmentOutcomeResultFactory'
+import createAppointmentFactory from '../testutils/factories/createAppointmentFactory'
 
 describe('appointmentClient', () => {
   let appointmentClient: AppointmentClient
@@ -90,6 +91,21 @@ describe('appointmentClient', () => {
       const response = await appointmentClient.bulkUpdate('some-user-name', projectCode, { updates })
 
       expect(response).toEqual({ results })
+    })
+  })
+
+  describe('create', () => {
+    it('should make a POST request to the appointment create path using user token', async () => {
+      const data = createAppointmentFactory.build()
+
+      nock(config.apis.communityPaybackApi.url)
+        .post(paths.appointments.create({}), data)
+        .matchHeader('authorization', 'Bearer test-system-token')
+        .reply(200)
+
+      const response = await appointmentClient.create('some-user-name', data)
+
+      expect(response).toBeTruthy()
     })
   })
 

--- a/server/data/appointmentClient.ts
+++ b/server/data/appointmentClient.ts
@@ -4,6 +4,7 @@ import logger from '../../logger'
 import paths from '../paths/api'
 import { AppointmentDto } from '../@types/shared/models/AppointmentDto'
 import {
+  CreateAppointmentDto,
   PagedModelAppointmentSummaryDto,
   PagedModelAppointmentTaskSummaryDto,
   ProjectTypeDto,
@@ -55,6 +56,11 @@ export default class AppointmentClient extends RestClient {
   ): Promise<UpdateAppointmentsOutcomesResultDto> {
     const path = paths.appointments.bulkUpdate({ projectCode })
     return this.put({ path, data }, asSystem(username))
+  }
+
+  create(username: string, data: CreateAppointmentDto): Promise<void> {
+    const path = paths.appointments.create({})
+    return this.post({ path, data }, asSystem(username))
   }
 
   async getAppointmentTasks(params: GetAppointmentTasksRequest): Promise<PagedModelAppointmentTaskSummaryDto> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -16,6 +16,7 @@ const offenderPath = adminUiPath.path('/offenders/:crn')
 
 export default {
   appointments: {
+    create: adminUiPath.path('appointments'),
     filter: adminUiPath.path('appointments'),
     singleAppointment: projectAppointmentsPath.path(':appointmentId'),
     outcome: projectAppointmentsPath.path(':appointmentId'),

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -5,6 +5,7 @@ import pagedModelAppointmentSummaryFactory from '../testutils/factories/pagedMod
 import pagedModelAppointmentTaskSummaryFactory from '../testutils/factories/pagedModelAppointmentTaskSummaryFactory'
 import updateAppointmentOutcomeFactory from '../testutils/factories/updateAppointmentOutcomeFactory'
 import updateAppointmentOutcomeResultFactory from '../testutils/factories/updateAppointmentOutcomeResultFactory'
+import createAppointmentFactory from '../testutils/factories/createAppointmentFactory'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import AppointmentService from './appointmentService'
 
@@ -59,6 +60,14 @@ describe('AppointmentService', () => {
 
     expect(appointmentClient.bulkUpdate).toHaveBeenCalledWith('some-username', '1', { updates })
     expect(result).toEqual({ results })
+  })
+
+  it('should call createAppointment on the api client', async () => {
+    const appointmentData = createAppointmentFactory.build()
+
+    await appointmentService.createAppointment(appointmentData, 'some-username')
+
+    expect(appointmentClient.create).toHaveBeenCalledWith('some-username', appointmentData)
   })
 
   describe('getProjectAppointmentsWithMissingOutcomes', () => {

--- a/server/services/appointmentService.ts
+++ b/server/services/appointmentService.ts
@@ -1,5 +1,6 @@
 import {
   AppointmentDto,
+  CreateAppointmentDto,
   PagedModelAppointmentSummaryDto,
   PagedModelAppointmentTaskSummaryDto,
   UpdateAppointmentOutcomeDto,
@@ -36,6 +37,10 @@ export default class AppointmentService {
     username: string,
   ): Promise<UpdateAppointmentsOutcomesResultDto> {
     return this.appointmentClient.bulkUpdate(username, projectCode, appointmentsToUpdate)
+  }
+
+  createAppointment(appointmentData: CreateAppointmentDto, username: string): Promise<void> {
+    return this.appointmentClient.create(username, appointmentData)
   }
 
   async getProjectAppointmentsWithMissingOutcomes({

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -138,6 +138,8 @@ describe('AppointmentFormService', () => {
         projectTeam: { code: project.teamCode, name: project.teamName },
         project: { code: project.projectCode, name: project.projectName },
         date,
+        startTime: project.availability[0].startTime,
+        endTime: project.availability[0].endTime,
       }
 
       expect(formClient.save).toHaveBeenCalledWith(

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -127,6 +127,8 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
       key: this.getFormKey(randomUUID()),
       data: {
         ...this.projectData(project),
+        startTime: project.availability[0].startTime,
+        endTime: project.availability[0].endTime,
         originalSearch: query,
         crn,
         requirement,

--- a/server/testutils/factories/createAppointmentFactory.ts
+++ b/server/testutils/factories/createAppointmentFactory.ts
@@ -1,0 +1,15 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { CreateAppointmentDto } from '../../@types/shared'
+
+export default Factory.define<CreateAppointmentDto>(
+  () =>
+    ({
+      crn: faker.string.alphanumeric(7),
+      deliusEventNumber: faker.number.int({ min: 1, max: 1000 }),
+      projectCode: faker.string.alpha(8),
+      date: faker.date.recent().toISOString().slice(0, 10),
+      startTime: '09:00',
+      endTime: '10:00',
+    }) satisfies CreateAppointmentDto,
+)


### PR DESCRIPTION
> [!IMPORTANT]
> The commit on populating times needs further consideration, see commit msg for details

## Context

This implements the submit of new appointments

[CPB-1144](https://dsdmoj.atlassian.net/browse/CPB-1144)

### Notes

I had discussed with Dhruv that we could populate the start and end times with the project availability (as in delius). However, wee do need to consider how this works when the user changes the project selection in the form. For now I have set this at form creation, but we could consider moving this to the submit of project.



### Screenshots of UI changes

Submitting a new appointment with attended outcome:


https://github.com/user-attachments/assets/90d74c6c-f4b5-45ed-ba92-4c02ecfa09ea

Submitting a new appointment with non-attended outcome:


https://github.com/user-attachments/assets/d4bd8d12-0826-4f87-8f80-12b3d7012219



## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1144]: https://dsdmoj.atlassian.net/browse/CPB-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ