### PR TITLE
CPB-1175: Handle back navigation through create form

### DIFF
--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -345,6 +345,7 @@ context('Create appointment - Confirm details', () => {
 
     // Scenario: navigating back to the date page via the date change link
     it('navigates to the date page when editing date', function test() {
+      cy.task('stubFindProject', { project: this.project })
       const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date: '2025-09-18' })
       cy.task('stubGetAppointmentForm', form)
 

--- a/integration_tests/tests/appointments/create/date.cy.ts
+++ b/integration_tests/tests/appointments/create/date.cy.ts
@@ -25,24 +25,36 @@
 //    And the person has multiple requirements
 //    When I click back
 //    Then I see the requirement page
+//    And I click back again
+//    Then I see the find a person page
+//    And I click back again
+//    Then I see the details of the project for that appointment
 
 //  Scenario: navigating back to the find a person page for an individual project
 //    Given I am on the 'date' page for a new appointment on an individual project
 //    And the person has one requirement
 //    When I click back
 //    Then I see the find a person page
+//    And I click back again
+//    Then I see the details of the project for that appointment
 
 //  Scenario: navigating back to the requirement page for a group session
 //    Given I am on the 'date' page for a new appointment on a group session
 //    And the person has multiple requirements
 //    When I click back
 //    Then I see the requirement page
+//    And I click back again
+//    Then I see the find a person page
+//    And I click back again
+//    Then I see the details of the session for that appointment
 
 //  Scenario: navigating back to the find a person page for a group session
 //    Given I am on the 'date' page for a new appointment on a group session
 //    And the person has one requirement
 //    When I click back
 //    Then I see the find a person page
+//    And I click back again
+//    Then I see the details of the session for that appointment
 
 import DatePage from '../../../pages/appointments/datePage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
@@ -56,6 +68,11 @@ import createAppointmentFormFactory from '../../../../server/testutils/factories
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import unpaidWorkDetailsFactory from '../../../../server/testutils/factories/unpaidWorkDetailsFactory'
 import Offender from '../../../../server/models/offender'
+import ProjectPage from '../../../pages/projects/projectPage'
+import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import ViewSessionPage from '../../../pages/viewSessionPage'
+import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
+import { baseProjectAppointmentRequest } from '../../../mockApis/projects'
 
 context('Create appointment - Date', () => {
   beforeEach(() => {
@@ -152,6 +169,25 @@ context('Create appointment - Date', () => {
 
         // Then I see the requirement page
         Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+
+        // And I click back again
+        page.clickBack()
+
+        // Then I see the find a person page
+        Page.verifyOnPage(FindAPersonPage)
+
+        // And I click back again
+        const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+
+        const request = {
+          ...baseProjectAppointmentRequest(),
+          projectCodes: [this.project.projectCode],
+        }
+        cy.task('stubGetAppointments', { request, pagedAppointments })
+        page.clickBack()
+
+        // Then I see the details of the project for that appointment
+        Page.verifyOnPage(ProjectPage, this.project)
       })
 
       // Scenario: navigating back to the find a person page for an individual project
@@ -171,18 +207,32 @@ context('Create appointment - Date', () => {
 
         // Then I see the find a person page
         Page.verifyOnPage(FindAPersonPage)
+
+        // And I click back again
+        const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+
+        const request = {
+          ...baseProjectAppointmentRequest(),
+          projectCodes: [this.project.projectCode],
+        }
+        cy.task('stubGetAppointments', { request, pagedAppointments })
+        page.clickBack()
+
+        // Then I see the details of the project for that appointment
+        Page.verifyOnPage(ProjectPage, this.project)
       })
     })
 
     describe('group session', () => {
       const project = projectFactory.build({ projectType: { group: 'GROUP' } })
       const date = '2025-09-19'
+      const session = sessionFactory.build({ ...project, date })
 
       beforeEach(function beforeEach() {
-        cy.task('stubFindProject', { project })
-
         const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date })
         cy.task('stubGetAppointmentForm', form)
+
+        cy.task('stubFindSession', { session })
       })
 
       // Scenario: navigating back to the requirement page for a group session
@@ -202,6 +252,21 @@ context('Create appointment - Date', () => {
 
         // Then I see the requirement page
         Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+
+        // And I click back again
+        page.clickBack()
+
+        // Then I see the find a person page
+        Page.verifyOnPage(FindAPersonPage)
+
+        const viewSession = sessionFactory.build({ ...project, date })
+        cy.task('stubFindSession', { session: viewSession })
+
+        // And I click back again
+        page.clickBack()
+
+        // Then I see the details of the session for that appointment
+        Page.verifyOnPage(ViewSessionPage, viewSession)
       })
 
       // Scenario: navigating back to the find a person page for a group session
@@ -221,6 +286,12 @@ context('Create appointment - Date', () => {
 
         // Then I see the find a person page
         Page.verifyOnPage(FindAPersonPage)
+
+        // And I click back again
+        page.clickBack()
+
+        // Then I see the details of the session for that appointment
+        Page.verifyOnPage(ViewSessionPage, session)
       })
     })
   })

--- a/integration_tests/tests/appointments/create/date.cy.ts
+++ b/integration_tests/tests/appointments/create/date.cy.ts
@@ -20,14 +20,42 @@
 //    When I submit the form
 //    Then I see the choose supervisor page
 
+//  Scenario: navigating back to the requirement page for an individual project
+//    Given I am on the 'date' page for a new appointment on an individual project
+//    And the person has multiple requirements
+//    When I click back
+//    Then I see the requirement page
+
+//  Scenario: navigating back to the find a person page for an individual project
+//    Given I am on the 'date' page for a new appointment on an individual project
+//    And the person has one requirement
+//    When I click back
+//    Then I see the find a person page
+
+//  Scenario: navigating back to the requirement page for a group session
+//    Given I am on the 'date' page for a new appointment on a group session
+//    And the person has multiple requirements
+//    When I click back
+//    Then I see the requirement page
+
+//  Scenario: navigating back to the find a person page for a group session
+//    Given I am on the 'date' page for a new appointment on a group session
+//    And the person has one requirement
+//    When I click back
+//    Then I see the find a person page
+
 import DatePage from '../../../pages/appointments/datePage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
+import RequirementPage from '../../../pages/requirementPage'
+import FindAPersonPage from '../../../pages/findAPersonPage'
 import Page from '../../../pages/page'
 import projectFactory from '../../../../server/testutils/factories/projectFactory'
 import offenderFullFactory from '../../../../server/testutils/factories/offenderFullFactory'
 import caseDetailsSummaryFactory from '../../../../server/testutils/factories/caseDetailsSummaryFactory'
 import createAppointmentFormFactory from '../../../../server/testutils/factories/createAppointmentFormFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
+import unpaidWorkDetailsFactory from '../../../../server/testutils/factories/unpaidWorkDetailsFactory'
+import Offender from '../../../../server/models/offender'
 
 context('Create appointment - Date', () => {
   beforeEach(() => {
@@ -35,7 +63,7 @@ context('Create appointment - Date', () => {
     cy.task('stubSignIn')
     cy.signIn()
 
-    const project = projectFactory.build()
+    const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
     cy.wrap(project).as('project')
 
     const offender = offenderFullFactory.build()
@@ -48,6 +76,7 @@ context('Create appointment - Date', () => {
 
     cy.task('stubGetOffenderSummary', { caseDetailsSummary })
     cy.task('stubGetAppointmentForm', form)
+    cy.task('stubFindProject', { project })
   })
 
   // Scenario: Validating the 'date' page
@@ -94,7 +123,6 @@ context('Create appointment - Date', () => {
     page.shouldHaveValue('01/01/2026')
 
     const teams = providerTeamSummaryFactory.buildList(2)
-    cy.task('stubFindProject', { project: this.project })
     cy.task('stubGetTeams', { teams: { providers: teams }, providerCode: this.project.providerCode })
     cy.task('stubSaveAppointmentForm')
 
@@ -103,5 +131,97 @@ context('Create appointment - Date', () => {
 
     // Then I see the choose supervisor page
     Page.verifyOnPage(ChooseSupervisorPage, { offender: this.offender })
+  })
+
+  describe('navigating back', () => {
+    describe('individual project', () => {
+      // Scenario: navigating back to the requirement page for an individual project
+      it('goes back to the requirement page when the person has multiple requirements', function test() {
+        // Given the person has multiple requirements
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({
+          offender: this.offender,
+          unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+        })
+        cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+        // And I am on the 'date' page for a new appointment on an individual project
+        const page = DatePage.visitForCreateAppointment(this.project.projectCode, this.offender)
+
+        // When I click back
+        page.clickBack()
+
+        // Then I see the requirement page
+        Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+      })
+
+      // Scenario: navigating back to the find a person page for an individual project
+      it('goes back to the find a person page when the person has one requirement', function test() {
+        // Given the person has one requirement
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({
+          offender: this.offender,
+          unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(1),
+        })
+        cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+        // And I am on the 'date' page for a new appointment on an individual project
+        const page = DatePage.visitForCreateAppointment(this.project.projectCode, this.offender)
+
+        // When I click back
+        page.clickBack()
+
+        // Then I see the find a person page
+        Page.verifyOnPage(FindAPersonPage)
+      })
+    })
+
+    describe('group session', () => {
+      const project = projectFactory.build({ projectType: { group: 'GROUP' } })
+      const date = '2025-09-19'
+
+      beforeEach(function beforeEach() {
+        cy.task('stubFindProject', { project })
+
+        const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date })
+        cy.task('stubGetAppointmentForm', form)
+      })
+
+      // Scenario: navigating back to the requirement page for a group session
+      it('goes back to the requirement page when the person has multiple requirements', function test() {
+        // Given the person has multiple requirements
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({
+          offender: this.offender,
+          unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+        })
+        cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+        // And I am on the 'date' page for a new appointment on a group session
+        const page = DatePage.visitForCreateAppointment(project.projectCode, this.offender)
+
+        // When I click back
+        page.clickBack()
+
+        // Then I see the requirement page
+        Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+      })
+
+      // Scenario: navigating back to the find a person page for a group session
+      it('goes back to the find a person page when the person has one requirement', function test() {
+        // Given the person has one requirement
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({
+          offender: this.offender,
+          unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(1),
+        })
+        cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+        // And I am on the 'date' page for a new appointment on a group session
+        const page = DatePage.visitForCreateAppointment(project.projectCode, this.offender)
+
+        // When I click back
+        page.clickBack()
+
+        // Then I see the find a person page
+        Page.verifyOnPage(FindAPersonPage)
+      })
+    })
   })
 })

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -15,6 +15,7 @@ import {
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import { NEW_APPOINTMENT_ID } from '../../pages/appointments/pathMap'
 import OffenderService from '../../services/offenderService'
+import { CaseDetailsSummaryDto } from '../../@types/shared'
 
 export type AppointmentStepViewDataParams = {
   req: Request
@@ -25,6 +26,7 @@ export type AppointmentStepViewDataParams = {
   errors: ValidationErrors<unknown>
   contextData?: unknown
   isSingleAppointment: boolean
+  offenderSummary?: CaseDetailsSummaryDto
 }
 
 export type ContextDataParams = {
@@ -77,6 +79,7 @@ export default abstract class BaseAppointmentController<
         errors: {},
         contextData,
         isSingleAppointment: true,
+        offenderSummary,
       })
 
       res.render(this.getTemplatePath(), { ...paths, heading, ...stepViewData })
@@ -151,6 +154,7 @@ export default abstract class BaseAppointmentController<
             errors,
             contextData,
             isSingleAppointment: true,
+            offenderSummary,
           })),
           errorSummary,
           errors,

--- a/server/controllers/appointments/dateController.ts
+++ b/server/controllers/appointments/dateController.ts
@@ -4,10 +4,37 @@ import BaseAppointmentController, { AppointmentStepViewDataParams } from './base
 import SessionService from '../../services/sessionService'
 import OffenderService from '../../services/offenderService'
 import DatePage from '../../pages/appointments/datePage'
+import ProjectService from '../../services/projectService'
 
 export default class DateController extends BaseAppointmentController<DatePage> {
-  protected getStepViewData({ form, req }: AppointmentStepViewDataParams): Promise<object> {
-    return Promise.resolve(this.page.viewData(form, req.body))
+  protected async getStepViewData({
+    form,
+    req,
+    res,
+    formId,
+    offenderSummary,
+    appointmentOrSession,
+  }: AppointmentStepViewDataParams): Promise<object> {
+    const { projectCode } = req.params
+    const { projectType } = appointmentOrSession?.session
+      ? appointmentOrSession.session
+      : await this.projectService.getProject({
+          username: res.locals.user.username,
+          projectCode: req.params.projectCode,
+        })
+
+    const backLink = this.page.getBackPath({
+      projectCode,
+      date: form.date,
+      projectTypeGroup: projectType.group,
+      formId,
+      offenderSummary,
+    })
+
+    return {
+      ...this.page.viewData(form, req.body),
+      backLink,
+    }
   }
 
   constructor(
@@ -15,6 +42,7 @@ export default class DateController extends BaseAppointmentController<DatePage> 
     appointmentFormService: AppointmentFormService,
     sessionService: SessionService,
     offenderService: OffenderService,
+    private readonly projectService: ProjectService,
   ) {
     super(new DatePage(), appointmentService, appointmentFormService, sessionService, offenderService)
   }

--- a/server/controllers/appointments/index.ts
+++ b/server/controllers/appointments/index.ts
@@ -99,6 +99,7 @@ const controllers = (services: Services) => {
     services.appointmentFormService,
     services.sessionService,
     services.offenderService,
+    services.projectService,
   )
 
   const updateControllers: Record<AppointmentFormPage, IAppointmentFormPageController> = {

--- a/server/controllers/personSearchController.test.ts
+++ b/server/controllers/personSearchController.test.ts
@@ -43,10 +43,10 @@ describe('PersonSearchController', () => {
 
   describe('show', () => {
     it('renders the find a person page', async () => {
-      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON)
+      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, { backPath: '/' })
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('pages/findAPerson', {})
+      expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { backLink: '/' })
     })
 
     it('renders the find a person page and sends an audit message for each result', async () => {
@@ -65,19 +65,22 @@ describe('PersonSearchController', () => {
         render: jest.fn(),
       })
 
-      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON)
+      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, { backPath: '/' })
       await requestHandler(request, responseWithResults, next)
 
       expect(auditService.sendAuditMessage).toHaveBeenCalledTimes(3)
-      expect(responseWithResults.render).toHaveBeenCalledWith('pages/findAPerson', {})
+      expect(responseWithResults.render).toHaveBeenCalledWith('pages/findAPerson', { backLink: '/' })
     })
   })
 
   it('renders the find a person page with result path if provided', async () => {
     const resultPath = '/some-path'
-    const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, resultPath)
+    const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+      resultPath,
+      backPath: '/',
+    })
     await requestHandler(request, response, next)
 
-    expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { resultPath })
+    expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { resultPath, backLink: '/' })
   })
 })

--- a/server/controllers/personSearchController.ts
+++ b/server/controllers/personSearchController.ts
@@ -4,7 +4,7 @@ import AuditService from '../services/auditService'
 export default class PersonSearchController {
   constructor(private readonly auditService: AuditService) {}
 
-  show(auditPageAction: string, resultPath?: string): RequestHandler {
+  show(auditPageAction: string, { resultPath, backPath }: { resultPath?: string; backPath: string }): RequestHandler {
     return async (req: Request, res: Response) => {
       if (res.locals.searchResults.response) {
         const people = res.locals.searchResults.response.content
@@ -21,7 +21,7 @@ export default class PersonSearchController {
         })
       }
 
-      return res.render('pages/findAPerson', { resultPath })
+      return res.render('pages/findAPerson', { resultPath, backLink: backPath })
     }
   }
 }

--- a/server/pages/appointments/datePage.test.ts
+++ b/server/pages/appointments/datePage.test.ts
@@ -3,6 +3,8 @@ import appointmentOutcomeFormFactory from '../../testutils/factories/appointment
 import MojDateInput from '../../forms/mojDateInput'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import DatePage from './datePage'
+import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
+import unpaidWorkDetailsFactory from '../../testutils/factories/unpaidWorkDetailsFactory'
 
 jest.mock('../../forms/mojDateInput')
 jest.mock('../../utils/dateTimeUtils')
@@ -149,6 +151,86 @@ describe('DatePage', () => {
 
       expect(MojDateInput.toIsoDate).toHaveBeenCalledWith('02/02/2026')
       expect(result).toEqual({ ...form, date: '2026-02-02' })
+    })
+  })
+
+  describe('getBackPath', () => {
+    it('should throw when no offender summary is provided', () => {
+      const page = new DatePage()
+
+      expect(() => page.getBackPath({ projectCode: 'P123', projectTypeGroup: 'INDIVIDUAL', formId: 'form-1' })).toThrow(
+        'Back path not implemented for cases without a person selected',
+      )
+    })
+
+    describe('given an offender with multiple requirements', () => {
+      const offenderSummary = caseDetailsSummaryFactory.build({
+        unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+      })
+      it('should return the individual project requirement path when project type is INDIVIDUAL', () => {
+        const page = new DatePage()
+
+        const result = page.getBackPath({
+          projectCode: 'P123',
+          projectTypeGroup: 'INDIVIDUAL',
+          formId: 'form-1',
+          offenderSummary,
+        })
+
+        expect(result).toBe(
+          `${paths.projects.create.requirement({ projectCode: 'P123', crn: offenderSummary.offender.crn })}?form=form-1`,
+        )
+      })
+
+      it('should return the session requirement path when project type is not INDIVIDUAL', () => {
+        const page = new DatePage()
+
+        const result = page.getBackPath({
+          projectCode: 'P123',
+          date: '2026-08-06',
+          projectTypeGroup: 'GROUP',
+          formId: 'form-1',
+          offenderSummary,
+        })
+
+        expect(result).toBe(
+          `${paths.sessions.create.requirement({ projectCode: 'P123', date: '2026-08-06', crn: offenderSummary.offender.crn })}?form=form-1`,
+        )
+      })
+    })
+
+    describe('given an offender with 1 requirement', () => {
+      const offenderSummary = caseDetailsSummaryFactory.build({
+        unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(1),
+      })
+      it('should return the individual project requirement path when project type is INDIVIDUAL', () => {
+        const page = new DatePage()
+
+        const result = page.getBackPath({
+          projectCode: 'P123',
+          projectTypeGroup: 'INDIVIDUAL',
+          formId: 'form-1',
+          offenderSummary,
+        })
+
+        expect(result).toBe(`${paths.projects.create.findAPerson({ projectCode: 'P123' })}?form=form-1`)
+      })
+
+      it('should return the session requirement path when project type is not INDIVIDUAL', () => {
+        const page = new DatePage()
+
+        const result = page.getBackPath({
+          projectCode: 'P123',
+          date: '2026-08-06',
+          projectTypeGroup: 'GROUP',
+          formId: 'form-1',
+          offenderSummary,
+        })
+
+        expect(result).toBe(
+          `${paths.sessions.create.findAPerson({ projectCode: 'P123', date: '2026-08-06' })}?form=form-1`,
+        )
+      })
     })
   })
 })

--- a/server/pages/appointments/datePage.ts
+++ b/server/pages/appointments/datePage.ts
@@ -1,5 +1,7 @@
+import { CaseDetailsSummaryDto, ProjectTypeDto } from '../../@types/shared'
 import { AppointmentOrSessionParams, ValidationErrors } from '../../@types/user-defined'
 import MojDateInput from '../../forms/mojDateInput'
+import paths from '../../paths'
 import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
@@ -58,5 +60,34 @@ export default class DatePage extends BaseAppointmentUpdatePage<DateBody> {
 
   protected nextPage(): AppointmentFormPage {
     return 'choose-supervisor'
+  }
+
+  getBackPath({
+    projectCode,
+    projectTypeGroup: projectType,
+    formId,
+    date,
+    offenderSummary,
+  }: {
+    projectTypeGroup: ProjectTypeDto['group']
+    formId: string
+    offenderSummary?: CaseDetailsSummaryDto
+  } & AppointmentOrSessionParams): string {
+    if (!offenderSummary) {
+      throw new Error('Back path not implemented for cases without a person selected')
+    }
+
+    const pathNamespace = projectType === 'INDIVIDUAL' ? 'projects' : 'sessions'
+
+    if (offenderSummary.unpaidWorkDetails.length === 1) {
+      const params = { projectCode, date }
+      return this.pathWithFormId(paths[pathNamespace].create.findAPerson(params), formId)
+    }
+
+    const { crn } = offenderSummary.offender
+
+    const params = { projectCode, date, crn }
+
+    return this.pathWithFormId(paths[pathNamespace].create.requirement(params), formId)
   }
 }

--- a/server/routes/people.ts
+++ b/server/routes/people.ts
@@ -20,7 +20,11 @@ export default function peopleRoutes(controllers: Controllers, services: Service
         const resultPath = paths.people.requirement({
           crn: ':crn',
         })
-        return personSearchController.show(Page.SEARCH_FIND_A_PERSON_RESULTS, resultPath)(req, res, next)
+        return personSearchController.show(Page.SEARCH_FIND_A_PERSON_RESULTS, { resultPath, backPath: '/' })(
+          req,
+          res,
+          next,
+        )
       },
     ],
     {

--- a/server/routes/project.ts
+++ b/server/routes/project.ts
@@ -29,7 +29,13 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
           projectCode: req.params.projectCode,
           crn: ':crn',
         })
-        return personSearchController.show(Page.SEARCH_PROJECT_FIND_A_PERSON_RESULTS, resultPath)(req, res, next)
+
+        const backPath = paths.projects.show({ projectCode: req.params.projectCode })
+        return personSearchController.show(Page.SEARCH_PROJECT_FIND_A_PERSON_RESULTS, { resultPath, backPath })(
+          req,
+          res,
+          next,
+        )
       },
     ],
     {

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -47,7 +47,13 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
           date: req.params.date,
           crn: ':crn',
         })
-        return personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON_RESULTS, resultPath)(req, res, next)
+
+        const backPath = paths.sessions.show({ projectCode: req.params.projectCode, date: req.params.date })
+        return personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON_RESULTS, { resultPath, backPath })(
+          req,
+          res,
+          next,
+        )
       },
     ],
     {

--- a/server/views/pages/findAPerson.njk
+++ b/server/views/pages/findAPerson.njk
@@ -1,8 +1,17 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = "Find a person with a community payback order" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "dashboard--index" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
 
 {% block content %}
   {% from "probation/case-search/macro.njk" import caseSearch %}


### PR DESCRIPTION
## Context

This implements back navigation back to a project or session page from any page of the create appointment form.
[CPB-1175](https://dsdmoj.atlassian.net/browse/CPB-1175)

## Changes in this PR

<!-- highlight the changes you’ve made -->
<!-- describe any particular difficulties or areas that you particularly want the opinion of the reviewer -->

### Screenshots of UI changes

Navigating from a session page and back:


https://github.com/user-attachments/assets/75b3578f-de07-49c6-b199-9145d0bdd0e6


Navigating from a project page and back:


https://github.com/user-attachments/assets/849323a0-338c-4366-8c44-e4d5ea1fe4b2



## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1175]: https://dsdmoj.atlassian.net/browse/CPB-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ