### PR TITLE
Submit `supervisorTeamCode` in payload from confirm controller

### DIFF
--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -19,6 +19,7 @@ import paths from '../../paths'
 import OffenderService from '../../services/offenderService'
 import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
 import createAppointmentFormFactory from '../../testutils/factories/createAppointmentFormFactory'
+import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 
 jest.mock('../../pages/appointments/confirmPage')
 
@@ -903,6 +904,46 @@ describe('ConfirmController', () => {
           },
           'user-name',
         )
+      })
+
+      describe('supervisorTeamCode', () => {
+        it('should include supervisor team code when this is set on the form', async () => {
+          confirmPageMock.mockImplementationOnce(() => {
+            return {
+              exitForm: () => '',
+              isAlertSelected: () => false,
+            }
+          })
+          const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+          const appointment = appointmentFactory.build({ version: appointmentVersion })
+          const contactOutcome = contactOutcomeFactory.build({ attended: false })
+          const team = providerTeamSummaryFactory.build()
+          const form = appointmentOutcomeFormFactory.build({
+            contactOutcome,
+            deliusVersion: formAppointmentVersion,
+            appointments: [{ id: 1, deliusVersion: formAppointmentVersion }],
+            supervisingTeam: team,
+          })
+
+          appointmentService.getAppointment.mockResolvedValue(appointment)
+          appointmentFormService.getForm.mockResolvedValue(form)
+
+          const requestHandler = confirmController.submitUpdate()
+          await requestHandler(bulkRequest, response, next)
+
+          expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+            projectCode,
+            {
+              updates: [
+                expect.objectContaining({
+                  supervisorTeamCode: team.code,
+                }),
+              ],
+            },
+            'user-name',
+          )
+        })
       })
 
       describe('alertActive', () => {

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -312,6 +312,7 @@ export default class ConfirmController implements IAppointmentFormPageController
       contactOutcomeCode: form.contactOutcome.code,
       attendanceData: didAttend ? form.attendanceData : undefined,
       supervisorOfficerCode: form.supervisor.code,
+      supervisorTeamCode: form.supervisingTeam?.code,
       date: appointment.date,
       projectCode: form.project.code,
     }


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-1135)

Here we add `supervisorTeamCode` to the payload sent from the confirm controller when we're saving an appointment. Prior to this there was a scenario where changing the supervisor to one belonging to a different team would result in a situation where the eventual data in Delius had an orphaned supervisor, because we were only submitting the updated supervisor's code but not their new team code.

(I've marked this property on the form in the payload as optional because making it mandatory and thus adding a supervising team to the factory creates absolute havoc in the integration tests, where we would need to stub out the `getTeam` endpoint in many, many more cases than we do currently. I can justify this because, fundamentally, it does feel optional: it works well enough with this property not set too.)

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
