### PR TITLE
CPB-1158 - Update display logic to show <last name>, <first name>

### DIFF
--- a/e2e-tests/delius/personOnProbation.ts
+++ b/e2e-tests/delius/personOnProbation.ts
@@ -6,12 +6,15 @@ export default class PersonOnProbation {
     public dateOfBirth: Date,
   ) {}
 
-  public getFullName() {
+  public getFullName(lastNameFirst = true) {
+    if (lastNameFirst) {
+      return `${this.lastName}, ${this.firstName}`
+    }
     return `${this.firstName} ${this.lastName}`
   }
 
-  public getNameAndCrnDisplay() {
-    return `${this.getFullName()} (${this.crn})`
+  public getNameAndCrnDisplay(lastNameFirst = true) {
+    return `${this.getFullName(lastNameFirst)} (${this.crn})`
   }
 
   public getDisplayName() {

--- a/e2e-tests/pages/appointments/confirmPage.ts
+++ b/e2e-tests/pages/appointments/confirmPage.ts
@@ -58,7 +58,7 @@ class ConfirmPageAssertions extends AppointmentFormPageAssertions {
   }
 
   async toShowSelectedPeople(peopleOnProbation: PersonOnProbation[]) {
-    const names = peopleOnProbation.map(person => person.getNameAndCrnDisplay())
+    const names = peopleOnProbation.map(person => person.getNameAndCrnDisplay(false))
     const peopleSectionLocator = this.confirmPage.details.itemWithLabel('People')
     /* eslint-disable no-await-in-loop */
     for (const name of names) {

--- a/e2e-tests/pages/travelTime/travelTimePage.ts
+++ b/e2e-tests/pages/travelTime/travelTimePage.ts
@@ -19,7 +19,7 @@ export default class TravelTimePage extends BasePage {
 
   constructor(page: Page, personOnProbation: PersonOnProbation) {
     super(page)
-    this.expect = new TravelTimePageAssertions(this, personOnProbation.getFullName())
+    this.expect = new TravelTimePageAssertions(this, personOnProbation.getFullName(false))
     this.hoursMinutesInput = new HoursMinutesInputComponent(page)
     this.dateInput = new DateInputComponent(page)
     this.creditTravelTimeButtonLocator = page.getByRole('button', { name: 'Credit travel time' })

--- a/integration_tests/pages/appointments/selectedPeopleCardComponent.ts
+++ b/integration_tests/pages/appointments/selectedPeopleCardComponent.ts
@@ -14,7 +14,7 @@ export default class SelectedPeopleCardComponent {
     expectedAppointmentSummaries.forEach(appointment => {
       const offender = new Offender(appointment.offender)
       this.card
-        .getValueWithLabel(`${offender.name} (${offender.crn})`)
+        .getValueWithLabel(`${offender.getNameFormattedWithLastNameFirst()} (${offender.crn})`)
         .should('contain.text', `${DateTimeFormats.timePeriod(appointment.startTime, appointment.endTime)}`)
     })
   }
@@ -22,7 +22,7 @@ export default class SelectedPeopleCardComponent {
   shouldNotShowPeople(appointments: Array<AppointmentSummaryDto>) {
     appointments.forEach(appointment => {
       const offender = new Offender(appointment.offender)
-      this.card.shouldNotContainRowWithLabel(`${offender.name} (${offender.crn})`)
+      this.card.shouldNotContainRowWithLabel(`${offender.getNameFormattedWithLastNameFirst()} (${offender.crn})`)
     })
   }
 }

--- a/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
+++ b/integration_tests/pages/courseCompletions/searchCourseCompletionsPage.ts
@@ -49,7 +49,7 @@ export default class SearchCourseCompletionsPage extends Page {
   }
 
   shouldShowSearchResults(courseCompletion: EteCourseCompletionEventDto) {
-    cy.get('td').eq(0).should('have.text', `${courseCompletion.firstName} ${courseCompletion.lastName}`)
+    cy.get('td').eq(0).should('have.text', `${courseCompletion.lastName}, ${courseCompletion.firstName}`)
     cy.get('td').eq(1).should('have.text', courseCompletion.courseName)
     cy.get('td')
       .eq(2)

--- a/integration_tests/pages/projects/projectPage.ts
+++ b/integration_tests/pages/projects/projectPage.ts
@@ -47,7 +47,7 @@ export default class ProjectPage extends Page {
       const offender = appointmentSummary.offender as OffenderFullDto
 
       return [
-        `${offender.forename} ${offender.surname}${offender.crn}`,
+        `${offender.surname}, ${offender.forename}${offender.crn}`,
         DateTimeFormats.isoDateToUIDate(appointmentSummary.date, { format: 'medium' }),
         DateTimeFormats.stripTime(appointmentSummary.startTime),
         DateTimeFormats.stripTime(appointmentSummary.endTime),

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -65,7 +65,7 @@ export default class ViewSessionPage extends Page {
       const offender = appointmentSummary.offender as OffenderFullDto
 
       return [
-        `${offender.forename} ${offender.surname}`,
+        `${offender.surname}, ${offender.forename}`,
         offender.crn,
         DateTimeFormats.timePeriod(appointmentSummary.startTime, appointmentSummary.endTime),
         DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(

--- a/server/models/offender.test.ts
+++ b/server/models/offender.test.ts
@@ -39,6 +39,7 @@ describe('Offender', () => {
         lastName: offenderDto.surname,
         dateOfBirth: offenderDto.dateOfBirth,
         description: `${offenderDto.forename} ${offenderDto.surname} (${offenderDto.crn})`,
+        descriptionWithLastNameFirst: `${offenderDto.surname}, ${offenderDto.forename} (${offenderDto.crn})`,
       })
     })
 
@@ -48,6 +49,14 @@ describe('Offender', () => {
         const result = offender.getTableHtml()
 
         expect(result).toBe('<span>Name</span><br />CRN123')
+      })
+    })
+
+    describe('getNameFormattedWithLastNameFirst', () => {
+      it('returns an appropriately formatted name', () => {
+        const result = offender.getNameFormattedWithLastNameFirst()
+
+        expect(result).toBe('Smith, Jane')
       })
     })
   })
@@ -91,6 +100,14 @@ describe('Offender', () => {
         expect(result).toBe(offender.crn)
       })
     })
+
+    describe('getNameFormattedWithLastNameFirst', () => {
+      it('returns an empty name', () => {
+        const result = offender.getNameFormattedWithLastNameFirst()
+
+        expect(result).toBe('')
+      })
+    })
   })
 
   describe('Not_Found', () => {
@@ -130,6 +147,14 @@ describe('Offender', () => {
         const result = offender.getTableHtml()
 
         expect(result).toBe(offender.crn)
+      })
+    })
+
+    describe('getNameFormattedWithLastNameFirst', () => {
+      it('returns an empty name', () => {
+        const result = offender.getNameFormattedWithLastNameFirst()
+
+        expect(result).toBe('')
       })
     })
   })

--- a/server/models/offender.ts
+++ b/server/models/offender.ts
@@ -7,6 +7,7 @@ export interface OffenderDetails {
   crn: string
   dateOfBirth?: string
   description: string
+  descriptionWithLastNameFirst?: string
 }
 
 export default class Offender {
@@ -49,6 +50,7 @@ export default class Offender {
       lastName: fullOffender.surname,
       dateOfBirth: fullOffender.dateOfBirth,
       description: `${fullOffender.forename} ${fullOffender.surname} (${fullOffender.crn})`,
+      descriptionWithLastNameFirst: `${fullOffender.surname}, ${fullOffender.forename} (${fullOffender.crn})`,
     }
   }
 
@@ -57,6 +59,14 @@ export default class Offender {
       return this.crn
     }
 
-    return `${HtmlUtils.getElementWithContent(this.name, 'strong')}<br />${this.crn}`
+    return `${HtmlUtils.getElementWithContent(this.getNameFormattedWithLastNameFirst(), 'strong')}<br />${this.crn}`
+  }
+
+  getNameFormattedWithLastNameFirst(): string {
+    if (this.isLimited) {
+      return this.name
+    }
+
+    return `${this.details.lastName}, ${this.details.firstName}`
   }
 }

--- a/server/pages/appointments/bulkUpdatePage.test.ts
+++ b/server/pages/appointments/bulkUpdatePage.test.ts
@@ -84,7 +84,7 @@ describe('BulkUpdatePage', () => {
         expect(getOptionsSpy).toHaveBeenCalledWith(
           [
             {
-              text: new Offender(included.offender).details.description,
+              text: new Offender(included.offender).details.descriptionWithLastNameFirst,
               value: included.id,
             },
           ],
@@ -126,7 +126,7 @@ describe('BulkUpdatePage', () => {
         expect(getOptionsSpy).toHaveBeenCalledWith(
           [
             {
-              text: new Offender(included.offender).details.description,
+              text: new Offender(included.offender).details.descriptionWithLastNameFirst,
               value: included.id,
             },
           ],
@@ -155,7 +155,7 @@ describe('BulkUpdatePage', () => {
         expect(getOptionsSpy).toHaveBeenCalledWith(
           [
             {
-              text: new Offender(session.appointmentSummaries[0].offender).details.description,
+              text: new Offender(session.appointmentSummaries[0].offender).details.descriptionWithLastNameFirst,
               value: { id: session.appointmentSummaries[0].id, deliusVersion: '2' }.id,
             },
           ],

--- a/server/pages/appointments/bulkUpdatePage.ts
+++ b/server/pages/appointments/bulkUpdatePage.ts
@@ -77,7 +77,7 @@ export default class BulkUpdatePage extends PageWithValidation<Body> {
         .filter(appointment => !appointment.contactOutcome && appointment.offender.objectType === 'Full')
         .map(appointment => {
           const offender = new Offender(appointment.offender)
-          return { value: appointment.id, text: offender.details.description }
+          return { value: appointment.id, text: offender.details.descriptionWithLastNameFirst }
         }),
       'text',
       'value',

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -29,11 +29,11 @@ describe('CourseCompletionIndexPage', () => {
         'endDate-year': '2025',
       } as CourseCompletionPageInput)
 
-      expect(page.courseCompletionTableHeaders(['firstName', 'lastName'], 'asc', '/test')).toEqual([
+      expect(page.courseCompletionTableHeaders(['lastName', 'firstName'], 'asc', '/test')).toEqual([
         sortHeader<CourseCompletionSortField>(
           'Name',
-          ['firstName', 'lastName'],
-          ['firstName', 'lastName'],
+          ['lastName', 'firstName'],
+          ['lastName', 'firstName'],
           'asc',
           '/test',
           'search-results',
@@ -41,7 +41,7 @@ describe('CourseCompletionIndexPage', () => {
         sortHeader<CourseCompletionSortField>(
           'Course name',
           'courseName',
-          ['firstName', 'lastName'],
+          ['lastName', 'firstName'],
           'asc',
           '/test',
           'search-results',
@@ -57,7 +57,7 @@ describe('CourseCompletionIndexPage', () => {
         sortHeader<CourseCompletionSortField>(
           'Course status',
           'status',
-          ['firstName', 'lastName'],
+          ['lastName', 'firstName'],
           'asc',
           '/test',
           'search-results',
@@ -101,7 +101,7 @@ describe('CourseCompletionIndexPage', () => {
 
       expect(result).toEqual([
         [
-          { text: `${courseCompletion.firstName} ${courseCompletion.lastName}` },
+          { text: `${courseCompletion.lastName}, ${courseCompletion.firstName}` },
           { text: courseCompletion.courseName },
           { text: fakeFormattedDate },
           { html: mockStatus },

--- a/server/pages/courseCompletionIndexPage.ts
+++ b/server/pages/courseCompletionIndexPage.ts
@@ -37,7 +37,7 @@ export default class CourseCompletionIndexPage {
     return [
       sortHeader<CourseCompletionSortField>(
         'Name',
-        ['firstName', 'lastName'],
+        ['lastName', 'firstName'],
         sortBy,
         sortDirection,
         hrefPrefix,
@@ -84,7 +84,7 @@ export default class CourseCompletionIndexPage {
       const linkHtml = HtmlUtils.getAnchor(actionContent, viewCourseCompletionPath)
 
       return [
-        { text: `${courseCompletion.firstName} ${courseCompletion.lastName}` },
+        { text: `${courseCompletion.lastName}, ${courseCompletion.firstName}` },
         { text: courseCompletion.courseName },
         { text: DateTimeFormats.isoDateToUIDate(courseCompletion.completionDateTime) },
         {

--- a/server/utils/courseCompletionUtils.test.ts
+++ b/server/utils/courseCompletionUtils.test.ts
@@ -85,6 +85,7 @@ describe('CourseCompletionUtils', () => {
           lastName: offender.surname,
           dateOfBirth,
           description: `${offender.forename} ${offender.surname} (${offender.crn})`,
+          descriptionWithLastNameFirst: `${offender.surname}, ${offender.forename} (${offender.crn})`,
         })
       })
     })

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -77,6 +77,9 @@ describe('SessionUtils', () => {
           name: 'Sam Smith',
           crn: 'CRN123',
           isLimited: false,
+          getNameFormattedWithLastNameFirst: () => {
+            return 'Smith, Sam'
+          },
         }
       })
       jest.restoreAllMocks()
@@ -99,7 +102,7 @@ describe('SessionUtils', () => {
       expect(DateTimeFormats.timePeriod).toHaveBeenCalledWith(appointments[0].startTime, appointments[0].endTime)
       expect(result).toEqual([
         [
-          { text: 'Sam Smith' },
+          { text: 'Smith, Sam' },
           { text: 'CRN123' },
           { text: '09:00 - 17:00' },
           { text: '1 hour' },
@@ -269,12 +272,12 @@ describe('SessionUtils', () => {
       offenderMock
         .mockImplementationOnce(() => {
           return {
-            details: { description: 'Sam Smith (CRN123)' },
+            details: { descriptionWithLastNameFirst: 'Smith, Sam (CRN123)' },
           }
         })
         .mockImplementationOnce(() => {
           return {
-            details: { description: 'Alex Jones (CRN456)' },
+            details: { descriptionWithLastNameFirst: 'Jones, Alex (CRN456)' },
           }
         })
 
@@ -317,11 +320,11 @@ describe('SessionUtils', () => {
         },
         rows: [
           {
-            key: { text: 'Sam Smith (CRN123)' },
+            key: { text: 'Smith, Sam (CRN123)' },
             value: { text: '09:00 - 10:00' },
           },
           {
-            key: { text: 'Alex Jones (CRN456)' },
+            key: { text: 'Jones, Alex (CRN456)' },
             value: { text: '10:30 - 11:30' },
           },
         ],

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -41,7 +41,7 @@ export default class SessionUtils {
         appointment.requirementMinutes - appointment.completedMinutes + appointment.adjustmentMinutes
 
       return [
-        { text: offender.name },
+        { text: offender.getNameFormattedWithLastNameFirst() },
         { text: offender.crn },
         { text: DateTimeFormats.timePeriod(appointment.startTime, appointment.endTime) },
         { text: DateTimeFormats.totalMinutesToHumanReadableHoursAndMinutes(minutesRemaining) },
@@ -106,7 +106,7 @@ export default class SessionUtils {
         const offender = new Offender(appointment.offender)
 
         return {
-          key: { text: offender.details.description },
+          key: { text: offender.details.descriptionWithLastNameFirst },
           value: { text: DateTimeFormats.timePeriod(appointment.startTime, appointment.endTime) },
         }
       })


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-1158)

In cases where we show multiple people at a time, we want to show these formatted with `<last name>, <first name>` (where we only show an individual, we still want to have `<first name> <last name>`).

This updates:
* Group session details
* Bulk update list
* Bulk update table
* Individual placement details
* Course completions

We also update sorting for course completions.

## Changes in this PR

### Screenshots of UI changes

<img width="1760" height="1335" alt="display-last-name-first" src="https://github.com/user-attachments/assets/36dea965-13a4-4d02-9b32-914b66d4b14e" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
