### PR TITLE
CPB-1175: handle back navigation from requirement page

### DIFF
--- a/integration_tests/tests/appointments/create/requirement.cy.ts
+++ b/integration_tests/tests/appointments/create/requirement.cy.ts
@@ -196,6 +196,24 @@ context('Create session appointment - requirement', () => {
     // Then I should see the dashboard
     Page.verifyOnPage(HomePage)
   })
+
+  it('navigates back to the find a person page', () => {
+    // Given a person on probation has multiple requirements
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({
+      offender,
+      unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+    })
+
+    cy.task('stubGetOffenderSummary', {
+      caseDetailsSummary,
+    })
+
+    // When I visit the requirement page
+    const requirementPage = RequirementPage.visitForSession(session, offender)
+    requirementPage.clickBack()
+
+    Page.verifyOnPage(FindAPersonPage)
+  })
 })
 
 context('Create project appointment - requirement', () => {
@@ -307,5 +325,23 @@ context('Create project appointment - requirement', () => {
 
     // Then I should see the date page
     Page.verifyOnPage(DatePage, { offender })
+  })
+
+  it('navigates back to the find a person page', () => {
+    // Given a person on probation has multiple requirements
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({
+      offender,
+      unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+    })
+
+    cy.task('stubGetOffenderSummary', {
+      caseDetailsSummary,
+    })
+
+    // When I visit the requirement page
+    const requirementPage = RequirementPage.visitForProject(project, offender)
+    requirementPage.clickBack()
+
+    Page.verifyOnPage(FindAPersonPage)
   })
 })

--- a/server/controllers/requirementController.test.ts
+++ b/server/controllers/requirementController.test.ts
@@ -22,6 +22,7 @@ describe('RequirementController', () => {
   const date = '2025-01-01'
   const formId = '1'
   const updatePath = '/path'
+  const backPath = '/back'
 
   let requirementController: RequirementController
 
@@ -73,13 +74,14 @@ describe('RequirementController', () => {
       const unpaidWorkOptions = [{ text: 'Option 1', value: 1, hint: { html: 'Hint HTML' }, checked: false }]
       jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
 
-      const requestHandler = requirementController.show(updatePath)
+      const requestHandler = requirementController.show({ updatePath, backPath })
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
         person,
         unpaidWorkOptions,
         updatePath,
+        backLink: backPath,
       })
     })
 
@@ -97,13 +99,14 @@ describe('RequirementController', () => {
       const unpaidWorkOptions = [{ text: 'Option 1', value: 1, hint: { html: 'Hint HTML' }, checked: false }]
       jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
 
-      const requestHandler = requirementController.show(updatePath)
+      const requestHandler = requirementController.show({ updatePath, backPath })
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
         person: { ...person, isLimited: true },
         unpaidWorkOptions,
         updatePath,
+        backLink: backPath,
       })
 
       expect(UnpaidWorkUtils.getUnpaidWorkOptions).toHaveBeenCalledWith(caseDetailsSummary.unpaidWorkDetails, null)
@@ -131,7 +134,7 @@ describe('RequirementController', () => {
         const form = createAppointmentFormFactory.build({ deliusEventNumber: '1' })
         formService.getForm.mockResolvedValue(form)
 
-        const requestHandler = requirementController.show(updatePath)
+        const requestHandler = requirementController.show({ updatePath, backPath })
         await requestHandler(request, response, next)
 
         expect(formService.getForm).toHaveBeenCalledWith(formId, username)
@@ -172,7 +175,7 @@ describe('RequirementController', () => {
       const unpaidWorkOptions = [{ text: 'Option 1', value: 1, hint: { html: 'Hint HTML' }, checked: false }]
       jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
 
-      const requestHandler = requirementController.submit({ updatePath, createAppointmentPath: path('/') })
+      const requestHandler = requirementController.submit({ updatePath, createAppointmentPath: path('/'), backPath })
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
@@ -181,6 +184,7 @@ describe('RequirementController', () => {
         updatePath,
         errorSummary,
         errors,
+        backLink: backPath,
       })
     })
 
@@ -203,7 +207,11 @@ describe('RequirementController', () => {
         const form = createAppointmentFormFactory.build({ deliusEventNumber: undefined })
         formService.getForm.mockResolvedValue(form)
 
-        const requestHandler = requirementController.submit({ updatePath, createAppointmentPath: path('/') })
+        const requestHandler = requirementController.submit({
+          updatePath,
+          createAppointmentPath: path('/'),
+          backPath: '/',
+        })
         await requestHandler(request, response, next)
 
         expect(formService.saveForm).toHaveBeenCalledWith(formId, username, { ...form, deliusEventNumber: '1' })
@@ -233,7 +241,7 @@ describe('RequirementController', () => {
         const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
         offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
 
-        const requestHandler = requirementController.submit({ updatePath: '/', createAppointmentPath })
+        const requestHandler = requirementController.submit({ updatePath: '/', createAppointmentPath, backPath: '/' })
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/requirementController.ts
+++ b/server/controllers/requirementController.ts
@@ -14,7 +14,7 @@ export default class RequirementController {
     private readonly offenderService: OffenderService,
   ) {}
 
-  show(updatePath: string): RequestHandler {
+  show({ updatePath, backPath }: { updatePath: string; backPath: string }): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn } = req.params
       const form = req.query?.form?.toString()
@@ -39,14 +39,17 @@ export default class RequirementController {
         person,
         unpaidWorkOptions,
         updatePath,
+        backLink: backPath,
       })
     }
   }
 
   submit<CreateAppointmentPathPattern extends `/${string}`>({
+    backPath,
     updatePath,
     createAppointmentPath,
   }: {
+    backPath: string
     updatePath: string
     createAppointmentPath: Path<CreateAppointmentPathPattern>
   }): RequestHandler {
@@ -81,6 +84,7 @@ export default class RequirementController {
           updatePath,
           errorSummary,
           errors,
+          backLink: backPath,
         })
       }
 

--- a/server/paths/createAppointmentPaths.ts
+++ b/server/paths/createAppointmentPaths.ts
@@ -1,0 +1,10 @@
+import { Path } from 'static-path'
+
+export default function createAppointmentPaths<Pattern extends `/${string}`>(basePath: Path<Pattern>) {
+  const createPath = basePath.path('create')
+  return {
+    createAppointment: createPath.path(':crn/:deliusEventNumber'),
+    findAPerson: createPath.path('/find-a-person'),
+    requirement: createPath.path('/:crn/requirement'),
+  }
+}

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -1,4 +1,5 @@
 import { path } from 'static-path'
+import createAppointmentPaths from './createAppointmentPaths'
 
 const projectsPath = path('/projects')
 const sessionsPath = path('/sessions')
@@ -11,10 +12,8 @@ const projectsIndividualPlacementsPath = projectsPath.path('individual-placement
 
 const travelTimeTaskPath = appointmentPath.path('travel-time/:taskId')
 const singleSessionPath = sessionsPath.path(':projectCode').path(':date')
-const createSessionAppointmentPath = singleSessionPath.path('create')
 
 const singleProjectPath = projectsPath.path(':projectCode')
-const createProjectAppointmentPath = singleProjectPath.path('create')
 const paths = {
   error: path('/error'),
   data: {
@@ -24,22 +23,14 @@ const paths = {
     index: projectsIndividualPlacementsPath,
     filter: projectsIndividualPlacementsPath.path('filter'),
     show: singleProjectPath,
-    create: {
-      createAppointment: createProjectAppointmentPath.path(':crn/:deliusEventNumber'),
-      findAPerson: createProjectAppointmentPath.path('/find-a-person'),
-      requirement: createProjectAppointmentPath.path('/:crn/requirement'),
-    },
+    create: createAppointmentPaths(singleProjectPath),
   },
   sessions: {
     index: sessionsPath,
     search: sessionsPath.path('search'),
     show: singleSessionPath,
     update: singleSessionPath.path('update/:page'),
-    create: {
-      createAppointment: createSessionAppointmentPath.path(':crn/:deliusEventNumber'),
-      findAPerson: createSessionAppointmentPath.path('/find-a-person'),
-      requirement: createSessionAppointmentPath.path('/:crn/requirement'),
-    },
+    create: createAppointmentPaths(singleSessionPath),
   },
   courseCompletions: {
     index: courseCompletionsPath,

--- a/server/paths/requirementPagePaths.test.ts
+++ b/server/paths/requirementPagePaths.test.ts
@@ -1,0 +1,27 @@
+import paths from '.'
+import buildRequirementPagePaths from './requirementPagePaths'
+
+describe('buildRequirementPaths', () => {
+  it('builds session requirement paths from the create namespace', () => {
+    const result = buildRequirementPagePaths(paths.sessions.create, {
+      crn: 'X123456',
+      projectCode: 'PROJECT',
+      date: '2025-01-01',
+    })
+
+    expect(result.backPath).toBe('/sessions/PROJECT/2025-01-01/create/find-a-person')
+    expect(result.updatePath).toBe('/sessions/PROJECT/2025-01-01/create/X123456/requirement')
+    expect(result.createAppointmentPath).toBe(paths.sessions.create.createAppointment)
+  })
+
+  it('builds project requirement paths from the create namespace', () => {
+    const result = buildRequirementPagePaths(paths.projects.create, {
+      crn: 'X123456',
+      projectCode: 'PROJECT',
+    })
+
+    expect(result.backPath).toBe('/projects/PROJECT/create/find-a-person')
+    expect(result.updatePath).toBe('/projects/PROJECT/create/X123456/requirement')
+    expect(result.createAppointmentPath).toBe(paths.projects.create.createAppointment)
+  })
+})

--- a/server/paths/requirementPagePaths.ts
+++ b/server/paths/requirementPagePaths.ts
@@ -1,0 +1,23 @@
+import { Path } from 'static-path'
+
+type CreateAppointmentPaths<
+  FindParams extends Record<string, string>,
+  RequirementParams extends FindParams,
+  CreatePattern extends `/${string}`,
+> = {
+  findAPerson: (params: FindParams) => string
+  requirement: (params: RequirementParams) => string
+  createAppointment: Path<CreatePattern>
+}
+
+export default function buildRequirementPagePaths<
+  FindParams extends Record<string, string>,
+  RequirementParams extends FindParams,
+  CreatePattern extends `/${string}`,
+>(paths: CreateAppointmentPaths<FindParams, RequirementParams, CreatePattern>, params: RequirementParams) {
+  return {
+    backPath: paths.findAPerson(params),
+    updatePath: paths.requirement(params),
+    createAppointmentPath: paths.createAppointment,
+  }
+}

--- a/server/routes/project.ts
+++ b/server/routes/project.ts
@@ -6,6 +6,7 @@ import { Services } from '../services'
 import featureFlagMiddleware from './featureFlagMiddleware'
 import { Controllers } from '../controllers'
 import requirementMiddleware from './requirementMiddleware'
+import buildRequirementPagePaths from '../paths/requirementPagePaths'
 
 export default function projectRoutes(controllers: Controllers, router: Router, services: Services): Router {
   const { get, post } = actions(router)
@@ -42,10 +43,12 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
       requirementMiddleware(services.offenderService, paths.projects.create.createAppointment),
       (req, res, next) => {
         const { crn, projectCode } = req.params
-        return requirementController.show({
-          backPath: paths.projects.create.findAPerson({ projectCode }),
-          updatePath: paths.projects.create.requirement({ crn, projectCode }),
-        })(req, res, next)
+        return requirementController.show(
+          buildRequirementPagePaths(paths.projects.create, {
+            crn,
+            projectCode,
+          }),
+        )(req, res, next)
       },
     ],
     {
@@ -55,15 +58,12 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
   post(
     paths.projects.create.requirement.pattern,
     (req, res, next) => {
-      const params = {
-        crn: req.params.crn,
-        projectCode: req.params.projectCode,
-      }
-      return requirementController.submit({
-        backPath: paths.projects.create.findAPerson(params),
-        updatePath: paths.projects.create.requirement(params),
-        createAppointmentPath: paths.projects.create.createAppointment,
-      })(req, res, next)
+      return requirementController.submit(
+        buildRequirementPagePaths(paths.projects.create, {
+          crn: req.params.crn,
+          projectCode: req.params.projectCode,
+        }),
+      )(req, res, next)
     },
     {
       auditEvent: Page.EDIT_CREATE_APPOINTMENT_REQUIREMENT_PAGE,

--- a/server/routes/project.ts
+++ b/server/routes/project.ts
@@ -42,7 +42,10 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
       requirementMiddleware(services.offenderService, paths.projects.create.createAppointment),
       (req, res, next) => {
         const { crn, projectCode } = req.params
-        return requirementController.show(paths.projects.create.requirement({ crn, projectCode }))(req, res, next)
+        return requirementController.show({
+          backPath: paths.projects.create.findAPerson({ projectCode }),
+          updatePath: paths.projects.create.requirement({ crn, projectCode }),
+        })(req, res, next)
       },
     ],
     {
@@ -57,6 +60,7 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
         projectCode: req.params.projectCode,
       }
       return requirementController.submit({
+        backPath: paths.projects.create.findAPerson(params),
         updatePath: paths.projects.create.requirement(params),
         createAppointmentPath: paths.projects.create.createAppointment,
       })(req, res, next)

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -59,13 +59,17 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
     [
       requirementMiddleware(services.offenderService, paths.sessions.create.createAppointment),
       (req, res, next) =>
-        requirementController.show(
-          paths.sessions.create.requirement({
+        requirementController.show({
+          backPath: paths.sessions.create.findAPerson({
+            projectCode: req.params.projectCode,
+            date: req.params.date,
+          }),
+          updatePath: paths.sessions.create.requirement({
             projectCode: req.params.projectCode,
             date: req.params.date,
             crn: req.params.crn,
           }),
-        )(req, res, next),
+        })(req, res, next),
     ],
     {
       auditEvent: Page.VIEW_CREATE_APPOINTMENT_REQUIREMENT_PAGE,
@@ -80,6 +84,7 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
         date: req.params.date,
       }
       return requirementController.submit({
+        backPath: paths.sessions.create.findAPerson(params),
         updatePath: paths.sessions.create.requirement(params),
         createAppointmentPath: paths.sessions.create.createAppointment,
       })(req, res, next)

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -7,6 +7,7 @@ import { APPOINTMENT_FORM_PAGES_AUDIT_MAP, AppointmentFormPage } from '../pages/
 import { Services } from '../services'
 import featureFlagMiddleware from './featureFlagMiddleware'
 import requirementMiddleware from './requirementMiddleware'
+import buildRequirementPagePaths from '../paths/requirementPagePaths'
 
 const bulkUpdateAppointmentFormPages: Array<AppointmentFormPage> = [
   'choose-supervisor',
@@ -59,17 +60,13 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
     [
       requirementMiddleware(services.offenderService, paths.sessions.create.createAppointment),
       (req, res, next) =>
-        requirementController.show({
-          backPath: paths.sessions.create.findAPerson({
-            projectCode: req.params.projectCode,
-            date: req.params.date,
-          }),
-          updatePath: paths.sessions.create.requirement({
+        requirementController.show(
+          buildRequirementPagePaths(paths.sessions.create, {
             projectCode: req.params.projectCode,
             date: req.params.date,
             crn: req.params.crn,
           }),
-        })(req, res, next),
+        )(req, res, next),
     ],
     {
       auditEvent: Page.VIEW_CREATE_APPOINTMENT_REQUIREMENT_PAGE,
@@ -78,16 +75,13 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
   post(
     paths.sessions.create.requirement.pattern,
     (req, res, next) => {
-      const params = {
-        crn: req.params.crn,
-        projectCode: req.params.projectCode,
-        date: req.params.date,
-      }
-      return requirementController.submit({
-        backPath: paths.sessions.create.findAPerson(params),
-        updatePath: paths.sessions.create.requirement(params),
-        createAppointmentPath: paths.sessions.create.createAppointment,
-      })(req, res, next)
+      return requirementController.submit(
+        buildRequirementPagePaths(paths.sessions.create, {
+          crn: req.params.crn,
+          projectCode: req.params.projectCode,
+          date: req.params.date,
+        }),
+      )(req, res, next)
     },
     {
       auditEvent: Page.EDIT_CREATE_APPOINTMENT_REQUIREMENT_PAGE,

--- a/server/views/pages/requirement.njk
+++ b/server/views/pages/requirement.njk
@@ -1,8 +1,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "../showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../partials/layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
 
 {% block content %}
   {{ showErrorSummary(errorSummary) }}


### PR DESCRIPTION
## Context

This adds a backlink on the requirement page of the create appointment form. This will be dynamic and set on the router to handle different entry points for the form. See #700 for more.

[CPB-1175](https://dsdmoj.atlassian.net/browse/CPB-1175)

## Changes in this PR

I have also created some methods to help build the create paths for each paths namespace (projects, sessions, people):

- createAppointmentPaths builder: used in the paths declaration to create an identical set of paths given a basePath (e.g. `/projects/:projectCode`)
- requirementPagePaths builder: returns these paths for the given basePath, in the shape expected by the requirement page controller in order to handle navigation (as a backPath, updatePath and createAppointmentPath)

### Pending work

- Handle in progress form parameter in paths
- Handle original search parameters in paths

### Thoughts on further improvements

- It would be good to tidy up the name difference for the `backLink` property everywhere!

### Screenshots of UI changes

Navigating back on the session route:

https://github.com/user-attachments/assets/fc6f3c0c-ee7e-42de-a37d-47e42560e1d9

Navigating back on the project route:


https://github.com/user-attachments/assets/6feb83e1-067a-4f7a-8278-344ecf0a9335



## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1175]: https://dsdmoj.atlassian.net/browse/CPB-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ