### PR TITLE
Decode projectCode in views

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -50,6 +50,7 @@ export default function nunjucksSetup(app: express.Express): void {
 
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
+  njkEnv.addFilter('urldecode', (str: string) => decodeURIComponent(str))
 
   njkEnv.addGlobal('paths', paths)
   njkEnv.addGlobal('htmlUtils', HtmlUtils)

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -24,7 +24,7 @@ export default class SessionUtils {
 
       return [
         {
-          html: `${HtmlUtils.getElementWithContent(projectLink)}${HtmlUtils.getElementWithContent(session.projectCode)}`,
+          html: `${HtmlUtils.getElementWithContent(projectLink)}${HtmlUtils.getElementWithContent(decodeURIComponent(session.projectCode))}`,
         },
         { text: DateTimeFormats.isoDateToUIDate(session.date) },
         { text: session.numberOfOffendersAllocated },

--- a/server/views/sessions/show.njk
+++ b/server/views/sessions/show.njk
@@ -40,7 +40,7 @@
   {% endfor %}
 {% endif %}
 
-{% call pageHeader({ title: session.projectName, caption: session.projectCode }) %}
+{% call pageHeader({ title: session.projectName, caption: session.projectCode | urldecode | safe }) %}
   {% if bulkUpdatePath %}
     {{ govukButton({
       text: "Bulk update",


### PR DESCRIPTION
## Context

* [JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CPB/boards/7852?selectedIssue=CPB-1169)

We have identified an issue where a `projectCode` sometimes contains forward slashes, which causes the app to break because these are interpreted in the routing as two separate path elements. Fixing this at the UI layer is hard because we would need to encode both the URLs we generate and also handle the encoding in the routes the app receives (neither Express nor static-path have any built-in support for this).

On this basis, we have determined it is more correct to handle these occasionally problematic `projectCode` instances at the API level, and to encode them there before they are passed to the frontend. We do, therefore, need to *decode* the `projectCode` when we are displaying it in the browser, which we do in just a couple of places in the views.
