### PR TITLE
CPB-1192: Deprecate get sessions endpoint

### DIFF
--- a/integration_tests/mockApis/sessions.ts
+++ b/integration_tests/mockApis/sessions.ts
@@ -1,8 +1,8 @@
 import type { SuperAgentRequest } from 'superagent'
-import { stubFor } from './wiremock'
+import { stubFor, arrayToQueryStubMappings } from './wiremock'
 import paths from '../../server/paths/api'
-import type { PagedModelSessionSummaryDto, SessionDto } from '../../server/@types/shared'
-import type { GetSessionsRequest } from '../../server/@types/user-defined'
+import type { PagedModelSessionSummaryDto } from '../../server/@types/shared'
+import type { GetSessionsRequest, Session } from '../../server/@types/user-defined'
 
 export default {
   stubGetSessions: ({
@@ -34,18 +34,49 @@ export default {
       },
     })
   },
-  stubFindSession: ({ session }: { session: SessionDto }): SuperAgentRequest => {
-    const pattern = paths.projects.sessionAppointments({ projectCode: session.projectCode, date: session.date })
-    return stubFor({
+  stubFindSession: async ({ session }: { session: Session }) => {
+    const { date, appointmentSummaries, ...project } = session
+    const projectPath = paths.projects.singleProject({ projectCode: session.projectCode })
+    const appointmentsPath = paths.appointments.filter.pattern
+
+    const projectStub = stubFor({
       request: {
         method: 'GET',
-        urlPath: pattern,
+        urlPath: projectPath,
       },
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: session,
+        jsonBody: project,
       },
     })
+
+    const appointmentsStub = stubFor({
+      request: {
+        method: 'GET',
+        urlPath: appointmentsPath,
+        queryParameters: {
+          projectCodes: {
+            includes: arrayToQueryStubMappings([session.projectCode]),
+          },
+          fromDate: {
+            equalTo: session.date,
+          },
+          toDate: {
+            equalTo: session.date,
+          },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          content: session.appointmentSummaries,
+          page: {},
+        },
+      },
+    })
+
+    return Promise.all([projectStub, appointmentsStub])
   },
 }

--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -3,10 +3,11 @@ import Page from '../page'
 import { AppointmentFormPage } from '../../../server/pages/appointments/pathMap'
 import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
-import { AppointmentDto, OffenderDto, SessionDto } from '../../../server/@types/shared'
+import { AppointmentDto, OffenderDto } from '../../../server/@types/shared'
+import { Session } from '../../../server/@types/user-defined'
 import SelectedPeopleCardComponent from './selectedPeopleCardComponent'
 
-export type AppointmentTitleContext = Pick<AppointmentDto, 'offender'> | Pick<SessionDto, 'projectName'>
+export type AppointmentTitleContext = Pick<AppointmentDto, 'offender'> | Pick<Session, 'projectName'>
 
 export default abstract class BaseAppointmentFormPage extends Page {
   readonly selectedPeopleCard = new SelectedPeopleCardComponent()
@@ -30,8 +31,8 @@ export default abstract class BaseAppointmentFormPage extends Page {
   }
 
   static visitForSession<T extends BaseAppointmentFormPage, A extends unknown[]>(
-    this: new (session: Pick<SessionDto, 'projectName'>, ...args: A) => T,
-    session: SessionDto,
+    this: new (session: Pick<Session, 'projectName'>, ...args: A) => T,
+    session: Session,
     ...args: A
   ): T {
     const page = new this({ projectName: session.projectName }, ...args)
@@ -71,7 +72,7 @@ export default abstract class BaseAppointmentFormPage extends Page {
       { form: '123' },
     )
 
-  protected sessionPath = (session: SessionDto) =>
+  protected sessionPath = (session: Session) =>
     pathWithQuery(
       paths.sessions.update({
         projectCode: session.projectCode,

--- a/integration_tests/pages/appointments/bulkUpdatePage.ts
+++ b/integration_tests/pages/appointments/bulkUpdatePage.ts
@@ -1,4 +1,5 @@
-import { AppointmentDto, SessionDto } from '../../../server/@types/shared'
+import { AppointmentDto } from '../../../server/@types/shared'
+import { Session } from '../../../server/@types/user-defined'
 import { pathWithQuery } from '../../../server/utils/utils'
 import paths from '../../../server/paths'
 import RadioOrCheckboxGroupComponent from '../components/radioOrCheckboxGroupComponent'
@@ -7,12 +8,12 @@ import Page from '../page'
 export default class BulkUpdatePage extends Page {
   private readonly checkBoxes: RadioOrCheckboxGroupComponent
 
-  constructor(session: SessionDto) {
+  constructor(session: Session) {
     super(session.projectName)
     this.checkBoxes = new RadioOrCheckboxGroupComponent('appointments')
   }
 
-  static visitForSession(session: SessionDto, formId?: string): BulkUpdatePage {
+  static visitForSession(session: Session, formId?: string): BulkUpdatePage {
     const query = formId ? { form: formId } : undefined
     const path = pathWithQuery(
       paths.sessions.update({

--- a/integration_tests/pages/findAPersonPage.ts
+++ b/integration_tests/pages/findAPersonPage.ts
@@ -1,6 +1,7 @@
 import Page from './page'
 import paths from '../../server/paths'
-import { ProjectDto, SessionDto } from '../../server/@types/shared'
+import { ProjectDto } from '../../server/@types/shared'
+import { Session } from '../../server/@types/user-defined'
 import PersonSearchComponent from './components/personSearchComponent'
 
 export default class FindAPersonPage extends Page {
@@ -10,7 +11,7 @@ export default class FindAPersonPage extends Page {
     super('Find a person with a community payback order')
   }
 
-  static visitForSession(session: SessionDto): FindAPersonPage {
+  static visitForSession(session: Session): FindAPersonPage {
     return this.visitAndCheck(
       paths.sessions.create.findAPerson({ projectCode: session.projectCode, date: session.date }),
     )

--- a/integration_tests/pages/requirementPage.ts
+++ b/integration_tests/pages/requirementPage.ts
@@ -1,4 +1,5 @@
-import { OffenderFullDto, ProjectDto, SessionDto } from '../../server/@types/shared'
+import { OffenderFullDto, ProjectDto } from '../../server/@types/shared'
+import { Session } from '../../server/@types/user-defined'
 import Offender from '../../server/models/offender'
 import paths from '../../server/paths'
 import RadioOrCheckboxGroupComponent from './components/radioOrCheckboxGroupComponent'
@@ -12,7 +13,7 @@ export default class RequirementPage extends Page {
     this.requirementOptions = new RadioOrCheckboxGroupComponent('deliusEventNumber')
   }
 
-  static visitForSession(session: SessionDto, offender: OffenderFullDto) {
+  static visitForSession(session: Session, offender: OffenderFullDto) {
     const { crn, name } = new Offender(offender)
     const path = paths.sessions.create.requirement({ projectCode: session.projectCode, date: session.date, crn })
     return this.visitAndCheck(path, name)

--- a/integration_tests/pages/viewSessionPage.ts
+++ b/integration_tests/pages/viewSessionPage.ts
@@ -1,4 +1,5 @@
-import { OffenderFullDto, ProjectDto, SessionDto } from '../../server/@types/shared'
+import { OffenderFullDto, ProjectDto } from '../../server/@types/shared'
+import { Session } from '../../server/@types/user-defined'
 import paths from '../../server/paths'
 import { pathWithQuery } from '../../server/utils/utils'
 
@@ -10,23 +11,23 @@ import DataTableComponent from './components/datatableComponent'
 export default class ViewSessionPage extends Page {
   private readonly sessionDetails: SummaryListComponent
 
-  private readonly session: SessionDto
+  private readonly session: Session
 
   sessionList: DataTableComponent
 
-  constructor(session: SessionDto) {
+  constructor(session: Session) {
     super(session.projectName)
     this.sessionDetails = new SummaryListComponent()
     this.sessionList = new DataTableComponent()
     this.session = session
   }
 
-  static visit(session: SessionDto): ViewSessionPage {
+  static visit(session: Session): ViewSessionPage {
     const path = `${paths.sessions.show({ projectCode: session.projectCode, date: session.date })}`
     return this.visitAndCheck(path, session)
   }
 
-  static visitForSearch(session: SessionDto, searchParams?: Record<string, string>): ViewSessionPage {
+  static visitForSearch(session: Session, searchParams?: Record<string, string>): ViewSessionPage {
     const path = pathWithQuery(
       paths.sessions.show({ projectCode: session.projectCode, date: session.date }),
       searchParams,

--- a/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
+++ b/integration_tests/tests/appointments/checkAppointmentDetails.cy.ts
@@ -118,8 +118,8 @@ context('Session details', () => {
     })
 
     const session = sessionFactory.build({
+      ...project,
       date: firstAppointment.date,
-      projectCode: project.projectCode,
       appointmentSummaries: [firstAppointmentSummary, secondAppointmentSummary],
     })
     cy.wrap(session).as('session')
@@ -134,7 +134,6 @@ context('Session details', () => {
   })
 
   beforeEach(function test() {
-    cy.task('stubFindProject', { project: this.project })
     cy.task('stubFindSession', { session: this.session })
     cy.task('stubFindAppointment', { appointment: this.appointment })
     cy.task('stubGetSupervisors', {
@@ -159,6 +158,7 @@ context('Session details', () => {
     })
 
     const session = sessionFactory.build({
+      ...this.project,
       appointmentSummaries,
       projectCode: this.project.projectCode,
     })
@@ -201,10 +201,6 @@ context('Session details', () => {
 
     // Given I am on the view session page
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
     const page = ViewSessionPage.visit(session)
 
     // Then I see limited information about offenders and cannot update

--- a/integration_tests/tests/appointments/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/appointments/chooseSupervisor.cy.ts
@@ -58,8 +58,8 @@ context('Choose supervisor', () => {
     const secondAppointmentSummary = appointmentSummaryFactory.build({ id: secondAppointment.id })
 
     const session = sessionFactory.build({
+      ...project,
       date: firstAppointment.date,
-      projectCode: project.projectCode,
       appointmentSummaries: [firstAppointmentSummary, secondAppointmentSummary],
     })
     cy.wrap(session).as('session')

--- a/integration_tests/tests/appointments/create/requirement.cy.ts
+++ b/integration_tests/tests/appointments/create/requirement.cy.ts
@@ -77,10 +77,6 @@ context('Create session appointment - requirement', () => {
 
     // When I click on a session in the results
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
 
     ViewSessionPage.visit(session)
 
@@ -126,10 +122,6 @@ context('Create session appointment - requirement', () => {
 
     // When I click on a session in the results
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
 
     ViewSessionPage.visit(session)
 
@@ -168,10 +160,6 @@ context('Create session appointment - requirement', () => {
 
     // When I click on a session in the results
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
 
     ViewSessionPage.visit(session)
 

--- a/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/attendanceOutcome.cy.ts
@@ -20,14 +20,11 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
     cy.task('stubSignIn')
     cy.signIn()
 
-    const project = projectFactory.build()
-    cy.wrap(project).as('project')
     const selectedAppointments = appointmentSummaryFactory.buildList(2, { contactOutcome: undefined })
     cy.wrap(selectedAppointments).as('selectedAppointments')
     const unselectedAppointment = appointmentSummaryFactory.build({ contactOutcome: undefined })
     cy.wrap(unselectedAppointment).as('unselectedAppointment')
     const session = sessionFactory.build({
-      projectCode: project.projectCode,
       appointmentSummaries: [...selectedAppointments, unselectedAppointment],
     })
     cy.wrap(session).as('session')
@@ -36,14 +33,13 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
     const contactOutcomes = contactOutcomesFactory.build({ contactOutcomes: [attendedOutcome] })
     cy.wrap(contactOutcomes).as('contactOutcomes')
 
-    cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
     cy.task('stubGetContactOutcomes', { contactOutcomes })
     cy.task(
       'stubGetAppointmentForm',
       appointmentOutcomeFormFactory.build({
         appointments: selectedAppointments.map(appointment => ({ id: appointment.id, deliusVersion: '' })),
-        projectTeam: providerTeamSummaryFactory.build({ code: project.teamCode }),
+        projectTeam: providerTeamSummaryFactory.build({ code: session.teamCode }),
       }),
     )
   })
@@ -60,10 +56,10 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
   it('navigates back to the previous page', function test() {
     const teams = providerTeamSummaryFactory.buildList(2)
 
-    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
+    cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.session.providerCode })
 
-    const projects = projectFactory.buildList(1, { projectCode: this.project.projectCode })
-    cy.task('stubGetProjects', { projects, teamCode: this.project.teamCode, providerCode: this.project.providerCode })
+    const projects = projectFactory.buildList(1, { projectCode: this.session.projectCode })
+    cy.task('stubGetProjects', { projects, teamCode: this.session.teamCode, providerCode: this.session.providerCode })
 
     const page = AttendanceOutcomePage.visitForSession(this.session)
     page.clickBack()
@@ -81,7 +77,7 @@ context('Group Session Bulk Update - Attendance Outcome', () => {
     const selectable = [...this.selectedAppointments, this.unselectedAppointment]
 
     selectable.forEach(appointmentSummary => {
-      const appointment = appointmentFactory.build({ ...appointmentSummary, projectCode: this.project.projectCode })
+      const appointment = appointmentFactory.build({ ...appointmentSummary, projectCode: this.session.projectCode })
       cy.task('stubFindAppointment', { appointment })
     })
 

--- a/integration_tests/tests/group-sessions/bulk-update/chooseProject.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/chooseProject.cy.ts
@@ -31,7 +31,7 @@ context('Group Session Bulk Update - Choose Project', () => {
     cy.wrap(unselectedAppointment).as('unselectedAppointment')
 
     const session = sessionFactory.build({
-      projectCode: project.projectCode,
+      ...project,
       appointmentSummaries: [...selectedAppointments, unselectedAppointment],
     })
     cy.wrap(session).as('session')
@@ -57,7 +57,6 @@ context('Group Session Bulk Update - Choose Project', () => {
       providerCode: project.providerCode,
     })
 
-    cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
     cy.task('stubGetAppointmentForm', form)
   })

--- a/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/chooseSupervisor.cy.ts
@@ -24,12 +24,11 @@ context('Group Session Bulk Update - Choose Supervisor', () => {
     const unselectedAppointment = appointmentSummaryFactory.build({ contactOutcome: undefined })
     cy.wrap(unselectedAppointment).as('unselectedAppointment')
     const session = sessionFactory.build({
-      projectCode: project.projectCode,
+      ...project,
       appointmentSummaries: [...selectedAppointments, unselectedAppointment],
     })
     cy.wrap(session).as('session')
 
-    cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
     cy.task(
       'stubGetAppointmentForm',

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -32,12 +32,11 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
     cy.wrap(project).as('project')
 
     const session = sessionFactory.build({
-      projectCode: project.projectCode,
+      ...project,
       appointmentSummaries: appointmentSummaryFactory.buildList(3, { contactOutcome: undefined }),
     })
     cy.wrap(session).as('session')
 
-    cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
 
     const appointments = session.appointmentSummaries.map(appointment =>

--- a/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/selectPeople.cy.ts
@@ -31,7 +31,7 @@ context('Group Session Bulk Update - Bulk Update', () => {
     })
 
     const session = sessionFactory.build({
-      projectCode: project.projectCode,
+      ...project,
       appointmentSummaries: [...selectableAppointments, appointmentSummaryWithContactOutcome],
     })
     cy.wrap(session).as('session')
@@ -50,7 +50,6 @@ context('Group Session Bulk Update - Bulk Update', () => {
     })
     cy.wrap(form).as('form')
 
-    cy.task('stubFindProject', { project })
     cy.task('stubFindSession', { session })
     cy.task('stubGetAppointmentForm', form)
     cy.task('stubSaveAppointmentForm')

--- a/integration_tests/tests/group-sessions/findASession.cy.ts
+++ b/integration_tests/tests/group-sessions/findASession.cy.ts
@@ -71,7 +71,6 @@ import { ProviderSummaryDto, ProviderTeamSummaryDto } from '../../../server/@typ
 import providerSummaryFactory from '../../../server/testutils/factories/providerSummaryFactory'
 import AuthSignInPage from '../../pages/authSignIn'
 import ServerErrorPage from '../../pages/serverErrorPage'
-import projectFactory from '../../../server/testutils/factories/projectFactory'
 
 context('Home', () => {
   const date = '2025-09-07'
@@ -278,16 +277,12 @@ context('Home', () => {
 
     // And I click on a session in the results
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
     page.clickOnASession()
 
     //  Then I see the session details page
     const sessionDetailsPage = Page.verifyOnPage(ViewSessionPage, session)
     sessionDetailsPage.shouldShowAppointmentsList()
-    sessionDetailsPage.shouldShowSessionDetails(project)
+    sessionDetailsPage.shouldShowSessionDetails(session)
   })
 
   //  Scenario: displaying error summary
@@ -347,10 +342,6 @@ context('Home', () => {
 
     // And I have visited a session
     cy.task('stubFindSession', { session })
-    const project = projectFactory.build({
-      projectCode: session.projectCode,
-    })
-    cy.task('stubFindProject', { project })
     page.clickOnASession()
 
     // When I return to the search page

--- a/integration_tests/tests/group-sessions/viewASession.cy.ts
+++ b/integration_tests/tests/group-sessions/viewASession.cy.ts
@@ -10,7 +10,6 @@ import BulkUpdatePage from '../../pages/appointments/bulkUpdatePage'
 import Page from '../../pages/page'
 import offenderLimitedFactory from '../../../server/testutils/factories/offenderLimitedFactory'
 import appointmentOutcomeFormFactory from '../../../server/testutils/factories/appointmentOutcomeFormFactory'
-import projectFactory from '../../../server/testutils/factories/projectFactory'
 
 context('view a session', () => {
   const date = '2025-09-19'
@@ -39,11 +38,6 @@ context('view a session', () => {
       })
 
       cy.task('stubFindSession', { session })
-      const project = projectFactory.build({
-        projectCode: session.projectCode,
-      })
-      cy.task('stubFindProject', { project })
-
       const sessionDetailsPage = ViewSessionPage.visitForSearch(session)
       sessionDetailsPage.shouldShowAppointmentsList()
 
@@ -71,10 +65,6 @@ context('view a session', () => {
       })
 
       cy.task('stubFindSession', { session })
-      const project = projectFactory.build({
-        projectCode: session.projectCode,
-      })
-      cy.task('stubFindProject', { project })
 
       const sessionDetailsPage = ViewSessionPage.visitForSearch(session)
       sessionDetailsPage.shouldNotShowBulkUpdateButton()

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -1,5 +1,5 @@
 import type { Response, RequestHandler } from 'express'
-import { AppointmentDto, SessionDto, ProjectTypeDto } from '../shared'
+import { AppointmentDto, ProjectTypeDto, AppointmentSummaryDto, ProjectDto } from '../shared'
 import ReferenceDataService from '../../services/referenceDataService'
 
 type PageHeader = { title: string; caption: string; description?: string }
@@ -122,9 +122,14 @@ export interface AppointmentOrSessionParams {
   projectCode: string
 }
 
+export interface Session extends ProjectDto {
+  appointmentSummaries: Array<AppointmentSummaryDto>
+  date: string
+}
+
 export type AppointmentOrSession = {
   appointment?: AppointmentDto
-  session?: SessionDto
+  session?: Session
 }
 
 export interface GovUkSelectOption {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -122,7 +122,10 @@ export interface AppointmentOrSessionParams {
   projectCode: string
 }
 
-export type AppointmentOrSession = AppointmentDto | SessionDto
+export type AppointmentOrSession = {
+  appointment?: AppointmentDto
+  session?: SessionDto
+}
 
 export interface GovUkSelectOption {
   text: string

--- a/server/controllers/appointments/appointmentDetailsController.ts
+++ b/server/controllers/appointments/appointmentDetailsController.ts
@@ -57,7 +57,7 @@ export default class AppointmentDetailsController {
       res.render('appointments/update/appointmentDetails', {
         ...page.commonViewData({
           pathData: { ...appointmentParams, date: appointment.date },
-          appointmentOrSession: appointment,
+          appointmentOrSession: { appointment },
           originalSearch: form.originalSearch,
           project,
           form: {} as AppointmentOutcomeForm,

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -12,7 +12,6 @@ import BaseAppointmentController, {
   AppointmentStepViewDataParams,
   ContextDataParams,
 } from './baseAppointmentController'
-import { AppointmentDto } from '../../@types/shared'
 
 export default class AttendanceOutcomeController extends BaseAppointmentController<AttendanceOutcomePage> {
   constructor(
@@ -43,8 +42,7 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
   }: AppointmentStepViewDataParams): Promise<object> {
     const { contactOutcomes } = contextData as AttendanceOutcomeContext
     const query = req.body as Record<string, unknown>
-    const appointment =
-      appointmentOrSession && isSingleAppointment ? (appointmentOrSession as AppointmentDto) : undefined
+    const { appointment } = appointmentOrSession ?? {}
     return this.page.viewData(appointment, form, contactOutcomes, query as AttendanceOutcomeBody, isSingleAppointment)
   }
 

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -95,7 +95,7 @@ export default abstract class BaseAppointmentController<
 
       const { formId, form } = await this.getForm(req, res)
       const contextData = await this.getContextData({ req, res, form })
-      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
+      const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 
       const viewData = {
         ...this.page.commonViewData({ pathData, appointmentOrSession, form, formId }),
@@ -186,7 +186,7 @@ export default abstract class BaseAppointmentController<
 
       const contextData = await this.getContextData({ req, res, form })
       const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body, contextData)
-      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
+      const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 
       if (hasErrors) {
         const viewData = {
@@ -243,5 +243,9 @@ export default abstract class BaseAppointmentController<
 
   private isSingleAppointment(params: AppointmentOrSessionParams): boolean {
     return !params.date
+  }
+
+  private getDate(appointmentOrSession?: AppointmentOrSession) {
+    return appointmentOrSession?.appointment?.date || appointmentOrSession?.session?.date
   }
 }

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -31,6 +31,7 @@ export type ContextDataParams = {
   req: Request
   res: Response
   form: AppointmentOutcomeForm
+  appointmentOrSession?: AppointmentOrSession
 }
 
 export default abstract class BaseAppointmentController<
@@ -94,7 +95,7 @@ export default abstract class BaseAppointmentController<
       })
 
       const { formId, form } = await this.getForm(req, res)
-      const contextData = await this.getContextData({ req, res, form })
+      const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
       const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 
       const viewData = {
@@ -184,7 +185,7 @@ export default abstract class BaseAppointmentController<
         sessionService: this.sessionService,
       })
 
-      const contextData = await this.getContextData({ req, res, form })
+      const contextData = await this.getContextData({ req, res, form, appointmentOrSession })
       const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body, contextData)
       const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 

--- a/server/controllers/appointments/chooseProjectController.test.ts
+++ b/server/controllers/appointments/chooseProjectController.test.ts
@@ -12,6 +12,7 @@ import getProjectsAndTeams from '../shared/getProjectsAndTeams'
 import projectFactory from '../../testutils/factories/projectFactory'
 import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 import { ErrorSummaryItem } from '../../utils/errorUtils'
 import OffenderService from '../../services/offenderService'
 
@@ -155,6 +156,24 @@ describe('ChooseProjectController', () => {
         }),
       )
     })
+
+    it('does not call projectService.getProject when getAppointmentOrSession returns session', async () => {
+      const request = createMock<Request>({
+        params: { projectCode: 'PROJECT-1', appointmentId: '1' },
+        method: 'GET',
+        query: { form: '1' },
+        body: {},
+      })
+      const response = createMock<Response>({ locals: { user: { username } } })
+
+      getAppointmentOrSessionMock.mockResolvedValue({ session: sessionFactory.build() })
+      appointmentFormService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
+
+      const requestHandler = controller.show()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).not.toHaveBeenCalled()
+    })
   })
 
   describe('submit', () => {
@@ -232,6 +251,25 @@ describe('ChooseProjectController', () => {
       expect(appointmentFormService.saveForm).toHaveBeenCalledWith('form-1', username, updatedForm)
       expect(response.redirect).toHaveBeenCalledWith('/next')
       expect(response.render).not.toHaveBeenCalled()
+    })
+
+    it('calls projectService.getProject when getAppointmentOrSession returns appointment', async () => {
+      const request = createMock<Request>({
+        params: { projectCode: 'PROJECT-1', appointmentId: '1' },
+        body: { form: 'form-1', team: 'TEAM-1', project: 'PROJECT-2' },
+      })
+      const response = createMock<Response>({ locals: { user: { username } } })
+
+      getAppointmentOrSessionMock.mockResolvedValue({ appointment: appointmentFactory.build() })
+      appointmentFormService.getForm.mockResolvedValue(appointmentOutcomeFormFactory.build())
+
+      const requestHandler = controller.submitUpdate()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).toHaveBeenCalledWith({
+        username,
+        projectCode: 'PROJECT-1',
+      })
     })
   })
 })

--- a/server/controllers/appointments/chooseProjectController.test.ts
+++ b/server/controllers/appointments/chooseProjectController.test.ts
@@ -70,7 +70,7 @@ describe('ChooseProjectController', () => {
 
     projectService.getProject.mockResolvedValue(project)
 
-    getAppointmentOrSessionMock.mockResolvedValue(appointmentFactory.build())
+    getAppointmentOrSessionMock.mockResolvedValue({ appointment: appointmentFactory.build() })
     getProjectsAndTeamsMock.mockReturnValue({
       teamItems: [{ value: 'T1', text: 'Team 1' }],
       projectItems: [{ value: 'PR1', text: 'Project 1' }],

--- a/server/controllers/appointments/chooseProjectController.ts
+++ b/server/controllers/appointments/chooseProjectController.ts
@@ -31,11 +31,18 @@ export default class ChooseProjectController extends BaseAppointmentController<C
     return 'appointments/update/chooseProject'
   }
 
-  protected async getContextData({ req, res, form }: ContextDataParams): Promise<ProjectsAndTeamsViewData> {
-    const project = await this.projectService.getProject({
-      username: res.locals.user.username,
-      projectCode: req.params.projectCode,
-    })
+  protected async getContextData({
+    req,
+    res,
+    form,
+    appointmentOrSession,
+  }: ContextDataParams): Promise<ProjectsAndTeamsViewData> {
+    const project = appointmentOrSession?.session
+      ? appointmentOrSession?.session
+      : await this.projectService.getProject({
+          username: res.locals.user.username,
+          projectCode: req.params.projectCode,
+        })
 
     const teamCode = req.method === 'GET' ? (req.query.team ?? form.projectTeam?.code) : req.body.team
     const projectCode = (req.body?.project ?? form.project?.code)?.toString()

--- a/server/controllers/appointments/chooseSupervisorController.test.ts
+++ b/server/controllers/appointments/chooseSupervisorController.test.ts
@@ -6,6 +6,7 @@ import appointmentFactory from '../../testutils/factories/appointmentFactory'
 import supervisorSummaryFactory from '../../testutils/factories/supervisorSummaryFactory'
 import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import projectFactory from '../../testutils/factories/projectFactory'
 import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 import ChooseSupervisorPage from '../../pages/appointments/chooseSupervisorPage'
@@ -13,8 +14,10 @@ import ChooseSupervisorController from './chooseSupervisorController'
 import ProjectService from '../../services/projectService'
 import SessionService from '../../services/sessionService'
 import OffenderService from '../../services/offenderService'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 
 jest.mock('../../pages/appointments/chooseSupervisorPage')
+jest.mock('../shared/getAppointmentOrSession')
 
 describe('ChooseSupervisorController', () => {
   const userName = 'user'
@@ -27,6 +30,7 @@ describe('ChooseSupervisorController', () => {
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const chooseSupervisorPageMock: jest.Mock = ChooseSupervisorPage as unknown as jest.Mock<ChooseSupervisorPage>
+  const getAppointmentOrSessionMock: jest.Mock = getAppointmentOrSession as unknown as jest.Mock
   const pageViewData = {
     someKey: 'some value',
   }
@@ -74,6 +78,8 @@ describe('ChooseSupervisorController', () => {
       sessionService,
       offenderService,
     )
+
+    getAppointmentOrSessionMock.mockResolvedValue({ appointment: appointmentFactory.build() })
   })
 
   describe('show', () => {
@@ -118,6 +124,42 @@ describe('ChooseSupervisorController', () => {
         'appointments/update/chooseSupervisor',
         expect.objectContaining(pageViewData),
       )
+    })
+
+    it('should not call projectService.getProject when getAppointmentOrSession returns session', async () => {
+      const form = appointmentOutcomeFormFactory.build()
+      const session = sessionFactory.build({ projectCode, providerCode })
+      const teams = providerTeamSummaryFactory.buildList(2)
+      const supervisors = supervisorSummaryFactory.buildList(2)
+
+      getAppointmentOrSessionMock.mockResolvedValue({ session })
+      formService.getForm.mockResolvedValue(form)
+      providerDataService.getTeams.mockResolvedValue({ providers: teams })
+      providerDataService.getSupervisors.mockResolvedValue(supervisors)
+
+      const requestHandler = appointmentsController.show()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).not.toHaveBeenCalled()
+    })
+
+    it('should call projectService.getProject when getAppointmentOrSession returns appointment', async () => {
+      const form = appointmentOutcomeFormFactory.build()
+      const appointment = appointmentFactory.build()
+      const project = projectFactory.build({ projectCode, providerCode })
+      const teams = providerTeamSummaryFactory.buildList(2)
+      const supervisors = supervisorSummaryFactory.buildList(2)
+
+      getAppointmentOrSessionMock.mockResolvedValue({ appointment })
+      projectService.getProject.mockResolvedValue(project)
+      formService.getForm.mockResolvedValue(form)
+      providerDataService.getTeams.mockResolvedValue({ providers: teams })
+      providerDataService.getSupervisors.mockResolvedValue(supervisors)
+
+      const requestHandler = appointmentsController.show()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).toHaveBeenCalledWith({ username: userName, projectCode })
     })
   })
 

--- a/server/controllers/appointments/chooseSupervisorController.ts
+++ b/server/controllers/appointments/chooseSupervisorController.ts
@@ -29,14 +29,21 @@ export default class ChooseSupervisorController extends BaseAppointmentControlle
     return 'appointments/update/chooseSupervisor'
   }
 
-  protected async getContextData({ req, res, form }: ContextDataParams): Promise<SupervisorPageContext> {
+  protected async getContextData({
+    req,
+    res,
+    form,
+    appointmentOrSession,
+  }: ContextDataParams): Promise<SupervisorPageContext> {
     const { username } = res.locals.user
     const projectCode = req.params.projectCode as string
 
-    const project = await this.projectService.getProject({
-      username,
-      projectCode,
-    })
+    const project = appointmentOrSession?.session
+      ? appointmentOrSession?.session
+      : await this.projectService.getProject({
+          username,
+          projectCode,
+        })
 
     const teams = await this.providerService.getTeams(project.providerCode, username)
 

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -11,6 +11,7 @@ import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeF
 import projectFactory from '../../testutils/factories/projectFactory'
 import projectAvailabilityFactory from '../../testutils/factories/projectAvailabilityFactory'
 import ProjectService from '../../services/projectService'
+import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import * as ErrorUtils from '../../utils/errorUtils'
 import SessionService from '../../services/sessionService'
 import AuditService from '../../services/auditService'
@@ -21,8 +22,10 @@ import OffenderService from '../../services/offenderService'
 import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
 import createAppointmentFormFactory from '../../testutils/factories/createAppointmentFormFactory'
 import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
+import sessionFactory from '../../testutils/factories/sessionFactory'
 
 jest.mock('../../pages/appointments/confirmPage')
+jest.mock('../shared/getAppointmentOrSession')
 
 describe('ConfirmController', () => {
   const appointmentId = '1'
@@ -36,6 +39,7 @@ describe('ConfirmController', () => {
   })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const confirmPageMock: jest.Mock = ConfirmPage as unknown as jest.Mock<ConfirmPage>
+  const getAppointmentOrSessionMock: jest.Mock = getAppointmentOrSession as unknown as jest.Mock
   const pageViewData = {
     preventDoubleClick: true,
     someKey: 'some value',
@@ -87,6 +91,31 @@ describe('ConfirmController', () => {
       auditService,
       offenderService,
     )
+
+    getAppointmentOrSessionMock.mockImplementation(async ({ appointmentOrSessionParams, res }) => {
+      if (appointmentOrSessionParams.appointmentId) {
+        return {
+          appointment: await appointmentService.getAppointment({
+            projectCode: appointmentOrSessionParams.projectCode,
+            appointmentId: appointmentOrSessionParams.appointmentId,
+            username: res.locals.user.username,
+          }),
+        }
+      }
+
+      const project = await projectService.getProject({
+        username: res.locals.user.username,
+        projectCode: appointmentOrSessionParams.projectCode,
+      })
+
+      return {
+        session: sessionFactory.build({
+          ...project,
+          projectCode: project?.projectCode ?? appointmentOrSessionParams.projectCode,
+          date: appointmentOrSessionParams.date,
+        }),
+      }
+    })
   })
 
   describe('create', () => {
@@ -1526,6 +1555,48 @@ describe('ConfirmController', () => {
             '/update/path',
           )
         })
+      })
+    })
+
+    it('does not call projectService.getProject when getAppointmentOrSession returns session', async () => {
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const form = appointmentOutcomeFormFactory.build()
+      const session = sessionFactory.build({ projectCode })
+
+      getAppointmentOrSessionMock.mockResolvedValue({ session })
+      appointmentFormService.getForm.mockResolvedValue(form)
+      mockPageInstance.validationErrors.mockReturnValue({
+        hasErrors: true,
+        errors: { alertPractitioner: { text: 'error' } },
+        errorSummary: [{ text: 'error', href: '#alertPractitioner' }],
+      })
+
+      const requestHandler = confirmController.submitUpdate()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).not.toHaveBeenCalled()
+    })
+
+    it('calls projectService.getProject when getAppointmentOrSession returns appointment', async () => {
+      const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+      const form = appointmentOutcomeFormFactory.build()
+      const appointment = appointmentFactory.build()
+
+      getAppointmentOrSessionMock.mockResolvedValue({ appointment })
+      appointmentFormService.getForm.mockResolvedValue(form)
+      projectService.getProject.mockResolvedValue(projectFactory.build({ projectCode }))
+      mockPageInstance.validationErrors.mockReturnValue({
+        hasErrors: true,
+        errors: { alertPractitioner: { text: 'error' } },
+        errorSummary: [{ text: 'error', href: '#alertPractitioner' }],
+      })
+
+      const requestHandler = confirmController.submitUpdate()
+      await requestHandler(request, response, next)
+
+      expect(projectService.getProject).toHaveBeenCalledWith({
+        username: 'user-name',
+        projectCode,
       })
     })
   })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -6,7 +6,11 @@ import AppointmentFormService, {
 } from '../../services/forms/appointmentFormService'
 import ConfirmPage from '../../pages/appointments/confirmPage'
 import { AppointmentDto, UpdateAppointmentDto } from '../../@types/shared'
-import { AppointmentOrSessionParams, IAppointmentFormPageController } from '../../@types/user-defined'
+import {
+  AppointmentOrSession,
+  AppointmentOrSessionParams,
+  IAppointmentFormPageController,
+} from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
 import { catchApiValidationErrorOrPropagate, generateErrorTextList } from '../../utils/errorUtils'
 import NotesUtils from '../../utils/components/notesUtils'
@@ -75,7 +79,7 @@ export default class ConfirmController implements IAppointmentFormPageController
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
-      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
+      const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 
       res.render('appointments/update/confirm', {
         ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
@@ -188,7 +192,7 @@ export default class ConfirmController implements IAppointmentFormPageController
 
       const { errors, hasErrors, errorSummary } = page.validationErrors(_req.body)
       const preventDoubleClick = true
-      const pathData = { ...appointmentOrSessionParams, date: appointmentOrSession.date }
+      const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 
       if (hasErrors) {
         return res.render('appointments/update/confirm', {
@@ -203,8 +207,8 @@ export default class ConfirmController implements IAppointmentFormPageController
       const didAttend = form.contactOutcome.attended
       const isAlertSelected = page.isAlertSelected(_req.body)
 
-      if (appointmentOrSessionParams.appointmentId) {
-        const appointment = appointmentOrSession as AppointmentDto
+      if (appointmentOrSession.appointment) {
+        const { appointment } = appointmentOrSession
         if (this.appointmentHasChangedSinceLoaded(form.deliusVersion, appointment)) {
           _req.flash('error', 'The arrival time has already been updated in the database, try again.')
           return res.redirect(page.exitForm(appointment, project, form.originalSearch))
@@ -317,7 +321,7 @@ export default class ConfirmController implements IAppointmentFormPageController
             )
           }
 
-          return res.redirect(page.exitForm(appointmentOrSession, project, form.originalSearch))
+          return res.redirect(page.exitForm(appointmentOrSessionParams, project, form.originalSearch))
         } catch (error) {
           return catchApiValidationErrorOrPropagate(
             _req,
@@ -328,6 +332,10 @@ export default class ConfirmController implements IAppointmentFormPageController
         }
       }
     }
+  }
+
+  private getDate(appointmentOrSession?: AppointmentOrSession) {
+    return appointmentOrSession?.appointment?.date || appointmentOrSession?.session?.date
   }
 
   private changedProjectMessage(message: string, project: AppointmentOutcomeForm['project'], date: string) {

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -174,17 +174,19 @@ export default class ConfirmController implements IAppointmentFormPageController
     return async (_req: Request, res: Response) => {
       const appointmentOrSessionParams = _req.params as unknown as AppointmentOrSessionParams
 
-      const project = await this.projectService.getProject({
-        username: res.locals.user.username,
-        projectCode: appointmentOrSessionParams.projectCode,
-      })
-
       const appointmentOrSession = await getAppointmentOrSession({
         appointmentOrSessionParams,
         res,
         appointmentService: this.appointmentService,
         sessionService: this.sessionService,
       })
+
+      const project = appointmentOrSession?.session
+        ? appointmentOrSession?.session
+        : await this.projectService.getProject({
+            username: res.locals.user.username,
+            projectCode: appointmentOrSessionParams.projectCode,
+          })
 
       const page = new ConfirmPage()
       const formId = _req.body.form?.toString()

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -24,8 +24,8 @@ export const controllers = (services: Services) => {
     services.auditService,
     services.providerService,
     services.sessionService,
-    services.projectService,
   )
+
   const courseCompletionsController = new CourseCompletionsController(
     services.auditService,
     services.courseCompletionService,

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -4,7 +4,7 @@ import type { NextFunction, Request, Response } from 'express'
 import SessionsController from './sessionsController'
 import ProviderService from '../services/providerService'
 import SessionService from '../services/sessionService'
-import { PagedModelSessionSummaryDto, SessionDto } from '../@types/shared'
+import { PagedModelSessionSummaryDto } from '../@types/shared'
 import SessionUtils from '../utils/sessionUtils'
 import DateTimeFormats from '../utils/dateTimeUtils'
 import GroupSessionIndexPage from '../pages/groupSessionIndexPage'
@@ -22,8 +22,6 @@ import { getPaginationRequestParams } from '../utils/paginationUtils'
 import paths from '../paths'
 import { pathWithQuery } from '../utils/utils'
 import AuditService from '../services/auditService'
-import ProjectService from '../services/projectService'
-import projectFactory from '../testutils/factories/projectFactory'
 import config from '../config'
 
 jest.mock('../pages/groupSessionIndexPage')
@@ -38,7 +36,6 @@ describe('SessionsController', () => {
   const auditService = createMock<AuditService>()
   const providerService = createMock<ProviderService>()
   const sessionService = createMock<SessionService>()
-  const projectService = createMock<ProjectService>()
   const pageMock: jest.Mock = GroupSessionIndexPage as unknown as jest.Mock<GroupSessionIndexPage>
 
   const getPaginationRequestParamsMock: jest.Mock = getPaginationRequestParams as unknown as jest.Mock<
@@ -67,7 +64,7 @@ describe('SessionsController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    sessionsController = new SessionsController(auditService, providerService, sessionService, projectService)
+    sessionsController = new SessionsController(auditService, providerService, sessionService)
     pageMock.mockImplementation(() => {
       return {
         validationErrors: () => ({}),
@@ -209,10 +206,7 @@ describe('SessionsController', () => {
   describe('show', () => {
     it('should render the session page', async () => {
       const session = sessionFactory.build()
-      const project = projectFactory.build()
-
       sessionService.getSession.mockResolvedValue(session)
-      projectService.getProject.mockResolvedValue(project)
 
       const sessionList = [[{ text: 'name' }, { text: 'CRN123' }]]
 
@@ -241,9 +235,9 @@ describe('SessionsController', () => {
           ...session,
           date,
           formattedLocation,
-          region: project.providerName,
-          team: project.teamName,
-          projectType: project.projectType.name,
+          region: session.providerName,
+          team: session.teamName,
+          projectType: session.projectType.name,
         },
         sessionList,
         backPath,

--- a/server/controllers/sessionsController.test.ts
+++ b/server/controllers/sessionsController.test.ts
@@ -208,7 +208,7 @@ describe('SessionsController', () => {
 
   describe('show', () => {
     it('should render the session page', async () => {
-      const session: SessionDto = sessionFactory.build()
+      const session = sessionFactory.build()
       const project = projectFactory.build()
 
       sessionService.getSession.mockResolvedValue(session)
@@ -253,7 +253,7 @@ describe('SessionsController', () => {
     })
 
     it('should pass search back link to view if provider param', async () => {
-      const session: SessionDto = sessionFactory.build()
+      const session = sessionFactory.build()
       sessionService.getSession.mockResolvedValue(session)
 
       const search = { provider: 'provider ' }
@@ -276,7 +276,7 @@ describe('SessionsController', () => {
         const date = '2026-06-12'
         const query = { provider: 'P1' }
 
-        const session: SessionDto = sessionFactory.build({
+        const session = sessionFactory.build({
           projectCode,
           date,
           appointmentSummaries: [
@@ -307,7 +307,7 @@ describe('SessionsController', () => {
         const date = '2026-06-12'
         const query = { provider: 'P1' }
 
-        const session: SessionDto = sessionFactory.build({
+        const session = sessionFactory.build({
           projectCode,
           date,
           appointmentSummaries: [
@@ -338,7 +338,7 @@ describe('SessionsController', () => {
         const date = '2026-06-12'
         const query = { provider: 'P1' }
 
-        const session: SessionDto = sessionFactory.build({
+        const session = sessionFactory.build({
           projectCode,
           date,
           appointmentSummaries: [
@@ -369,7 +369,7 @@ describe('SessionsController', () => {
 
     describe('createAppointmentPath', () => {
       it('returns null if feature flag is disabled', async () => {
-        const session: SessionDto = sessionFactory.build()
+        const session = sessionFactory.build()
         sessionService.getSession.mockResolvedValue(session)
 
         config.featureFlags.createAppointmentEnabled = false
@@ -392,7 +392,7 @@ describe('SessionsController', () => {
       })
 
       it('returns path if feature flag is enabled', async () => {
-        const session: SessionDto = sessionFactory.build()
+        const session = sessionFactory.build()
         sessionService.getSession.mockResolvedValue(session)
 
         config.featureFlags.createAppointmentEnabled = true

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -12,7 +12,6 @@ import paths from '../paths'
 import { SessionsSortField } from '../@types/user-defined'
 import { getPaginationRequestParams } from '../utils/paginationUtils'
 import AuditService, { Page } from '../services/auditService'
-import ProjectService from '../services/projectService'
 import config from '../config'
 import { AppointmentDto, SessionDto, SessionSummaryDto } from '../@types/shared'
 
@@ -23,7 +22,6 @@ export default class SessionsController {
     private readonly auditService: AuditService,
     private readonly providerService: ProviderService,
     private readonly sessionService: SessionService,
-    private readonly projectService: ProjectService,
   ) {}
 
   index(): RequestHandler {
@@ -121,7 +119,6 @@ export default class SessionsController {
       }
       const query = _req.query as GroupSessionIndexPageInput
       const session = await this.sessionService.getSession(request)
-      const project = await this.projectService.getProject(request)
       const sessionList = SessionUtils.sessionListTableRows(session, query)
       const formattedDate = DateTimeFormats.isoDateToUIDate(date)
       const formattedLocation = LocationUtils.locationToString(session.location)
@@ -154,9 +151,9 @@ export default class SessionsController {
           ...session,
           date: formattedDate,
           formattedLocation,
-          region: project.providerName,
-          team: project.teamName,
-          projectType: project.projectType.name,
+          region: session.providerName,
+          team: session.teamName,
+          projectType: session.projectType.name,
         },
         sessionList,
         backPath,

--- a/server/controllers/sessionsController.ts
+++ b/server/controllers/sessionsController.ts
@@ -9,11 +9,11 @@ import getProvidersAndTeams from './shared/getProvidersAndTeams'
 import { generateErrorSummary, generateErrorTextList } from '../utils/errorUtils'
 import { pathWithQuery } from '../utils/utils'
 import paths from '../paths'
-import { SessionsSortField } from '../@types/user-defined'
+import { Session, SessionsSortField } from '../@types/user-defined'
 import { getPaginationRequestParams } from '../utils/paginationUtils'
 import AuditService, { Page } from '../services/auditService'
 import config from '../config'
-import { AppointmentDto, SessionDto, SessionSummaryDto } from '../@types/shared'
+import { AppointmentDto, SessionSummaryDto } from '../@types/shared'
 
 export const sessionsSortFields = ['date', 'projectName', 'allocatedCount', 'outcomeCount'] as const
 
@@ -167,7 +167,7 @@ export default class SessionsController {
   }
 
   private getCreateAppointmentPath(
-    appointmentOrSession: SessionSummaryDto | SessionDto | AppointmentDto,
+    appointmentOrSession: SessionSummaryDto | Session | AppointmentDto,
     query?: Record<string, string>,
   ) {
     if (!config.featureFlags.createAppointmentEnabled) {

--- a/server/controllers/shared/getAppointmentOrSession.test.ts
+++ b/server/controllers/shared/getAppointmentOrSession.test.ts
@@ -31,7 +31,7 @@ describe('getAppointmentOrSession', () => {
       sessionService,
     })
 
-    expect(result).toEqual(appointment)
+    expect(result).toEqual({ appointment })
     expect(appointmentService.getAppointment).toHaveBeenCalledWith({
       appointmentId: '123',
       projectCode: 'XRC',
@@ -64,7 +64,7 @@ describe('getAppointmentOrSession', () => {
       sessionService,
     })
 
-    expect(result).toEqual(session)
+    expect(result).toEqual({ session })
     expect(sessionService.getSession).toHaveBeenCalledWith({
       username: 'username',
       projectCode: 'XRC',

--- a/server/controllers/shared/getAppointmentOrSession.ts
+++ b/server/controllers/shared/getAppointmentOrSession.ts
@@ -29,7 +29,7 @@ export default async ({
       appointmentId,
       username,
     })
-    return appointment
+    return { appointment }
   }
 
   const session = await sessionService.getSession({
@@ -38,5 +38,5 @@ export default async ({
     date,
   })
 
-  return session
+  return { session }
 }

--- a/server/data/sessionClient.test.ts
+++ b/server/data/sessionClient.test.ts
@@ -3,7 +3,6 @@ import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients
 import SessionClient from './sessionClient'
 import config from '../config'
 import { createQueryString } from '../utils/utils'
-import sessionFactory from '../testutils/factories/sessionFactory'
 
 describe('SessionClient', () => {
   let sessionClient: SessionClient
@@ -20,24 +19,6 @@ describe('SessionClient', () => {
   afterEach(() => {
     nock.cleanAll()
     jest.resetAllMocks()
-  })
-
-  describe('find', () => {
-    it('should make a GET request to the find sessions path using user token and return the response body', async () => {
-      const projectCode = '1'
-      const date = '2026-01-01'
-
-      const session = sessionFactory.build()
-
-      nock(config.apis.communityPaybackApi.url)
-        .get(`/admin/projects/${projectCode}/sessions/${date}`)
-        .matchHeader('authorization', 'Bearer test-system-token')
-        .reply(200, session)
-
-      const response = await sessionClient.find({ username: 'some-username', projectCode, date })
-
-      expect(response).toEqual(session)
-    })
   })
 
   describe('getSessions', () => {

--- a/server/data/sessionClient.ts
+++ b/server/data/sessionClient.ts
@@ -3,8 +3,8 @@ import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients
 import config from '../config'
 import logger from '../../logger'
 import paths from '../paths/api'
-import { PagedModelSessionSummaryDto, SessionDto } from '../@types/shared'
-import { GetSessionRequest, GetSessionsRequest } from '../@types/user-defined'
+import { PagedModelSessionSummaryDto } from '../@types/shared'
+import { GetSessionsRequest } from '../@types/user-defined'
 import { createQueryString } from '../utils/utils'
 
 export default class SessionClient extends RestClient {
@@ -18,10 +18,5 @@ export default class SessionClient extends RestClient {
     const query = createQueryString(queryParams)
 
     return (await this.get({ path, query }, asSystem(username))) as PagedModelSessionSummaryDto
-  }
-
-  async find({ username, projectCode, date }: GetSessionRequest): Promise<SessionDto> {
-    const path = paths.projects.sessionAppointments({ projectCode, date })
-    return (await this.get({ path }, asSystem(username))) as SessionDto
   }
 }

--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -448,7 +448,7 @@ describe('AttendanceOutcomePage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -471,7 +471,7 @@ describe('AttendanceOutcomePage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -492,7 +492,7 @@ describe('AttendanceOutcomePage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -125,7 +125,12 @@ describe('BaseAppointmentUpdatePage', () => {
         const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: '1' })
 
         expect(result.selectedPeopleCard).toEqual(selectedPeopleCard)
-        expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(session, form.appointments, '1')
+        expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(
+          pathData,
+          session.appointmentSummaries,
+          form.appointments,
+          '1',
+        )
       })
     })
   })

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -1,6 +1,6 @@
 /* eslint max-classes-per-file: "off" -- need multiple classes to test different implementations of this abstract class */
 
-import { AppointmentOrSession } from '../../@types/user-defined'
+import { AppointmentOrSessionParams } from '../../@types/user-defined'
 import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
 import Offender from '../../models/offender'
 import paths from '../../paths'
@@ -64,7 +64,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
         const result = page.commonViewData({
           pathData: { projectCode: '', date: '' },
-          appointmentOrSession: appointmentFactory.build(),
+          appointmentOrSession: { appointment: appointmentFactory.build() },
           form,
           formId: '1',
         })
@@ -84,7 +84,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
         const result = page.commonViewData({
           pathData: { projectCode: '', date: '' },
-          appointmentOrSession: session,
+          appointmentOrSession: { session },
           form,
           formId: '1',
         })
@@ -103,7 +103,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
         const result = page.commonViewData({
           pathData: { projectCode: '', date: '' },
-          appointmentOrSession: appointmentFactory.build(),
+          appointmentOrSession: { appointment: appointmentFactory.build() },
           form,
           formId: '1',
         })
@@ -122,7 +122,7 @@ describe('BaseAppointmentUpdatePage', () => {
 
         jest.spyOn(SessionUtils, 'selectedPeopleCard').mockReturnValue(selectedPeopleCard)
 
-        const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: '1' })
+        const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: '1' })
 
         expect(result.selectedPeopleCard).toEqual(selectedPeopleCard)
         expect(SessionUtils.selectedPeopleCard).toHaveBeenCalledWith(session, form.appointments, '1')
@@ -263,7 +263,7 @@ class PageWithNextPage extends BaseAppointmentUpdatePage<unknown> {
     return 'confirm-details'
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): AppointmentPage {
+  protected backPage(_appointmentOrSession: AppointmentOrSessionParams): AppointmentPage {
     return 'choose-supervisor'
   }
 
@@ -286,7 +286,7 @@ class PageWithoutNavigationPages extends BaseAppointmentUpdatePage<unknown> {
     return undefined
   }
 
-  protected backPage(_appointmentOrSession: AppointmentOrSession): undefined {
+  protected backPage(_appointmentOrSession: AppointmentOrSessionParams): undefined {
     return undefined
   }
 

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -146,7 +146,12 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
 
     const { session } = appointmentOrSession
     if (session && this.page !== 'confirm-details') {
-      viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(session, form.appointments ?? [], formId)
+      viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(
+        pathData,
+        session.appointmentSummaries,
+        form.appointments ?? [],
+        formId,
+      )
     }
 
     return viewData

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -108,9 +108,6 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     return this.buildPath(pathData, this.page, formId)
   }
 
-  protected isSingleAppointment = (appointmentOrSession: AppointmentOrSession) =>
-    'deliusEventNumber' in appointmentOrSession
-
   protected backPath(
     pathData: AppointmentOrSessionParams,
     originalSearch?: Record<string, string>,
@@ -147,12 +144,9 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
       heading: this.buildHeading(appointmentOrSession),
     }
 
-    if (this.page !== 'confirm-details' && !this.isSingleAppointment(appointmentOrSession)) {
-      viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(
-        appointmentOrSession,
-        form.appointments ?? [],
-        formId,
-      )
+    const { session } = appointmentOrSession
+    if (session && this.page !== 'confirm-details') {
+      viewData.selectedPeopleCard = SessionUtils.selectedPeopleCard(session, form.appointments ?? [], formId)
     }
 
     return viewData
@@ -178,14 +172,14 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     }
   }
 
-  private buildHeading(appointmentOrSession: AppointmentOrSession) {
-    if ('offender' in appointmentOrSession) {
-      return this.offenderHeading(appointmentOrSession.offender)
+  private buildHeading({ appointment, session }: AppointmentOrSession) {
+    if (appointment) {
+      return this.offenderHeading(appointment.offender)
     }
     return {
-      title: appointmentOrSession.projectName,
+      title: session.projectName,
       caption: 'Bulk update',
-      description: `Date: ${DateTimeFormats.isoDateToUIDate(appointmentOrSession.date)}`,
+      description: `Date: ${DateTimeFormats.isoDateToUIDate(session.date)}`,
     }
   }
 

--- a/server/pages/appointments/bulkUpdatePage.ts
+++ b/server/pages/appointments/bulkUpdatePage.ts
@@ -1,5 +1,5 @@
-import { AppointmentDto, SessionDto } from '../../@types/shared'
-import { GovUkRadioOrCheckboxOption, PageHeader, ValidationErrors } from '../../@types/user-defined'
+import { AppointmentDto } from '../../@types/shared'
+import { GovUkRadioOrCheckboxOption, PageHeader, Session, ValidationErrors } from '../../@types/user-defined'
 import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
 import GovUkCheckboxes from '../../forms/GovUkCheckboxes'
 import Offender from '../../models/offender'
@@ -13,7 +13,7 @@ interface Body {
 }
 
 export default class BulkUpdatePage extends PageWithValidation<Body> {
-  viewData({ formData, session, formId }: { formData: AppointmentOutcomeForm; session: SessionDto; formId: string }): {
+  viewData({ formData, session, formId }: { formData: AppointmentOutcomeForm; session: Session; formId: string }): {
     backLink: string
     updatePath: string
     options: Array<GovUkRadioOrCheckboxOption>
@@ -50,12 +50,12 @@ export default class BulkUpdatePage extends PageWithValidation<Body> {
     return this.pathWithFormId(path, formId)
   }
 
-  private backPath(session: SessionDto, originalSearch?: Record<string, string>): string {
+  private backPath(session: Session, originalSearch?: Record<string, string>): string {
     const backPath = paths.sessions.show({ projectCode: session.projectCode, date: session.date })
     return pathWithQuery(backPath, originalSearch)
   }
 
-  private updatePath(formId: string, session: SessionDto): string {
+  private updatePath(formId: string, session: Session): string {
     const path = paths.sessions.update({ projectCode: session.projectCode, date: session.date, page: 'select-people' })
     return this.pathWithFormId(path, formId)
   }
@@ -71,7 +71,7 @@ export default class BulkUpdatePage extends PageWithValidation<Body> {
     }
   }
 
-  private items(session: SessionDto, formData: AppointmentOutcomeForm) {
+  private items(session: Session, formData: AppointmentOutcomeForm) {
     return GovUkCheckboxes.getOptions(
       session.appointmentSummaries
         .filter(appointment => !appointment.contactOutcome && appointment.offender.objectType === 'Full')

--- a/server/pages/appointments/checkAppointmentDetailsPage.test.ts
+++ b/server/pages/appointments/checkAppointmentDetailsPage.test.ts
@@ -467,7 +467,7 @@ describe('CheckAppointmentDetailsPage', () => {
 
       const result = page.commonViewData({
         pathData,
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         project: projectFactory.build({ projectType: { group: 'GROUP' } }),
         originalSearch,
         form: {} as AppointmentOutcomeForm,
@@ -490,7 +490,7 @@ describe('CheckAppointmentDetailsPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         project,
         originalSearch: search,
         form: {} as AppointmentOutcomeForm,
@@ -508,7 +508,7 @@ describe('CheckAppointmentDetailsPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         project: projectFactory.build(),
         originalSearch: {},
         form: {} as AppointmentOutcomeForm,

--- a/server/pages/appointments/chooseProjectPage.test.ts
+++ b/server/pages/appointments/chooseProjectPage.test.ts
@@ -23,7 +23,7 @@ describe('ChooseProjectPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'F1',
       })

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -223,7 +223,7 @@ describe('ChooseSupervisorPage', () => {
 
     it('should use session paths when appointmentOrSession is a session', () => {
       const pathData = { projectCode: 'P123', date: '2026-06-10' }
-      const session = sessionFactory.build(pathData)
+      const session = sessionFactory.build()
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
@@ -231,13 +231,13 @@ describe('ChooseSupervisorPage', () => {
       const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'choose-supervisor',
       })
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'select-people',
       })
       expect(paths.appointments.update).not.toHaveBeenCalled()

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -167,7 +167,7 @@ describe('ChooseSupervisorPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -189,7 +189,7 @@ describe('ChooseSupervisorPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -212,7 +212,7 @@ describe('ChooseSupervisorPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -228,7 +228,7 @@ describe('ChooseSupervisorPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -718,7 +718,7 @@ describe('ConfirmPage', () => {
 
     it('should use session paths when appointmentOrSession is a session', () => {
       const pathData = { projectCode: 'P123', date: '2026-06-10' }
-      const session = sessionFactory.build(pathData)
+      const session = sessionFactory.build()
       const submitted = appointmentOutcomeFormFactory.build({
         contactOutcome: contactOutcomeFactory.build({ attended: false }),
       })
@@ -734,13 +734,13 @@ describe('ConfirmPage', () => {
       })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'confirm-details',
       })
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'attendance-outcome',
       })
       expect(paths.appointments.update).not.toHaveBeenCalled()

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -40,7 +40,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -50,7 +50,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -64,7 +64,7 @@ describe('ConfirmPage', () => {
 
         const determineCheckedValueSpy = jest.spyOn(GovUkRadioGroup, 'determineCheckedValue')
 
-        const result = page.viewData(session, { projectCode: 'XY', date: '2026-01-02' }, formWithSession)
+        const result = page.viewData({ session }, { projectCode: 'XY', date: '2026-01-02' }, formWithSession)
 
         expect(determineCheckedValueSpy).toHaveBeenCalledWith(undefined)
         expect(result.alertPractitionerItems).toEqual(items)
@@ -85,7 +85,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: true },
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertDiaryText).toContain('also')
       })
 
@@ -93,7 +93,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: false },
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
         expect(result.alertDiaryText).not.toContain('also')
       })
     })
@@ -102,7 +102,7 @@ describe('ConfirmPage', () => {
       form = appointmentOutcomeFormFactory.build({
         contactOutcome: { code: 'some-code', willAlertEnforcementDiary: value },
       })
-      const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, form)
+      const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
       expect(result.showWillAlertPractitionerMessage).toEqual(value)
     })
 
@@ -123,7 +123,7 @@ describe('ConfirmPage', () => {
           notes,
           isSensitive: undefined,
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
         expect(result.submittedItems).toEqual([
           {
             key: {
@@ -238,7 +238,7 @@ describe('ConfirmPage', () => {
         const submitted = appointmentOutcomeFormFactory.build({
           contactOutcome,
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
             key: {
@@ -266,7 +266,7 @@ describe('ConfirmPage', () => {
           contactOutcome,
         })
 
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
 
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
@@ -295,7 +295,7 @@ describe('ConfirmPage', () => {
         const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const submitted = appointmentOutcomeFormFactory.build({ contactOutcome, date: '2026-01-20' })
 
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted, undefined, {
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted, undefined, {
           includeDateItem: true,
         })
 
@@ -323,7 +323,7 @@ describe('ConfirmPage', () => {
         const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
         const submitted = appointmentOutcomeFormFactory.build({ contactOutcome })
 
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted)
+        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
 
         expect(result.submittedItems).not.toContainEqual(expect.objectContaining({ key: { text: 'Date' } }))
       })
@@ -378,7 +378,11 @@ describe('ConfirmPage', () => {
           contactOutcome,
           attendanceData: { workQuality: 'GOOD', behaviour: 'NOT_APPLICABLE' },
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted).submittedItems
+        const result = page.viewData(
+          { appointment },
+          { projectCode: 'XY', appointmentId: '1' },
+          submitted,
+        ).submittedItems
 
         expect(result).toContainEqual({
           key: {
@@ -405,7 +409,11 @@ describe('ConfirmPage', () => {
           contactOutcome,
           notes: 'test',
         })
-        const result = page.viewData(appointment, { projectCode: 'XY', appointmentId: '1' }, submitted).submittedItems
+        const result = page.viewData(
+          { appointment },
+          { projectCode: 'XY', appointmentId: '1' },
+          submitted,
+        ).submittedItems
 
         expect(result).toContainEqual({
           key: {
@@ -453,7 +461,7 @@ describe('ConfirmPage', () => {
         })
 
         const pathData = { projectCode: 'XY', date: '2026-01-01' }
-        const result = page.viewData(session, pathData, submitted)
+        const result = page.viewData({ session }, pathData, submitted)
         const expectedPeople = 'Sam Jones (CRN002) <br/>Alex Smith (CRN001)'
 
         expect(result.submittedItems).toEqual([
@@ -583,7 +591,7 @@ describe('ConfirmPage', () => {
           ],
         })
 
-        const result = page.viewData(session, { projectCode: '', date: '' }, submitted)
+        const result = page.viewData({ session }, { projectCode: '', date: '' }, submitted)
 
         expect(result.submittedItems).toContainEqual(
           expect.objectContaining({
@@ -593,12 +601,24 @@ describe('ConfirmPage', () => {
         )
       })
 
-      it('should return an empty array from buildOffenderItem when appointmentOrSession is undefined', () => {
+      it('should not include offender item when appointment or session is undefined', () => {
         const submitted = appointmentOutcomeFormFactory.build()
 
-        const result = page.buildOffenderItem(submitted, undefined, { projectCode: 'XY', appointmentId: '1' }, '')
+        const result = page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, submitted)
 
-        expect(result).toEqual([])
+        const peopleItem = result.submittedItems.find(item => item.key.text === 'People')
+
+        expect(peopleItem).toBeUndefined()
+      })
+
+      it('should not include offender item when session is undefined', () => {
+        const submitted = appointmentOutcomeFormFactory.build()
+
+        const result = page.viewData({}, { projectCode: 'XY', appointmentId: '1' }, submitted)
+
+        const peopleItem = result.submittedItems.find(item => item.key.text === 'People')
+
+        expect(peopleItem).toBeUndefined()
       })
 
       it('should pass undefined appointment  when appointmentOrSession is undefined', () => {
@@ -638,7 +658,7 @@ describe('ConfirmPage', () => {
             projectCode: appointment.projectCode,
             date: '2026-01-20',
           },
-          appointmentOrSession: appointment,
+          appointmentOrSession: { appointment },
           form: formWithAttendance,
           formId: 'formId',
         })
@@ -662,7 +682,7 @@ describe('ConfirmPage', () => {
             projectCode: appointment.projectCode,
             date: '2026-01-20',
           },
-          appointmentOrSession: appointment,
+          appointmentOrSession: { appointment },
           form: formWithoutAttendance,
           formId: 'formId',
         })
@@ -684,7 +704,7 @@ describe('ConfirmPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -706,7 +726,12 @@ describe('ConfirmPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ pathData, appointmentOrSession: session, form: submitted, formId: 'formId' })
+      const result = page.commonViewData({
+        pathData,
+        appointmentOrSession: { session },
+        form: submitted,
+        formId: 'formId',
+      })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ContactOutcomeDto } from '../../@types/shared'
+import { AppointmentDto, ContactOutcomeDto, SessionDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOrSessionParams,
@@ -68,10 +68,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
   }
 
   private appointmentAlertValue(appointmentOrSession: AppointmentOrSession | undefined) {
-    if (!appointmentOrSession) {
-      return undefined
-    }
-    return this.isSingleAppointment(appointmentOrSession) ? appointmentOrSession.alertActive : undefined
+    return appointmentOrSession?.appointment?.alertActive
   }
 
   isAlertSelected(query: Query): boolean | null {
@@ -120,11 +117,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     formId?: string,
     options?: ItemsOptions,
   ): GovUkSummaryListItem[] {
-    const isSession = appointmentOrSession !== undefined && 'appointmentSummaries' in appointmentOrSession
+    const { appointment, session } = appointmentOrSession ?? {}
     const items: GovUkSummaryListItem[] = []
 
-    if (isSession) {
-      items.push(...this.buildOffenderItem(form, appointmentOrSession, pathData, formId))
+    if (session) {
+      items.push(...this.buildOffenderItem(form, session, pathData, formId))
     }
 
     if (options?.includeDateItem) {
@@ -259,10 +256,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
       )
     }
 
-    const appointment =
-      appointmentOrSession !== undefined && this.isSingleAppointment(appointmentOrSession)
-        ? appointmentOrSession
-        : undefined
+    const isSession = session !== undefined
 
     items.push(
       ...NotesUtils.checkYourAnswersRows(
@@ -286,21 +280,15 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     }
   }
 
-  buildOffenderItem(
+  private buildOffenderItem(
     form: AppointmentOutcomeForm,
-    appointmentOrSession: AppointmentOrSession | undefined,
+    session: SessionDto,
     pathData: AppointmentOrSessionParams,
     formId: string,
   ): Array<GovUkSummaryListItem> {
-    if (!appointmentOrSession || this.isSingleAppointment(appointmentOrSession)) {
-      return []
-    }
-
     const offenderDescriptions = form.appointments
       ?.map(appointment => {
-        const appointmentSummary = appointmentOrSession.appointmentSummaries.find(
-          summary => summary.id === appointment.id,
-        )
+        const appointmentSummary = session.appointmentSummaries.find(summary => summary.id === appointment.id)
         if (!appointmentSummary) {
           return undefined
         }

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,4 +1,4 @@
-import { AppointmentDto, ContactOutcomeDto, SessionDto } from '../../@types/shared'
+import { AppointmentDto, AppointmentSummaryDto, ContactOutcomeDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOrSessionParams,
@@ -121,7 +121,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     const items: GovUkSummaryListItem[] = []
 
     if (session) {
-      items.push(...this.buildOffenderItem(form, session, pathData, formId))
+      items.push(...this.buildOffenderItem(form, session.appointmentSummaries, pathData, formId))
     }
 
     if (options?.includeDateItem) {
@@ -282,13 +282,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
 
   private buildOffenderItem(
     form: AppointmentOutcomeForm,
-    session: SessionDto,
+    appointmentSummaries: Array<AppointmentSummaryDto>,
     pathData: AppointmentOrSessionParams,
     formId: string,
   ): Array<GovUkSummaryListItem> {
     const offenderDescriptions = form.appointments
       ?.map(appointment => {
-        const appointmentSummary = session.appointmentSummaries.find(summary => summary.id === appointment.id)
+        const appointmentSummary = appointmentSummaries.find(summary => summary.id === appointment.id)
         if (!appointmentSummary) {
           return undefined
         }

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -139,7 +139,7 @@ describe('LogCompliancePage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -161,7 +161,7 @@ describe('LogCompliancePage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -181,7 +181,7 @@ describe('LogCompliancePage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/logCompliancePage.test.ts
+++ b/server/pages/appointments/logCompliancePage.test.ts
@@ -176,7 +176,7 @@ describe('LogCompliancePage', () => {
 
     it('should use session paths when appointmentOrSession is a session', () => {
       const pathData = { projectCode: 'P123', date: '2026-06-10' }
-      const session = sessionFactory.build(pathData)
+      const session = sessionFactory.build()
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
@@ -184,13 +184,13 @@ describe('LogCompliancePage', () => {
       const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'log-compliance',
       })
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'log-hours',
       })
       expect(paths.appointments.update).not.toHaveBeenCalled()

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -180,7 +180,7 @@ describe('LogHoursPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -202,7 +202,7 @@ describe('LogHoursPage', () => {
           projectCode: appointment.projectCode,
           date: '2026-01-20',
         },
-        appointmentOrSession: appointment,
+        appointmentOrSession: { appointment },
         form,
         formId: 'formId',
       })
@@ -222,7 +222,7 @@ describe('LogHoursPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
-      const result = page.commonViewData({ pathData, appointmentOrSession: session, form, formId: 'formId' })
+      const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
         projectCode: session.projectCode,

--- a/server/pages/appointments/logHoursPage.test.ts
+++ b/server/pages/appointments/logHoursPage.test.ts
@@ -217,7 +217,7 @@ describe('LogHoursPage', () => {
 
     it('should use session paths when appointmentOrSession is a session', () => {
       const pathData = { projectCode: 'P123', date: '2026-06-10' }
-      const session = sessionFactory.build(pathData)
+      const session = sessionFactory.build()
 
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
@@ -225,13 +225,13 @@ describe('LogHoursPage', () => {
       const result = page.commonViewData({ pathData, appointmentOrSession: { session }, form, formId: 'formId' })
 
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'log-hours',
       })
       expect(paths.sessions.update).toHaveBeenCalledWith({
-        projectCode: session.projectCode,
-        date: session.date,
+        projectCode: pathData.projectCode,
+        date: pathData.date,
         page: 'attendance-outcome',
       })
       expect(paths.appointments.update).not.toHaveBeenCalled()

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -28,16 +28,18 @@ export const services = () => {
   } = dataAccess()
 
   const referenceDataService = new ReferenceDataService(referenceDataClient)
+  const projectService = new ProjectService(projectClient)
+  const appointmentService = new AppointmentService(appointmentClient)
 
   return {
     applicationInfo,
     auditService: new AuditService(auditClient),
     providerService: new ProviderService(providerClient),
-    projectService: new ProjectService(projectClient),
-    sessionService: new SessionService(sessionClient),
+    projectService,
+    sessionService: new SessionService(sessionClient, projectService, appointmentService),
     courseCompletionService: new CourseCompletionService(courseCompletionClient),
     referenceDataService,
-    appointmentService: new AppointmentService(appointmentClient),
+    appointmentService,
     appointmentFormService: new AppointmentFormService(formClient),
     courseCompletionFormService: new CourseCompletionFormService(formClient),
     offenderService: new OffenderService(offenderClient, referenceDataService),

--- a/server/services/projectService.ts
+++ b/server/services/projectService.ts
@@ -7,6 +7,11 @@ import { apiPageNumber, uiPageNumber } from '../utils/paginationUtils'
 export default class ProjectService {
   constructor(private readonly projectClient: ProjectClient) {}
 
+  /**
+   * If you are using this method to fetch session details
+   * consider using {@link SessionService.getSession} instead
+   * as this also calls this method under the hood.
+   */
   async getProject(request: GetProjectRequest): Promise<ProjectDto> {
     return this.projectClient.find(request)
   }

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -1,18 +1,25 @@
+import { createMock } from '@golevelup/ts-jest'
 import { PagedModelSessionSummaryDto } from '../@types/shared'
 import SessionClient from '../data/sessionClient'
 import SessionService from './sessionService'
-import sessionFactory from '../testutils/factories/sessionFactory'
 import sessionSummaryFactory from '../testutils/factories/sessionSummaryFactory'
 import pagedMetadataFactory from '../testutils/factories/pagedMetadataFactory'
+import projectFactory from '../testutils/factories/projectFactory'
+import pagedModelAppointmentSummaryFactory from '../testutils/factories/pagedModelAppointmentSummaryFactory'
+import ProjectService from './projectService'
+import AppointmentService from './appointmentService'
 
 jest.mock('../data/sessionClient')
 
 describe('ProviderService', () => {
-  const sessionClient = new SessionClient(null) as jest.Mocked<SessionClient>
+  const sessionClient = createMock<SessionClient>()
+  const projectService = createMock<ProjectService>()
+  const appointmentService = createMock<AppointmentService>()
   let sessionService: SessionService
 
   beforeEach(() => {
-    sessionService = new SessionService(sessionClient)
+    jest.resetAllMocks()
+    sessionService = new SessionService(sessionClient, projectService, appointmentService)
   })
 
   it('should call getSessions on the api client and return its result', async () => {
@@ -40,18 +47,34 @@ describe('ProviderService', () => {
     })
   })
 
-  it('should call find on the client and return its result', async () => {
-    const session = sessionFactory.build()
+  it('should call project and appointment services and return merged session data', async () => {
+    const project = projectFactory.build()
+    const date = '2025-01-01'
+    const appointments = pagedModelAppointmentSummaryFactory.build()
 
-    sessionClient.find.mockResolvedValue(session)
+    projectService.getProject.mockResolvedValue(project)
+    appointmentService.getAppointments.mockResolvedValue(appointments)
     const result = await sessionService.getSession({
       username: 'some-username',
-      projectCode: '1',
-      date: '2025-01-01',
+      projectCode: project.projectCode,
+      date,
     })
 
-    expect(sessionClient.find).toHaveBeenCalledTimes(1)
-    expect(result).toEqual(session)
-    expect(result.appointmentSummaries[0]).toEqual(session.appointmentSummaries[0])
+    expect(projectService.getProject).toHaveBeenCalledWith({
+      username: 'some-username',
+      projectCode: project.projectCode,
+    })
+
+    expect(appointmentService.getAppointments).toHaveBeenCalledWith('some-username', {
+      projectCodes: [project.projectCode],
+      fromDate: date,
+      toDate: date,
+    })
+
+    expect(result).toEqual({
+      ...project,
+      date,
+      appointmentSummaries: appointments.content,
+    })
   })
 })

--- a/server/services/sessionService.ts
+++ b/server/services/sessionService.ts
@@ -1,10 +1,16 @@
-import { PagedModelSessionSummaryDto, SessionDto } from '../@types/shared'
-import { GetSessionRequest, GetSessionsParams } from '../@types/user-defined'
+import { PagedModelSessionSummaryDto } from '../@types/shared'
+import { GetSessionRequest, GetSessionsParams, Session } from '../@types/user-defined'
 import SessionClient from '../data/sessionClient'
 import { apiPageNumber, uiPageNumber } from '../utils/paginationUtils'
+import AppointmentService from './appointmentService'
+import ProjectService from './projectService'
 
 export default class SessionService {
-  constructor(private readonly sessionClient: SessionClient) {}
+  constructor(
+    private readonly sessionClient: SessionClient,
+    private readonly projectService: ProjectService,
+    private readonly appointmentService: AppointmentService,
+  ) {}
 
   async getSessions(request: GetSessionsParams): Promise<PagedModelSessionSummaryDto> {
     const { page, sortBy, sortDirection, size, ...params } = request
@@ -23,8 +29,15 @@ export default class SessionService {
     } as PagedModelSessionSummaryDto
   }
 
-  async getSession(request: GetSessionRequest): Promise<SessionDto> {
-    const appointments = await this.sessionClient.find(request)
-    return appointments
+  async getSession(request: GetSessionRequest): Promise<Session> {
+    const { username, projectCode, date } = request
+    const project = await this.projectService.getProject({ username, projectCode })
+    const appointments = await this.appointmentService.getAppointments(username, {
+      projectCodes: [projectCode],
+      fromDate: date,
+      toDate: date,
+    })
+
+    return { ...project, appointmentSummaries: appointments.content, date } as Session
   }
 }

--- a/server/testutils/factories/sessionFactory.ts
+++ b/server/testutils/factories/sessionFactory.ts
@@ -1,16 +1,11 @@
 import { Factory } from 'fishery'
-import { faker, fakerEN_GB as fakerEngb } from '@faker-js/faker'
-import { SessionDto } from '../../@types/shared'
+import { faker } from '@faker-js/faker'
 import appointmentSummaryFactory from './appointmentSummaryFactory'
-import locationFactory from './locationFactory'
+import { Session } from '../../@types/user-defined'
+import projectFactory from './projectFactory'
 
-export default Factory.define<SessionDto>(() => ({
-  projectCode: faker.string.alpha(10),
-  projectName: faker.company.name(),
-  projectLocation: fakerEngb.location.county(),
-  location: locationFactory.build(),
+export default Factory.define<Session>(() => ({
+  ...projectFactory.build(),
   date: faker.date.recent().toISOString().split('T')[0],
-  startTime: '09:00',
-  endTime: '17:00',
   appointmentSummaries: appointmentSummaryFactory.buildList(3),
 }))

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -361,7 +361,7 @@ describe('SessionUtils', () => {
       expect(path).toBe(`/sessions/${session.projectCode}/${session.date}`)
     })
 
-    it('returns expected path given a SessionDto', () => {
+    it('returns expected path given a Session', () => {
       const session = sessionFactory.build()
       const path = SessionUtils.getSessionPath(session, {})
 

--- a/server/utils/sessionUtils.test.ts
+++ b/server/utils/sessionUtils.test.ts
@@ -285,17 +285,18 @@ describe('SessionUtils', () => {
         .mockReturnValueOnce('09:00 - 10:00')
         .mockReturnValueOnce('10:30 - 11:30')
 
-      const session = sessionFactory.build()
-
-      const [firstAppointment, secondAppointment] = session.appointmentSummaries
+      const appointmentSummaries = appointmentSummaryFactory.buildList(2)
+      const [firstAppointment, secondAppointment] = appointmentSummaries
 
       const selectedAppointments = [
         { id: firstAppointment.id, deliusVersion: '' },
         { id: secondAppointment.id, deliusVersion: '' },
       ]
 
+      const pathData = { projectCode: '2', date: '2026-01-02' }
+
       const formId = '1'
-      const result = SessionUtils.selectedPeopleCard(session, selectedAppointments, formId)
+      const result = SessionUtils.selectedPeopleCard(pathData, appointmentSummaries, selectedAppointments, formId)
 
       expect(result).toEqual({
         card: {
@@ -305,8 +306,8 @@ describe('SessionUtils', () => {
               {
                 href: pathWithQuery(
                   paths.sessions.update({
-                    projectCode: session.projectCode,
-                    date: session.date,
+                    projectCode: pathData.projectCode,
+                    date: pathData.date,
                     page: 'select-people',
                   }),
                   { form: formId },

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -1,5 +1,6 @@
 import {
   AppointmentDto,
+  AppointmentSummaryDto,
   ContactOutcomeDto,
   PagedModelSessionSummaryDto,
   SessionDto,
@@ -101,12 +102,13 @@ export default class SessionUtils {
   }
 
   static selectedPeopleCard(
-    session: SessionDto,
+    pathData: AppointmentOrSessionParams,
+    appointmentSummaries: Array<AppointmentSummaryDto>,
     selectedAppointments: AppointmentOutcomeForm['appointments'],
     formId: string,
   ): GovUkSummaryList {
     const ids = selectedAppointments.map(appointment => appointment.id)
-    const rows = session.appointmentSummaries
+    const rows = appointmentSummaries
       .filter(appointment => ids.includes(appointment.id))
       .map(appointment => {
         const offender = new Offender(appointment.offender)
@@ -124,7 +126,11 @@ export default class SessionUtils {
           items: [
             {
               href: pathWithQuery(
-                paths.sessions.update({ date: session.date, projectCode: session.projectCode, page: 'select-people' }),
+                paths.sessions.update({
+                  date: pathData.date,
+                  projectCode: pathData.projectCode,
+                  page: 'select-people',
+                }),
                 {
                   form: formId,
                 },

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -10,7 +10,7 @@ import Offender from '../models/offender'
 import paths from '../paths'
 import DateTimeFormats from './dateTimeUtils'
 import HtmlUtils from './htmlUtils'
-import { AppointmentOrSessionParams, GovUkSummaryList, GovUKValue } from '../@types/user-defined'
+import { AppointmentOrSessionParams, GovUkSummaryList, GovUKValue, Session } from '../@types/user-defined'
 import { AppointmentOutcomeForm } from '../services/forms/appointmentFormService'
 import { pathWithQuery } from './utils'
 import { GroupSessionIndexPageInput } from '../pages/groupSessionIndexPage'
@@ -41,7 +41,7 @@ export default class SessionUtils {
     })
   }
 
-  static sessionListTableRows(session: SessionDto, originalSearch: Record<string, string>) {
+  static sessionListTableRows(session: Session, originalSearch: Record<string, string>) {
     return session.appointmentSummaries.map(appointment => {
       const offender = new Offender(appointment.offender)
       const minutesRemaining =

--- a/server/utils/sessionUtils.ts
+++ b/server/utils/sessionUtils.ts
@@ -3,7 +3,6 @@ import {
   AppointmentSummaryDto,
   ContactOutcomeDto,
   PagedModelSessionSummaryDto,
-  SessionDto,
   SessionSummaryDto,
 } from '../@types/shared'
 import Offender from '../models/offender'
@@ -65,7 +64,7 @@ export default class SessionUtils {
 
   static getSessionPath(
     appointmentOrSession: Pick<
-      SessionSummaryDto | SessionDto | AppointmentDto | AppointmentOrSessionParams,
+      SessionSummaryDto | Session | AppointmentDto | AppointmentOrSessionParams,
       'date' | 'projectCode'
     >,
     query?: Record<string, string>,


### PR DESCRIPTION
## Context

Here, we replace the `getSession` request with 2 separate calls to `getProject` and `getAppointments`, so that we can take advantage of the same sorting and filtering on the `getAppointments` endpoint.

This change should enable us to remove the `getSession` endpoint and `SessionDto` from the API.

[CPB-1192](https://dsdmoj.atlassian.net/browse/CPB-1192)

## Changes in this PR

I have opted to take the approach of updating the `sessionService.getSession` method with these two separate calls, rather than replacing every inline reference to this method with to the two calls to the appointment service and project service.

One consideration against taking this approach would be that developers could unintentionally introduce duplicate `getProject` calls, so I'm wondering if we should introduce some inline documentation warning against this in the Project service.

This means we can also:
- Easily swap out the `SessionDto` instance (Which will also be deprecated), with our own definition in largely the same shape.
- Update our integration stub implementation, without updating all tests (although we do need to remove some additional `getProject` stubs to make this work

The PR does include some refactors to the use of the `SessionDto` to make this change smooth:

- Rewrite the `AppointmentOrSession` type, as this did not work with the updated type. Hopefully this refactor also simplifies the handling of single vs bulk updates.
- Fix some tests which were incorrectly asserting against a `SessionDto`
- Narrow the scope of some parameters

### Further work needed

The current implementation ignores paging on the `getAppointments` endpoint, and removes page data from the response. This enabled a smoother swap out of the `SessionDto`, but we should introduce this when needed (or next). 

This will introduce some breaking changes, unless we reassign the `content` property in the service method.

### Screenshots of UI changes

<img width="1408" height="1524" alt="Session page with session list sorted alphabetical by surname" src="https://github.com/user-attachments/assets/a9c2ecb2-84c7-4bd6-ad3d-ac1b74e8b61b" />

<img width="1397" height="786" alt="Bulk update select people question with people sorted alphabetically" src="https://github.com/user-attachments/assets/5736f536-413a-4ae3-b21c-e837874b62f6" />

<img width="1404" height="851" alt="Bulk update selected people widget sorted alphabetically" src="https://github.com/user-attachments/assets/59134431-bb8e-4192-8451-9dd4983fb94c" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1192]: https://dsdmoj.atlassian.net/browse/CPB-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ