### PR TITLE
Add node and jest to types in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noImplicitAny": true,
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
-    "lib": ["es2016","dom"]
+    "types": ["node", "jest"],
+    "lib": ["es2016", "dom"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This change resolves an issue with syntax highlighting in VS Code for jest types when using TypeScript. By adding "node" and "jest" to the "types" array in tsconfig.json, we ensure that the TypeScript compiler recognizes the types provided by these libraries.

## Context

When using Jest with TypeScript in VS code, the editor highlights syntax errors since it doesn't recognise the types brought in by jest. By making this change, we avoid seeing the unnecessary red lines under each test.

## Changes in this PR

Add the types for node and jest to the tsconfig file

### Screenshots of UI changes

**Before:**

<img width="959" height="822" alt="image" src="https://github.com/user-attachments/assets/751606f9-89fc-4bea-a99b-8fe54d802489" />

**After:**
<img width="959" height="822" alt="image" src="https://github.com/user-attachments/assets/585e3dc3-6e01-4fe3-a8ec-4f6f01151b6d" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
