### PR TITLE
Refactor: Add `create` namespace in session paths

### DIFF
--- a/integration_tests/pages/findAPersonPage.ts
+++ b/integration_tests/pages/findAPersonPage.ts
@@ -11,6 +11,8 @@ export default class FindAPersonPage extends Page {
   }
 
   static visit(session: SessionDto): FindAPersonPage {
-    return this.visitAndCheck(paths.sessions.findAPerson({ projectCode: session.projectCode, date: session.date }))
+    return this.visitAndCheck(
+      paths.sessions.create.findAPerson({ projectCode: session.projectCode, date: session.date }),
+    )
   }
 }

--- a/integration_tests/pages/requirementPage.ts
+++ b/integration_tests/pages/requirementPage.ts
@@ -14,7 +14,7 @@ export default class RequirementPage extends Page {
 
   static visit(session: SessionDto, offender: OffenderFullDto) {
     const { crn, name } = new Offender(offender)
-    const path = paths.sessions.requirement({ projectCode: session.projectCode, date: session.date, crn })
+    const path = paths.sessions.create.requirement({ projectCode: session.projectCode, date: session.date, crn })
     return this.visitAndCheck(path, name)
   }
 

--- a/server/controllers/requirementController.test.ts
+++ b/server/controllers/requirementController.test.ts
@@ -77,7 +77,7 @@ describe('RequirementController', () => {
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
         person,
         unpaidWorkOptions,
-        updatePath: paths.sessions.requirement({ crn, projectCode, date }),
+        updatePath: paths.sessions.create.requirement({ crn, projectCode, date }),
       })
     })
 
@@ -101,7 +101,7 @@ describe('RequirementController', () => {
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
         person: { ...person, isLimited: true },
         unpaidWorkOptions,
-        updatePath: paths.sessions.requirement({ crn, projectCode, date }),
+        updatePath: paths.sessions.create.requirement({ crn, projectCode, date }),
       })
 
       expect(UnpaidWorkUtils.getUnpaidWorkOptions).toHaveBeenCalledWith(caseDetailsSummary.unpaidWorkDetails, null)
@@ -176,7 +176,7 @@ describe('RequirementController', () => {
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
         person,
         unpaidWorkOptions,
-        updatePath: paths.sessions.requirement({ crn, projectCode, date }),
+        updatePath: paths.sessions.create.requirement({ crn, projectCode, date }),
         errorSummary,
         errors,
       })
@@ -233,7 +233,7 @@ describe('RequirementController', () => {
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(
-          paths.sessions.createAppointment({ projectCode, crn, date, deliusEventNumber: '1' }),
+          paths.sessions.create.createAppointment({ projectCode, crn, date, deliusEventNumber: '1' }),
         )
       })
     })

--- a/server/controllers/requirementController.ts
+++ b/server/controllers/requirementController.ts
@@ -36,7 +36,7 @@ export default class RequirementController {
       res.render('pages/requirement', {
         person,
         unpaidWorkOptions,
-        updatePath: paths.sessions.requirement({ crn, projectCode, date }),
+        updatePath: paths.sessions.create.requirement({ crn, projectCode, date }),
       })
     }
   }
@@ -69,7 +69,7 @@ export default class RequirementController {
         return res.render('pages/requirement', {
           person,
           unpaidWorkOptions,
-          updatePath: paths.sessions.requirement({ crn, projectCode, date }),
+          updatePath: paths.sessions.create.requirement({ crn, projectCode, date }),
           errorSummary,
           errors,
         })
@@ -90,7 +90,12 @@ export default class RequirementController {
       }
 
       return res.redirect(
-        paths.sessions.createAppointment({ crn, projectCode, date, deliusEventNumber: req.body.deliusEventNumber }),
+        paths.sessions.create.createAppointment({
+          crn,
+          projectCode,
+          date,
+          deliusEventNumber: req.body.deliusEventNumber,
+        }),
       )
     }
   }

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -410,7 +410,7 @@ describe('SessionsController', () => {
           'sessions/show',
           expect.objectContaining({
             createAppointmentPath: pathWithQuery(
-              paths.sessions.findAPerson({ projectCode: session.projectCode, date: session.date }),
+              paths.sessions.create.findAPerson({ projectCode: session.projectCode, date: session.date }),
             ),
           }),
         )

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -179,6 +179,6 @@ export default class SessionsController {
 
     const { date, projectCode } = appointmentOrSession
 
-    return pathWithQuery(paths.sessions.findAPerson({ projectCode, date }), query)
+    return pathWithQuery(paths.sessions.create.findAPerson({ projectCode, date }), query)
   }
 }

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -11,6 +11,7 @@ const projectsIndividualPlacementsPath = projectsPath.path('individual-placement
 
 const travelTimeTaskPath = appointmentPath.path('travel-time/:taskId')
 const singleSessionPath = sessionsPath.path(':projectCode').path(':date')
+const createSessionAppointmentPath = singleSessionPath.path('create')
 
 const paths = {
   error: path('/error'),
@@ -27,9 +28,11 @@ const paths = {
     search: sessionsPath.path('search'),
     show: singleSessionPath,
     update: singleSessionPath.path('update/:page'),
-    createAppointment: singleSessionPath.path('create/:crn/:deliusEventNumber'),
-    findAPerson: singleSessionPath.path('/find-a-person'),
-    requirement: singleSessionPath.path('/:crn/requirement'),
+    create: {
+      createAppointment: createSessionAppointmentPath.path(':crn/:deliusEventNumber'),
+      findAPerson: createSessionAppointmentPath.path('/find-a-person'),
+      requirement: createSessionAppointmentPath.path('/:crn/requirement'),
+    },
   },
   courseCompletions: {
     index: courseCompletionsPath,

--- a/server/routes/requirementMiddleware.test.ts
+++ b/server/routes/requirementMiddleware.test.ts
@@ -67,7 +67,7 @@ describe('requirementMiddleware', () => {
     await middleware(req, res, next)
 
     expect(res.redirect).toHaveBeenCalledWith(
-      paths.sessions.createAppointment({
+      paths.sessions.create.createAppointment({
         deliusEventNumber: '1',
         crn,
         projectCode,

--- a/server/routes/requirementMiddleware.ts
+++ b/server/routes/requirementMiddleware.ts
@@ -17,7 +17,7 @@ export default function requirementMiddleware(offenderService: OffenderService) 
 
     if (unpaidWorkDetails.length === 1) {
       return res.redirect(
-        paths.sessions.createAppointment({
+        paths.sessions.create.createAppointment({
           deliusEventNumber: unpaidWorkDetails[0].eventNumber.toString(),
           crn,
           projectCode,

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -34,14 +34,14 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
   post(selectPeopleRoute, appointments.bulkUpdateController.submitUpdate(), {
     auditEvent: Page.EDIT_SESSIONS_SELECT_PEOPLE,
   })
-  post(paths.sessions.findAPerson.pattern, services.personSearchService.post)
+  post(paths.sessions.create.findAPerson.pattern, services.personSearchService.post)
   get(
-    paths.sessions.findAPerson.pattern,
+    paths.sessions.create.findAPerson.pattern,
     [
       featureFlagMiddleware('createAppointmentEnabled'),
       services.personSearchService.get,
       (req, res, next) => {
-        const resultPath = paths.sessions.requirement({
+        const resultPath = paths.sessions.create.requirement({
           projectCode: req.params.projectCode,
           date: req.params.date,
           crn: ':crn',
@@ -55,13 +55,13 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
   )
 
   get(
-    paths.sessions.requirement.pattern,
+    paths.sessions.create.requirement.pattern,
     [requirementMiddleware(services.offenderService), requirementController.show()],
     {
       auditEvent: Page.VIEW_CREATE_APPOINTMENT_REQUIREMENT_PAGE,
     },
   )
-  post(paths.sessions.requirement.pattern, requirementController.submit(), {
+  post(paths.sessions.create.requirement.pattern, requirementController.submit(), {
     auditEvent: Page.EDIT_CREATE_APPOINTMENT_REQUIREMENT_PAGE,
   })
 
@@ -80,7 +80,7 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
     })
   })
 
-  get(paths.sessions.createAppointment.pattern, appointments.appointmentsController.create())
+  get(paths.sessions.create.createAppointment.pattern, appointments.appointmentsController.create())
 
   return router
 }


### PR DESCRIPTION
## Context

This will contain the new pages added for the create appointment (for a session) journey, as we now have a few.

Tidy-up ahead of implementation for [CPB-1177](https://dsdmoj.atlassian.net/browse/CPB-1177)

### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1177]: https://dsdmoj.atlassian.net/browse/CPB-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ