### PR TITLE
Last name first causing e2e test selection issue

### DIFF
--- a/e2e-tests/delius/personOnProbation.ts
+++ b/e2e-tests/delius/personOnProbation.ts
@@ -6,7 +6,7 @@ export default class PersonOnProbation {
     public dateOfBirth: Date,
   ) {}
 
-  public getFullName(lastNameFirst = true) {
+  public getFullName(lastNameFirst = false) {
     if (lastNameFirst) {
       return `${this.lastName}, ${this.firstName}`
     }

--- a/e2e-tests/pages/travelTime/travelTimePage.ts
+++ b/e2e-tests/pages/travelTime/travelTimePage.ts
@@ -19,7 +19,7 @@ export default class TravelTimePage extends BasePage {
 
   constructor(page: Page, personOnProbation: PersonOnProbation) {
     super(page)
-    this.expect = new TravelTimePageAssertions(this, personOnProbation.getFullName(false))
+    this.expect = new TravelTimePageAssertions(this, personOnProbation.getFullName(true))
     this.hoursMinutesInput = new HoursMinutesInputComponent(page)
     this.dateInput = new DateInputComponent(page)
     this.creditTravelTimeButtonLocator = page.getByRole('button', { name: 'Credit travel time' })


### PR DESCRIPTION
We swapped around first name / last name ordering in some but not all places - this caused a few issues around the edges in the e2e tests. Here we fix the problem by setting a correct default on `PersonOnProbation#getFullName`