### PR TITLE
CPB-971: Case admin UI mandatory radio buttons for choosing to alert Probation Practitioner

### DIFF
--- a/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
+++ b/e2e-tests/pages/courseCompletions/courseCompletionFormPage.ts
@@ -33,6 +33,8 @@ export default class CourseCompletionFormPage extends BasePage {
 
   readonly projectQuestions: ProjectQuestionsComponent
 
+  private readonly alertPractitionerQuestionLocator: Locator
+
   constructor(
     page: Page,
     readonly hasExistingAppointments: boolean = false,
@@ -50,6 +52,9 @@ export default class CourseCompletionFormPage extends BasePage {
     this.createNewAppointmentButton = page.getByRole('button', { name: 'Create an appointment' })
     this.unableToCreditTimeNotes = page.getByLabel('Add reason')
     this.unableToCreditTimeLink = page.getByRole('link', { name: 'Unable to credit hours' })
+    this.alertPractitionerQuestionLocator = page.getByRole('group', {
+      name: /Would you (?:also )?like to share this outcome with the probation practitioner?/,
+    })
   }
 
   async continue() {
@@ -90,6 +95,10 @@ export default class CourseCompletionFormPage extends BasePage {
 
   async clickUnableToCreditTimeLink() {
     await this.unableToCreditTimeLink.click()
+  }
+
+  async selectAlertPractitioner() {
+    await this.alertPractitionerQuestionLocator.getByLabel('Yes').check()
   }
 }
 

--- a/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
+++ b/e2e-tests/tests/ete/06_course_completion_existing_appointment.spec.ts
@@ -66,6 +66,7 @@ test('Process course completion - credit time on existing appointment', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.selectAlertPractitioner()
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
+++ b/e2e-tests/tests/ete/07_course_completion_new_appointment.spec.ts
@@ -64,6 +64,7 @@ test('Process course completion - create new appointment', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.selectAlertPractitioner()
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
+++ b/e2e-tests/tests/ete/11_course_completion_recommended_crn.spec.ts
@@ -64,6 +64,7 @@ test('Process course completion - use recommended CRN', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.selectAlertPractitioner()
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()
@@ -107,6 +108,7 @@ test('Process course completion - use recommended CRN', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.selectAlertPractitioner()
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
+++ b/e2e-tests/tests/ete/course_completion_process_failure.spec.ts
@@ -64,6 +64,7 @@ test('Process course completion failure', async ({
   await courseCompletionFormPage.continue()
 
   await courseCompletionFormPage.expect.toBeOnThePage('confirm')
+  await courseCompletionFormPage.selectAlertPractitioner()
   await courseCompletionFormPage.continue()
 
   await searchCourseCompletionsPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/02_update_appointment_enforcement.spec.ts
@@ -40,6 +40,8 @@ test('Update a session appointment with an enforceable outcome', async ({
   await confirmPage.expect.toShowOutcome('Unacceptable absence')
   await confirmPage.expect.toShowMessageThatOutcomeWillAlert()
 
+  await confirmPage.selectAlertPractitioner()
+
   await confirmPage.confirmButtonLocator.click()
 
   await sessionPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/03_update_appointment_attended_enforcement.spec.ts
@@ -46,6 +46,8 @@ test('Update a session appointment with an attended but enforceable outcome', as
   await confirmPage.expect.toShowOutcome('Attended \u2013 failed to comply')
   await confirmPage.expect.toShowComplianceAnswer()
 
+  await confirmPage.selectAlertPractitioner()
+
   await confirmPage.confirmButtonLocator.click()
 
   await sessionPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
+++ b/e2e-tests/tests/group-placements/04_update_appointment_notAttended_noEnforcement.spec.ts
@@ -42,6 +42,8 @@ test('Update a session appointment with a not attended but not enforceable outco
   await confirmPage.expect.toShowAnswers(team.supervisor, project.availability, false)
   await confirmPage.expect.toShowOutcome('Rescheduled \u2013 service request')
 
+  await confirmPage.selectAlertPractitioner()
+
   await confirmPage.confirmButtonLocator.click()
 
   await sessionPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/05_update_individual_placement_appointment.spec.ts
@@ -47,6 +47,8 @@ test('Update an individual placement appointment with attended complied', async 
   await confirmPage.expect.toShowOutcome('Attended \u2013 complied')
   await confirmPage.expect.toShowComplianceAnswer()
 
+  await confirmPage.selectAlertPractitioner()
+
   await confirmPage.confirmButtonLocator.click()
 
   await projectPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/09_credit_travel_time.spec.ts
@@ -50,6 +50,7 @@ test(
     const confirmPage = new ConfirmPage(page)
     await confirmPage.expect.toBeOnThePage()
 
+    await confirmPage.selectAlertPractitioner()
     await confirmPage.confirmButtonLocator.click()
 
     await sessionPage.expect.toBeOnThePage()

--- a/e2e-tests/tests/travel-time/10_unable_to_credit_travel_time.spec.ts
+++ b/e2e-tests/tests/travel-time/10_unable_to_credit_travel_time.spec.ts
@@ -41,6 +41,7 @@ test(
     const confirmPage = new ConfirmPage(page)
     await confirmPage.expect.toBeOnThePage()
 
+    await confirmPage.selectAlertPractitioner()
     await confirmPage.confirmButtonLocator.click()
 
     await sessionPage.expect.toBeOnThePage()

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -105,6 +105,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     })
   }
 
+  shouldShowAlertPractitionerError() {
+    cy.get(`[data-cy-error-alertpractitioner]`).should('contain', 'Choose whether you want to send an alert')
+  }
+
   shouldNotShowChangeLink(label: string) {
     this.formDetails.shouldNotContainAction(label)
   }

--- a/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
+++ b/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
@@ -89,4 +89,8 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
       cy.get('li').contains(message)
     })
   }
+
+  shouldShowAlertPractitionerError() {
+    cy.get(`[data-cy-error-alertpractitioner]`).should('contain', 'Choose whether you want to send an alert')
+  }
 }

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -534,6 +534,9 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubUpdateAppointmentOutcome', { appointment })
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // And I click confirm
       page.clickSubmit('Confirm')
 
@@ -607,6 +610,9 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubUpdateAppointmentOutcome', { appointment })
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // And I click confirm
       page.clickSubmit('Confirm')
 
@@ -665,6 +671,9 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubUpdateAppointmentOutcome', { appointment })
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // And I click confirm
       page.clickSubmit('Confirm')
 
@@ -710,6 +719,9 @@ context('Confirm appointment details page', () => {
 
       cy.task('stubUpdateAppointmentOutcome', { appointment })
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // And I click confirm
       page.clickSubmit('Confirm')
 
@@ -743,6 +755,9 @@ context('Confirm appointment details page', () => {
         appointment,
         userMessage,
       })
+
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
 
       // And I click confirm
       page.clickSubmit('Confirm')

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -62,6 +62,12 @@
 //    And I click confirm
 //    Then I can see the error message
 
+// Scenario: submitting a new appointment that fails validation
+//    Given I am on the confirm page for a new appointment
+//    And I do not choose an option for sending an alert to the practitioner
+//    When I click confirm
+//    Then I see the error message
+
 import appointmentFactory from '../../../server/testutils/factories/appointmentFactory'
 import appointmentOutcomeFormFactory from '../../../server/testutils/factories/appointmentOutcomeFormFactory'
 import attendanceDataFactory from '../../../server/testutils/factories/attendanceDataFactory'
@@ -764,6 +770,32 @@ context('Confirm appointment details page', () => {
 
       // Then I can see the error message
       page.shouldShowErrorSummary(userMessage)
+    })
+
+    // Scenario: submitting a new appointment that fails validation
+    it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {
+      const appointment = appointmentFactory.build({ version: '1', alertActive: null })
+      const form = appointmentOutcomeFormFactory.build({ deliusVersion: '1' })
+      const project = projectFactory.build({
+        projectCode: appointment.projectCode,
+      })
+
+      cy.task('stubFindProject', { project })
+
+      // Given I am on the confirm page of an in progress update
+      cy.task('stubFindAppointment', { appointment })
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visit(appointment, form)
+
+      // And I do not choose an option for sending an alert to the practitioner
+      // When I click confirm
+
+      page.clickSubmit('Confirm')
+
+      // Then I see the error message
+      page.shouldShowAlertPractitionerError()
     })
   })
 })

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -379,6 +379,9 @@ context('Create appointment - Confirm details', () => {
       // Given I am on the confirm page for a new appointment
       const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // When I click confirm
       page.clickSubmit('Confirm')
 
@@ -408,6 +411,9 @@ context('Create appointment - Confirm details', () => {
       // Given I am on the confirm page for a new appointment
       const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
 
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // When I click confirm
       page.clickSubmit('Confirm')
 
@@ -433,6 +439,9 @@ context('Create appointment - Confirm details', () => {
 
       // Given I am on the confirm page for a new appointment
       const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
 
       // When I click confirm
       page.clickSubmit('Confirm')

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -46,6 +46,12 @@
 //    When I click confirm
 //    Then I see the error message
 
+// Scenario: submitting a new appointment that fails validation
+//    Given I am on the confirm page for a new appointment
+//    And I do not choose an option for sending an alert to the practitioner
+//    When I click confirm
+//    Then I see the error message
+
 import attendanceDataFactory from '../../../../server/testutils/factories/attendanceDataFactory'
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import {
@@ -448,6 +454,28 @@ context('Create appointment - Confirm details', () => {
 
       // Then I see the error message
       page.shouldShowErrorSummary(userMessage)
+    })
+
+    // Scenario: submitting a new appointment that fails validation
+    it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {
+      const form = createAppointmentFormFactory.build({
+        crn: this.offender.crn,
+        project: { code: this.project.projectCode, name: this.project.projectName },
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubFindProject', { project: this.project })
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // And I do not choose an option for sending an alert to the practitioner
+      // When I click confirm
+
+      page.clickSubmit('Confirm')
+
+      // Then I see the error message
+      page.shouldShowAlertPractitionerError()
     })
   })
 })

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -450,6 +450,9 @@ context('Confirm details page', () => {
         userMessage,
       })
 
+      // When I select yes to sending an alert
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       // And I submit
       page.clickSubmit()
 

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -69,6 +69,11 @@
 //      When I submit
 //      And the API returns a 400 error
 //      Then I can see the error message
+//    Scenario: submitting a new appointment that fails validation
+//      Given I am on the confirm page for a new appointment
+//      And I do not choose an option for sending an alert to the practitioner
+//      When I click confirm
+//      Then I see the error message
 
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import courseCompletionFactory from '../../../../server/testutils/factories/courseCompletionFactory'
@@ -458,6 +463,19 @@ context('Confirm details page', () => {
 
       // Then I can see the error message
       page.shouldShowErrorSummary(userMessage)
+    })
+
+    it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {
+      // Given I am on the confirm page of an in progress update
+      const page = ConfirmDetailsPage.visit(courseCompletion, form)
+
+      // And I do not choose an option for sending an alert to the practitioner
+      // When I click confirm
+
+      page.clickSubmit('Continue')
+
+      // Then I see the error message
+      page.shouldShowAlertPractitionerError()
     })
   })
 })

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -184,6 +184,8 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       const results = updateAppointmentOutcomeResultFactory.buildList(2)
       cy.task('stubBulkUpdateAppointmentOutcome', { projectCode: this.project.projectCode, results })
 
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       page.clickSubmit('Confirm')
 
       const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
@@ -229,6 +231,8 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
       ]
       cy.task('stubBulkUpdateAppointmentOutcome', { projectCode: this.project.projectCode, results })
 
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
       page.clickSubmit('Confirm')
 
       const viewSessionPage = Page.verifyOnPage(ViewSessionPage, this.session)
@@ -248,6 +252,9 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
     })
 
     const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+
+    page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
     page.clickSubmit('Confirm')
 
     page.shouldShowErrorSummary(userMessage)

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -259,4 +259,17 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
 
     page.shouldShowErrorSummary(userMessage)
   })
+
+  it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {
+    // Given I am on the confirm page of an in progress update
+    const page = ConfirmDetailsPage.visitForSession(this.session, this.form)
+
+    // And I do not choose an option for sending an alert to the practitioner
+    // When I click confirm
+
+    page.clickSubmit('Confirm')
+
+    // Then I see the error message
+    page.shouldShowAlertPractitionerError()
+  })
 })

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -41,6 +41,16 @@ describe('ConfirmController', () => {
     someKey: 'some value',
   }
 
+  let mockPageInstance: {
+    validationErrors: jest.Mock
+    commonViewData: jest.Mock
+    viewData: jest.Mock
+    paths: jest.Mock
+    offenderHeading: jest.Mock
+    isAlertSelected: jest.Mock
+    exitForm: jest.Mock
+    updatePath: jest.Mock
+  }
   let confirmController: ConfirmController
   const appointmentService = createMock<AppointmentService>()
   const appointmentFormService = createMock<AppointmentFormService>()
@@ -51,6 +61,24 @@ describe('ConfirmController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
+
+    mockPageInstance = {
+      validationErrors: jest.fn().mockReturnValue({
+        hasErrors: false,
+        errors: {},
+        errorSummary: [],
+      }),
+      commonViewData: jest.fn().mockReturnValue(pageViewData),
+      viewData: jest.fn().mockReturnValue(pageViewData),
+      paths: jest.fn().mockReturnValue({}),
+      offenderHeading: jest.fn().mockReturnValue({ title: 'Some Name', caption: 'X123456' }),
+      isAlertSelected: jest.fn().mockReturnValue(true),
+      exitForm: jest.fn().mockReturnValue('/default'),
+      updatePath: jest.fn().mockReturnValue('/default'),
+    }
+
+    confirmPageMock.mockReturnValue(mockPageInstance)
+
     confirmController = new ConfirmController(
       appointmentService,
       appointmentFormService,
@@ -71,13 +99,9 @@ describe('ConfirmController', () => {
       const viewDataSpy = jest.fn().mockReturnValue(pageViewData)
       const pathsSpy = jest.fn().mockReturnValue(navigationPaths)
       const offenderHeadingSpy = jest.fn().mockReturnValue(heading)
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          paths: pathsSpy,
-          viewData: viewDataSpy,
-          offenderHeading: offenderHeadingSpy,
-        }
-      })
+      mockPageInstance.paths.mockImplementation(pathsSpy)
+      mockPageInstance.viewData.mockImplementation(viewDataSpy)
+      mockPageInstance.offenderHeading.mockImplementation(offenderHeadingSpy)
 
       const response = createMock<Response>({ locals: { user: { username: 'user-name' }, errorMessages: [] } })
       appointmentFormService.getForm.mockResolvedValue(form)
@@ -113,13 +137,9 @@ describe('ConfirmController', () => {
       const form = appointmentOutcomeFormFactory.build({ date: '2026-01-01' })
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
 
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          paths: () => ({}),
-          viewData: () => pageViewData,
-          offenderHeading: () => ({ title: 'Some Name', caption: 'X123456' }),
-        }
-      })
+      mockPageInstance.paths.mockReturnValue({})
+      mockPageInstance.viewData.mockReturnValue(pageViewData)
+      mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
 
       const response = createMock<Response>({
         locals: { user: { username: 'user-name' }, errorMessages },
@@ -143,12 +163,8 @@ describe('ConfirmController', () => {
     it('should render the check appointment details page', async () => {
       const form = appointmentOutcomeFormFactory.build()
 
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          commonViewData: () => ({}),
-          viewData: () => pageViewData,
-        }
-      })
+      mockPageInstance.commonViewData.mockReturnValue({})
+      mockPageInstance.viewData.mockReturnValue(pageViewData)
       const appointment = appointmentFactory.build()
 
       const response = createMock<Response>()
@@ -170,12 +186,8 @@ describe('ConfirmController', () => {
       const form = appointmentOutcomeFormFactory.build()
       const appointment = appointmentFactory.build()
 
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          commonViewData: () => ({}),
-          viewData: () => pageViewData,
-        }
-      })
+      mockPageInstance.commonViewData.mockReturnValue({})
+      mockPageInstance.viewData.mockReturnValue(pageViewData)
 
       appointmentService.getAppointment.mockResolvedValue(appointment)
       appointmentFormService.getForm.mockResolvedValue(form)
@@ -197,12 +209,8 @@ describe('ConfirmController', () => {
       const project = projectFactory.build({ projectCode })
       const nextPath = 'next'
       const exitFormSpy = jest.fn().mockReturnValue(nextPath)
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: exitFormSpy,
-          isAlertSelected: () => true,
-        }
-      })
+      mockPageInstance.exitForm.mockImplementation(exitFormSpy)
+      mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
       const requestWithNewAppointment = createMock<Request>({
@@ -250,12 +258,8 @@ describe('ConfirmController', () => {
     })
 
     it('should create appointment data without attendance data if did not attend', async () => {
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: () => 'next',
-          isAlertSelected: () => true,
-        }
-      })
+      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const project = projectFactory.build({ projectCode })
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -286,12 +290,8 @@ describe('ConfirmController', () => {
 
     describe('start and end times', () => {
       it('uses the form value when the outcome is attended', async () => {
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => 'next',
-            isAlertSelected: () => true,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue('next')
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
 
         const project = projectFactory.build({ projectCode })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -323,12 +323,8 @@ describe('ConfirmController', () => {
       })
 
       it('uses the project default availability when the outcome is not attended, ignoring any edited form value', async () => {
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => 'next',
-            isAlertSelected: () => true,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue('next')
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
 
         const project = projectFactory.build({
           projectCode,
@@ -367,12 +363,8 @@ describe('ConfirmController', () => {
     })
 
     it('should set the audit subject to the CRN', async () => {
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: () => 'next',
-          isAlertSelected: () => true,
-        }
-      })
+      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const project = projectFactory.build({ projectCode })
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -399,12 +391,8 @@ describe('ConfirmController', () => {
     })
 
     it.each([true, false])('uses the alert value selected by the user', async (userSelectedValue: boolean) => {
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          exitForm: () => 'next',
-          isAlertSelected: () => userSelectedValue,
-        }
-      })
+      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.isAlertSelected.mockReturnValue(userSelectedValue)
 
       const project = projectFactory.build({ projectCode })
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -446,12 +434,8 @@ describe('ConfirmController', () => {
         },
       }
 
-      confirmPageMock.mockImplementationOnce(() => {
-        return {
-          isAlertSelected: () => true,
-          updatePath: () => '/update/path',
-        }
-      })
+      mockPageInstance.isAlertSelected.mockReturnValue(true)
+      mockPageInstance.updatePath.mockReturnValue('/update/path')
 
       const project = projectFactory.build({ projectCode })
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -496,12 +480,8 @@ describe('ConfirmController', () => {
     describe('given an individual appointment route', () => {
       it('should send appointment data and redirect to session page with success message', async () => {
         const nextPath = 'next'
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => nextPath,
-            isAlertSelected: () => true,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue(nextPath)
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
         const project = projectFactory.build()
         const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -544,12 +524,8 @@ describe('ConfirmController', () => {
 
       it('should add a session link to the success message if project has changed', async () => {
         const nextPath = 'next'
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => nextPath,
-            isAlertSelected: () => true,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue(nextPath)
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
         const project = projectFactory.build()
         const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -702,12 +678,8 @@ describe('ConfirmController', () => {
         it.each([true, false])(
           'any user selected value is submitted with the update',
           async (userSelectedValue: boolean) => {
-            confirmPageMock.mockImplementationOnce(() => {
-              return {
-                isAlertSelected: () => userSelectedValue,
-                exitForm: () => '',
-              }
-            })
+            mockPageInstance.isAlertSelected.mockReturnValue(userSelectedValue)
+            mockPageInstance.exitForm.mockReturnValue('')
             const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
             const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -731,12 +703,8 @@ describe('ConfirmController', () => {
         it.each([true, false, undefined])(
           'sends original appointment value if user selected value is undefined',
           async (appointmentValue?: boolean) => {
-            confirmPageMock.mockImplementationOnce(() => {
-              return {
-                isAlertSelected: (): boolean | null => null,
-                exitForm: () => '',
-              }
-            })
+            mockPageInstance.isAlertSelected.mockReturnValue(null)
+            mockPageInstance.exitForm.mockReturnValue('')
             const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
             const appointment = appointmentFactory.build({ version: appointmentVersion, alertActive: appointmentValue })
@@ -803,12 +771,8 @@ describe('ConfirmController', () => {
 
       it('redirects to next page if appointment was updated elsewhere', async () => {
         const nextPath = 'next'
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => nextPath,
-            isAlertSelected: (): boolean | null => null,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue(nextPath)
+        mockPageInstance.isAlertSelected.mockReturnValue(null)
         formAppointmentVersion = '1'
         appointmentVersion = '2'
 
@@ -844,12 +808,8 @@ describe('ConfirmController', () => {
           },
         }
 
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            isAlertSelected: () => true,
-            updatePath: () => '/update/path',
-          }
-        })
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
+        mockPageInstance.updatePath.mockReturnValue('/update/path')
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
         const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -890,12 +850,8 @@ describe('ConfirmController', () => {
 
       it('should send multiple appointment updates via saveAppointments and redirect', async () => {
         const nextPath = 'next'
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => nextPath,
-            isAlertSelected: () => true,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue(nextPath)
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
         const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
@@ -1001,12 +957,8 @@ describe('ConfirmController', () => {
       })
 
       it('should include attendance data when didAttend is true', async () => {
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => '',
-            isAlertSelected: () => false,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue('')
+        mockPageInstance.isAlertSelected.mockReturnValue(false)
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
         const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -1037,12 +989,8 @@ describe('ConfirmController', () => {
       })
 
       it('should exclude attendance data when didAttend is false', async () => {
-        confirmPageMock.mockImplementationOnce(() => {
-          return {
-            exitForm: () => '',
-            isAlertSelected: () => false,
-          }
-        })
+        mockPageInstance.exitForm.mockReturnValue('')
+        mockPageInstance.isAlertSelected.mockReturnValue(false)
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
         const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -1074,12 +1022,9 @@ describe('ConfirmController', () => {
 
       describe('start and end times', () => {
         it('uses the form value when the outcome is attended', async () => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => '',
-              isAlertSelected: () => false,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue('')
+          mockPageInstance.isAlertSelected.mockReturnValue(false)
+
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointment = appointmentFactory.build({
@@ -1149,12 +1094,8 @@ describe('ConfirmController', () => {
         })
 
         it('uses the appointment value when the outcome is not attended, ignoring any edited form value', async () => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => '',
-              isAlertSelected: () => false,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue('')
+          mockPageInstance.isAlertSelected.mockReturnValue(false)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointment = appointmentFactory.build({
@@ -1192,12 +1133,8 @@ describe('ConfirmController', () => {
 
       describe('supervisorTeamCode', () => {
         it('should include supervisor team code when this is set on the form', async () => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => '',
-              isAlertSelected: () => false,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue('')
+          mockPageInstance.isAlertSelected.mockReturnValue(false)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointment = appointmentFactory.build({ version: appointmentVersion })
@@ -1232,12 +1169,8 @@ describe('ConfirmController', () => {
 
       describe('alertActive', () => {
         it.each([true, false])('uses user selected value for alertActive', async (userSelectedValue: boolean) => {
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              isAlertSelected: () => userSelectedValue,
-              exitForm: () => '',
-            }
-          })
+          mockPageInstance.isAlertSelected.mockReturnValue(userSelectedValue)
+          mockPageInstance.exitForm.mockReturnValue('')
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointment = appointmentFactory.build({ version: appointmentVersion, alertActive: false })
@@ -1270,12 +1203,8 @@ describe('ConfirmController', () => {
         it.each([true, false, undefined])(
           'uses appointment value when user selected value is not set',
           async (appointmentValue?: boolean) => {
-            confirmPageMock.mockImplementationOnce(() => {
-              return {
-                isAlertSelected: (): boolean | null => null,
-                exitForm: () => '',
-              }
-            })
+            mockPageInstance.isAlertSelected.mockReturnValue(null)
+            mockPageInstance.exitForm.mockReturnValue('')
             const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
             const appointment = appointmentFactory.build({
@@ -1344,15 +1273,59 @@ describe('ConfirmController', () => {
         })
       })
 
+      it('should send appointment start and end times if undefined on form', async () => {
+        const nextPath = 'next'
+
+        mockPageInstance.exitForm.mockReturnValue(nextPath)
+        mockPageInstance.isAlertSelected.mockReturnValue(true)
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+
+        const appointment = appointmentFactory.build({ version: appointmentVersion })
+        const contactOutcome = contactOutcomeFactory.build({ attended: true })
+        const form = appointmentOutcomeFormFactory.build({
+          startTime: undefined,
+          endTime: undefined,
+          contactOutcome,
+          deliusVersion: formAppointmentVersion,
+          isSensitive: 'yes',
+          appointments: [{ id: appointment.id, deliusVersion: appointmentVersion }],
+        })
+
+        appointmentService.getAppointment.mockResolvedValueOnce(appointment)
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = confirmController.submitUpdate()
+        await requestHandler(bulkRequest, response, next)
+
+        expect(appointmentService.saveAppointments).toHaveBeenCalledWith(
+          projectCode,
+          {
+            updates: [
+              {
+                deliusId: appointment.id,
+                deliusVersionToUpdate: appointment.version,
+                alertActive: true,
+                sensitive: appointment.sensitive,
+                startTime: appointment.startTime,
+                endTime: appointment.endTime,
+                contactOutcomeCode: form.contactOutcome.code,
+                attendanceData: form.attendanceData,
+                supervisorOfficerCode: form.supervisor.code,
+                date: appointment.date,
+                notes: form.notes,
+                projectCode: form.project.code,
+              },
+            ],
+          },
+          'user-name',
+        )
+      })
+
       describe('bulk update response handling', () => {
         it('should flash success message when all results are successful', async () => {
           const nextPath = 'next'
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => nextPath,
-              isAlertSelected: () => true,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue(nextPath)
+          mockPageInstance.isAlertSelected.mockReturnValue(true)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
           const project = projectFactory.build()
           const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
@@ -1390,12 +1363,8 @@ describe('ConfirmController', () => {
 
         it('should add a session link to the success message if project has changed', async () => {
           const nextPath = 'next'
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => nextPath,
-              isAlertSelected: () => true,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue(nextPath)
+          mockPageInstance.isAlertSelected.mockReturnValue(true)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
           const project = projectFactory.build()
           const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
@@ -1441,12 +1410,8 @@ describe('ConfirmController', () => {
 
         it('should flash error message when some results have errors', async () => {
           const nextPath = 'next'
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => nextPath,
-              isAlertSelected: () => true,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue(nextPath)
+          mockPageInstance.isAlertSelected.mockReturnValue(true)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
@@ -1485,12 +1450,8 @@ describe('ConfirmController', () => {
 
         it('should flash error message when all results have errors', async () => {
           const nextPath = 'next'
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              exitForm: () => nextPath,
-              isAlertSelected: () => true,
-            }
-          })
+          mockPageInstance.exitForm.mockReturnValue(nextPath)
+          mockPageInstance.isAlertSelected.mockReturnValue(true)
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointments = appointmentFactory.buildList(2, { version: appointmentVersion })
@@ -1540,12 +1501,8 @@ describe('ConfirmController', () => {
             },
           }
 
-          confirmPageMock.mockImplementationOnce(() => {
-            return {
-              isAlertSelected: () => true,
-              updatePath: () => '/update/path',
-            }
-          })
+          mockPageInstance.isAlertSelected.mockReturnValue(true)
+          mockPageInstance.updatePath.mockReturnValue('/update/path')
           const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
 
           const appointment = appointmentFactory.build({ version: appointmentVersion })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -159,6 +159,21 @@ export default class ConfirmController implements IAppointmentFormPageController
       const page = new ConfirmPage()
       const formId = _req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
+
+      const { errors, hasErrors, errorSummary } = page.validationErrors(_req.body)
+      const preventDoubleClick = true
+      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
+
+      if (hasErrors) {
+        return res.render('appointments/update/confirm', {
+          ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
+          ...page.viewData(appointmentOrSession, pathData, form, formId),
+          errorSummary,
+          errors,
+          preventDoubleClick,
+        })
+      }
+
       const didAttend = form.contactOutcome.attended
       const isAlertSelected = page.isAlertSelected(_req.body)
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -107,6 +107,32 @@ export default class ConfirmController implements IAppointmentFormPageController
         projectCode: appointmentParams.projectCode,
       })
 
+      const navigationPaths = page.paths({
+        pathData: appointmentParams,
+        form,
+        formId,
+      })
+
+      const offenderSummary = await this.offenderService.getOffenderSummary({
+        username: res.locals.user.username,
+        crn: (form as CreateAppointmentForm).crn,
+      })
+
+      const { errors, hasErrors, errorSummary } = page.validationErrors(req.body)
+      const preventDoubleClick = true
+      const pathData = { ...appointmentParams, date: form.date }
+
+      if (hasErrors) {
+        return res.render('appointments/update/confirm', {
+          heading: page.offenderHeading(offenderSummary.offender),
+          ...navigationPaths,
+          ...page.viewData(undefined, pathData, form, formId, { includeDateItem: true }),
+          errorSummary,
+          errors,
+          preventDoubleClick,
+        })
+      }
+
       const didAttend = form.contactOutcome.attended
       const defaultAvailability = project.availability[0]
 

--- a/server/controllers/courseCompletions/process/confirmController.test.ts
+++ b/server/controllers/courseCompletions/process/confirmController.test.ts
@@ -22,6 +22,7 @@ import pagedModelAppointmentSummaryFactory from '../../../testutils/factories/pa
 import { pathWithQuery } from '../../../utils/utils'
 import appointmentFactory from '../../../testutils/factories/appointmentFactory'
 import AuditService from '../../../services/auditService'
+import { YesOrNo } from '../../../@types/user-defined'
 
 describe('ConfirmController', () => {
   const username = 'username'
@@ -187,13 +188,21 @@ describe('ConfirmController', () => {
   })
 
   describe('submit', () => {
+    beforeEach(() => {
+      page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
+    })
+
     it('saves course completion and redirects to the search page', async () => {
       const resolution = courseCompletionResolutionFactory.build()
       const successMessage = 'Success'
       page.requestBody.mockReturnValue(resolution)
       page.successMessage.mockReturnValue(successMessage)
       const query = { pdu: '2', form: '1' }
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query, body: {} })
+      const request: DeepMocked<Request> = createMock<Request>({
+        params: { id: '1' },
+        query,
+        body: { alertPractitioner: 'yes' },
+      })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)
@@ -204,7 +213,7 @@ describe('ConfirmController', () => {
       expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
       expect(request.flash).toHaveBeenCalledWith('success', successMessage)
       expect(appointmentService.getAppointment).not.toHaveBeenCalled()
-      expect(page.requestBody).toHaveBeenCalledWith(form, {}, undefined)
+      expect(page.requestBody).toHaveBeenCalledWith(form, { alertPractitioner: 'yes' as YesOrNo }, undefined)
     })
 
     it('redirects to the index page if no original search', async () => {
@@ -213,9 +222,14 @@ describe('ConfirmController', () => {
       formService.getForm.mockResolvedValue(form)
       const successMessage = 'Success'
       page.requestBody.mockReturnValue(resolution)
+      page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
       page.successMessage.mockReturnValue(successMessage)
       const query = { pdu: '2', form: '1' }
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
+      const request: DeepMocked<Request> = createMock<Request>({
+        params: { id: '1' },
+        query,
+        body: { alertPractitioner: 'yes' },
+      })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)
@@ -231,9 +245,14 @@ describe('ConfirmController', () => {
       formService.getForm.mockResolvedValue(form)
       const successMessage = 'Success'
       page.requestBody.mockReturnValue(resolution)
+      page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
       page.successMessage.mockReturnValue(successMessage)
       const query = { pdu: '2', form: '1' }
-      const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query })
+      const request: DeepMocked<Request> = createMock<Request>({
+        params: { id: '1' },
+        query,
+        body: { alertPractitioner: 'yes' },
+      })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)
@@ -258,11 +277,12 @@ describe('ConfirmController', () => {
       }
 
       page.requestBody.mockReturnValue(resolution)
+      page.validationErrors.mockReturnValue({ hasErrors: false, errors: {}, errorSummary: [] })
       const path = '/path'
       page.updatePath.mockReturnValue(path)
       courseCompletionService.saveResolution.mockRejectedValue(error)
 
-      const request = createMock<Request>({ params: { id: '1', form: '2' } })
+      const request = createMock<Request>({ params: { id: '1', form: '2' }, body: { alertPractitioner: 'yes' } })
 
       const requestHandler = confirmController.submit()
       await requestHandler(request, response, next)
@@ -283,7 +303,11 @@ describe('ConfirmController', () => {
         page.requestBody.mockReturnValue(resolution)
         page.successMessage.mockReturnValue(successMessage)
         const query = { pdu: '2', form: '1' }
-        const request: DeepMocked<Request> = createMock<Request>({ params: { id: '1' }, query, body: {} })
+        const request: DeepMocked<Request> = createMock<Request>({
+          params: { id: '1' },
+          query,
+          body: { alertPractitioner: 'yes' },
+        })
 
         const requestHandler = confirmController.submit()
         await requestHandler(request, response, next)
@@ -294,7 +318,11 @@ describe('ConfirmController', () => {
         expect(courseCompletionService.saveResolution).toHaveBeenCalledWith({ id: '1', username }, resolution)
         expect(request.flash).toHaveBeenCalledWith('success', successMessage)
 
-        expect(page.requestBody).toHaveBeenCalledWith(form, {}, appointmentIsSensitive)
+        expect(page.requestBody).toHaveBeenCalledWith(
+          form,
+          { alertPractitioner: 'yes' as YesOrNo },
+          appointmentIsSensitive,
+        )
       },
     )
   })

--- a/server/controllers/courseCompletions/process/confirmController.ts
+++ b/server/controllers/courseCompletions/process/confirmController.ts
@@ -58,6 +58,23 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
       })
 
       const payload = this.page.requestBody(formData, req.body, appointment?.sensitive)
+      const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body)
+      const preventDoubleClick = true
+
+      const courseCompletion = await this.courseCompletionService.getCourseCompletion({
+        username: res.locals.user.username,
+        id: courseCompletionId,
+      })
+
+      if (hasErrors) {
+        return res.render(this.page.templatePath, {
+          ...this.page.viewData(courseCompletion, formId, this.getOriginalSearch(req, formData)),
+          ...(await this.getStepViewData({ req, res, courseCompletion, formData, formId, errors })),
+          errorSummary,
+          errors,
+          preventDoubleClick,
+        })
+      }
 
       try {
         await this.courseCompletionService.saveResolution(
@@ -68,9 +85,9 @@ export default class ConfirmController extends BaseController<ConfirmPage> {
 
         req.flash('success', successMessage)
 
-        res.redirect(this.buildNextPath(formData))
+        return res.redirect(this.buildNextPath(formData))
       } catch (error) {
-        catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath({ courseCompletionId, formId }))
+        return catchApiValidationErrorOrPropagate(req, res, error, this.page.updatePath({ courseCompletionId, formId }))
       }
     }
   }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -774,6 +774,23 @@ describe('ConfirmPage', () => {
     )
   })
 
+  describe('validationErrors', () => {
+    it('returns error when no alert option is selected', () => {
+      const page = new ConfirmPage()
+
+      const { errors } = page.validationErrors({ alertPractitioner: undefined })
+      expect(errors).toEqual({
+        alertPractitioner: { text: 'Choose whether you want to send an alert' },
+      })
+    })
+    it('returns no error when an alert option is selected', () => {
+      const page = new ConfirmPage()
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' })
+      expect(errors).toEqual({})
+    })
+  })
+
   describe('deliusVersionChangedMessage', () => {
     it('should return singular form message for 1 appointment', () => {
       const page = new ConfirmPage()

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -37,8 +37,14 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     return form
   }
 
-  protected getValidationErrors(_query: Query, _additionalParams?: unknown): ValidationErrors<Query> {
-    return {}
+  protected getValidationErrors(query: Query, _additionalParams?: unknown): ValidationErrors<Query> {
+    const validationErrors: ValidationErrors<Query> = {}
+
+    if (!query.alertPractitioner) {
+      validationErrors.alertPractitioner = { text: 'Choose whether you want to send an alert' }
+    }
+
+    return validationErrors
   }
 
   viewData(

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -5,7 +5,7 @@ import {
   ProviderTeamSummaryDto,
   UnpaidWorkDetailsDto,
 } from '../../../@types/shared'
-import { GovUkSummaryListItem, YesOrNo } from '../../../@types/user-defined'
+import { GovUkSummaryListItem, ValidationErrors, YesOrNo } from '../../../@types/user-defined'
 import GovukFrontendDateInput from '../../../forms/GovukFrontendDateInput'
 import GovUkRadioGroup from '../../../forms/GovUkRadioGroup'
 import paths from '../../../paths'
@@ -40,8 +40,15 @@ interface AppointmentItems {
 export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
   protected page: CourseCompletionPage = 'confirm'
 
-  protected getValidationErrors(_: Body) {
-    return {}
+  protected getValidationErrors(body: Body) {
+    const validationErrors: ValidationErrors<Body> = {}
+
+    if (!body.alertPractitioner) {
+      validationErrors.alertPractitioner = {
+        text: 'Choose whether you want to send an alert',
+      }
+    }
+    return validationErrors
   }
 
   getFormData(formData: CourseCompletionForm, _body: Body): CourseCompletionForm {

--- a/server/views/appointments/update/confirm.njk
+++ b/server/views/appointments/update/confirm.njk
@@ -48,7 +48,8 @@
     hint: {
       text: "Select yes to send an alert"
     },
-    items: alertPractitionerItems
+    items: alertPractitionerItems,
+    errorMessage: errors.alertPractitioner
   }) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Context

This introduces checks and error messages when the user completes an appointment form or a course completion. These changes are required to ensure we meet best practice for multiple choice radio buttons. We need to ensure a selection is made and display an error if it is not.

## Changes in this PR

- Refactor existing tests to ensure that an option is selected
- Refactor the confirmController tests to use a single mock instance of the page
- Add validation to the pages which include an alert diary question
- Display an error message when the alert diary question has no option selected
- Add new tests to detect the error message when relevant

### Screenshots of UI changes

<img width="1840" height="1103" alt="image" src="https://github.com/user-attachments/assets/1df117a6-991f-4887-bead-496f4487c903" />

<img width="1840" height="1103" alt="image" src="https://github.com/user-attachments/assets/b29366aa-0d56-4222-b56f-5ac9e114e5e7" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
