### PR TITLE
CPB-1123: Rename `requirement` to `deliusEventNumber`

### DIFF
--- a/server/controllers/appointments/appointmentsController.test.ts
+++ b/server/controllers/appointments/appointmentsController.test.ts
@@ -10,13 +10,13 @@ import { pathWithQuery } from '../../utils/utils'
 describe('AppointmentsController', () => {
   const userName = 'user'
   const crn = 'X123456'
-  const requirement = '1'
+  const deliusEventNumber = '1'
   const projectCode = '2'
   const date = '2026-01-01'
   const formId = 'some-form-id'
 
   const request = createMock<Request>({
-    params: { crn, requirement, projectCode, date },
+    params: { crn, deliusEventNumber, projectCode, date },
     query: { provider: 'provider-code' },
   })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
@@ -52,7 +52,7 @@ describe('AppointmentsController', () => {
         userName,
         request.query,
         crn,
-        requirement,
+        deliusEventNumber,
         project,
         date,
       )

--- a/server/controllers/appointments/appointmentsController.ts
+++ b/server/controllers/appointments/appointmentsController.ts
@@ -13,7 +13,7 @@ export default class AppointmentsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn, requirement, projectCode, date } = req.params
+      const { crn, deliusEventNumber, projectCode, date } = req.params
       const { username } = res.locals.user
 
       const project = await this.projectService.getProject({ username, projectCode })
@@ -22,7 +22,7 @@ export default class AppointmentsController {
         username,
         req.query as Record<string, string>,
         crn,
-        requirement,
+        deliusEventNumber,
         project,
         date,
       )

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -213,7 +213,7 @@ describe('ConfirmController', () => {
       const form = createAppointmentFormFactory.build({
         project: { code: projectCode, name: 'Project name' },
         date: '2026-06-09',
-        requirement: '1001',
+        deliusEventNumber: '1001',
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
         originalSearch: { provider: 'provider' },
       })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -119,7 +119,7 @@ export default class ConfirmController implements IAppointmentFormPageController
         supervisorOfficerCode: form.supervisor.code,
         date: form.date,
         crn: form.crn,
-        deliusEventNumber: Number(form.requirement),
+        deliusEventNumber: Number(form.deliusEventNumber),
         projectCode: form.project.code,
       }
 

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -27,7 +27,7 @@ const paths = {
     search: sessionsPath.path('search'),
     show: singleSessionPath,
     update: singleSessionPath.path('update/:page'),
-    createAppointment: singleSessionPath.path('create/:crn/:requirement'),
+    createAppointment: singleSessionPath.path('create/:crn/:deliusEventNumber'),
   },
   courseCompletions: {
     index: courseCompletionsPath,

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -125,16 +125,23 @@ describe('AppointmentFormService', () => {
       const user = 'some-user'
       const query = { provider: 'provider-code', team: 'team-code' }
       const crn = 'X123456'
-      const requirement = '1'
+      const deliusEventNumber = '1'
       const project = projectFactory.build()
       const date = '2026-01-01'
 
-      const result = await appointmentFormService.createNewAppointmentForm(user, query, crn, requirement, project, date)
+      const result = await appointmentFormService.createNewAppointmentForm(
+        user,
+        query,
+        crn,
+        deliusEventNumber,
+        project,
+        date,
+      )
 
       const expectedForm = {
         originalSearch: query,
         crn,
-        requirement,
+        deliusEventNumber,
         projectTeam: { code: project.teamCode, name: project.teamName },
         project: { code: project.projectCode, name: project.projectName },
         date,

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -42,9 +42,8 @@ export type AppointmentOutcomeForm = {
 
 export type CreateAppointmentForm = Omit<AppointmentOutcomeForm, 'deliusVersion'> & {
   crn: string
-  requirement: string
   date: string
-  deliusEventNumber?: string
+  deliusEventNumber: string
 }
 
 export interface Form<T extends AppointmentOutcomeForm> {
@@ -119,7 +118,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
     username: string,
     query: Record<string, string>,
     crn: string,
-    requirement: string,
+    deliusEventNumber: string,
     project: ProjectDto,
     date: string,
   ): Promise<Form<CreateAppointmentForm>> {
@@ -131,7 +130,7 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
         endTime: project.availability[0].endTime,
         originalSearch: query,
         crn,
-        requirement,
+        deliusEventNumber,
         date,
       },
     }

--- a/server/testutils/factories/createAppointmentFormFactory.ts
+++ b/server/testutils/factories/createAppointmentFormFactory.ts
@@ -10,7 +10,7 @@ export default Factory.define<CreateAppointmentForm>(
       startTime: '09:00',
       endTime: '17:00',
       crn: `CRN${faker.string.alphanumeric({ length: 5 })}`,
-      requirement: faker.string.alpha(10),
+      deliusEventNumber: faker.number.int({ min: 1, max: 1000 }).toString(),
       notes: undefined,
       isSensitive: undefined,
       originalSearch: {


### PR DESCRIPTION
## Context

To prevent confusion between  a 'requirement' and  a 'deliusEventNumber', changing all instances of the identifier (number) itself to `deliusEventNumber`. This will be referred to as a 'requirement' in user facing situations (which is identified by the `deliusEventNumber`).

This matches with the implementation of the requirement details in the course completions form

Small tidy-up ahead of merging #691 

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
