### PR TITLE
CPB-1175: Handle form and search persistence

### DIFF
--- a/integration_tests/pages/requirementPage.ts
+++ b/integration_tests/pages/requirementPage.ts
@@ -2,6 +2,7 @@ import { OffenderFullDto, ProjectDto } from '../../server/@types/shared'
 import { Session } from '../../server/@types/user-defined'
 import Offender from '../../server/models/offender'
 import paths from '../../server/paths'
+import { pathWithQuery } from '../../server/utils/utils'
 import RadioOrCheckboxGroupComponent from './components/radioOrCheckboxGroupComponent'
 import Page from './page'
 
@@ -13,15 +14,21 @@ export default class RequirementPage extends Page {
     this.requirementOptions = new RadioOrCheckboxGroupComponent('deliusEventNumber')
   }
 
-  static visitForSession(session: Session, offender: OffenderFullDto) {
+  static visitForSession(session: Session, offender: OffenderFullDto, originalSearch?: Record<string, string>) {
     const { crn, name } = new Offender(offender)
-    const path = paths.sessions.create.requirement({ projectCode: session.projectCode, date: session.date, crn })
+    const path = pathWithQuery(
+      paths.sessions.create.requirement({ projectCode: session.projectCode, date: session.date, crn }),
+      originalSearch,
+    )
     return this.visitAndCheck(path, name)
   }
 
-  static visitForProject(project: ProjectDto, offender: OffenderFullDto) {
+  static visitForProject(project: ProjectDto, offender: OffenderFullDto, originalSearch?: Record<string, string>) {
     const { crn, name } = new Offender(offender)
-    const path = paths.projects.create.requirement({ projectCode: project.projectCode, crn })
+    const path = pathWithQuery(
+      paths.projects.create.requirement({ projectCode: project.projectCode, crn }),
+      originalSearch,
+    )
     return this.visitAndCheck(path, name)
   }
 

--- a/integration_tests/tests/appointments/create/date.cy.ts
+++ b/integration_tests/tests/appointments/create/date.cy.ts
@@ -73,6 +73,12 @@ import sessionFactory from '../../../../server/testutils/factories/sessionFactor
 import ViewSessionPage from '../../../pages/viewSessionPage'
 import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
 import { baseProjectAppointmentRequest } from '../../../mockApis/projects'
+import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
+import FindASessionPage from '../../../pages/findASessionPage'
+import sessionSummaryFactory from '../../../../server/testutils/factories/sessionSummaryFactory'
+import { CreateAppointmentForm } from '../../../../server/services/forms/appointmentFormService'
+import pagedModelProjectOutcomeSummaryFactory from '../../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
+import FindIndividualPlacementPage from '../../../pages/projects/findIndividualPlacementPage'
 
 context('Create appointment - Date', () => {
   beforeEach(() => {
@@ -188,6 +194,24 @@ context('Create appointment - Date', () => {
 
         // Then I see the details of the project for that appointment
         Page.verifyOnPage(ProjectPage, this.project)
+
+        // And I click back again
+        const provider = providerSummaryFactory.build({ code: this.form.originalSearch.provider })
+        const team = providerTeamSummaryFactory.build({ code: this.form.originalSearch.team })
+        cy.task('stubGetProviders', { providers: { providers: [provider] } })
+        cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+
+        const projects = pagedModelProjectOutcomeSummaryFactory.build()
+        cy.task('stubGetProjects', {
+          teamCode: this.form.originalSearch.team,
+          providerCode: this.form.originalSearch.provider,
+          projects,
+        })
+        page.clickBack()
+
+        // Then I see the original search results
+        const searchPage = Page.verifyOnPage(FindIndividualPlacementPage, projects.content)
+        searchPage.shouldShowIndividualPlacements()
       })
 
       // Scenario: navigating back to the find a person page for an individual project
@@ -220,16 +244,35 @@ context('Create appointment - Date', () => {
 
         // Then I see the details of the project for that appointment
         Page.verifyOnPage(ProjectPage, this.project)
+
+        // And I click back again
+        const provider = providerSummaryFactory.build({ code: this.form.originalSearch.provider })
+        const team = providerTeamSummaryFactory.build({ code: this.form.originalSearch.team })
+        cy.task('stubGetProviders', { providers: { providers: [provider] } })
+        cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+
+        const projects = pagedModelProjectOutcomeSummaryFactory.build()
+        cy.task('stubGetProjects', {
+          teamCode: this.form.originalSearch.team,
+          providerCode: this.form.originalSearch.provider,
+          projects,
+        })
+        page.clickBack()
+
+        // Then I see the original search results
+        const searchPage = Page.verifyOnPage(FindIndividualPlacementPage, projects.content)
+        searchPage.shouldShowIndividualPlacements()
       })
     })
 
-    describe('group session', () => {
+    describe('group session', function describe() {
       const project = projectFactory.build({ projectType: { group: 'GROUP' } })
       const date = '2025-09-19'
       const session = sessionFactory.build({ ...project, date })
+      let form: CreateAppointmentForm
 
       beforeEach(function beforeEach() {
-        const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date })
+        form = createAppointmentFormFactory.build({ crn: this.offender.crn, date })
         cy.task('stubGetAppointmentForm', form)
 
         cy.task('stubFindSession', { session })
@@ -267,6 +310,31 @@ context('Create appointment - Date', () => {
 
         // Then I see the details of the session for that appointment
         Page.verifyOnPage(ViewSessionPage, viewSession)
+
+        // And I click back again
+        const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
+        const team = providerTeamSummaryFactory.build({ code: form.originalSearch.team })
+        cy.task('stubGetProviders', { providers: { providers: [provider] } })
+        cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+        const sessionSummary = sessionSummaryFactory.build()
+        cy.task('stubGetSessions', {
+          request: {
+            providerCode: provider.code,
+            teamCode: team.code,
+            startDate: '2025-01-01',
+            endDate: '2025-01-01',
+            username: 'some-name',
+          },
+          sessions: {
+            content: [sessionSummary],
+          },
+        })
+
+        page.clickBack()
+
+        // Then I see the original search results
+        const searchPage = Page.verifyOnPage(FindASessionPage)
+        searchPage.shouldShowSearchResults(sessionSummary)
       })
 
       // Scenario: navigating back to the find a person page for a group session
@@ -292,6 +360,31 @@ context('Create appointment - Date', () => {
 
         // Then I see the details of the session for that appointment
         Page.verifyOnPage(ViewSessionPage, session)
+
+        // And I click back again
+        const provider = providerSummaryFactory.build({ code: form.originalSearch.provider })
+        const team = providerTeamSummaryFactory.build({ code: form.originalSearch.team })
+        cy.task('stubGetProviders', { providers: { providers: [provider] } })
+        cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+        const sessionSummary = sessionSummaryFactory.build()
+        cy.task('stubGetSessions', {
+          request: {
+            providerCode: provider.code,
+            teamCode: team.code,
+            startDate: '2025-01-01',
+            endDate: '2025-01-01',
+            username: 'some-name',
+          },
+          sessions: {
+            content: [sessionSummary],
+          },
+        })
+
+        page.clickBack()
+
+        // Then I see the original search results
+        const searchPage = Page.verifyOnPage(FindASessionPage)
+        searchPage.shouldShowSearchResults(sessionSummary)
       })
     })
   })

--- a/integration_tests/tests/appointments/create/requirement.cy.ts
+++ b/integration_tests/tests/appointments/create/requirement.cy.ts
@@ -13,6 +13,15 @@ import DatePage from '../../../pages/appointments/datePage'
 import createAppointmentFormFactory from '../../../../server/testutils/factories/createAppointmentFormFactory'
 import Offender from '../../../../server/models/offender'
 import NoRequirementsPage from '../../../pages/noRequirementsPage'
+import FindASessionPage from '../../../pages/findASessionPage'
+import providerSummaryFactory from '../../../../server/testutils/factories/providerSummaryFactory'
+import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
+import sessionSummaryFactory from '../../../../server/testutils/factories/sessionSummaryFactory'
+import ProjectPage from '../../../pages/projects/projectPage'
+import FindIndividualPlacementPage from '../../../pages/projects/findIndividualPlacementPage'
+import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
+import pagedModelProjectOutcomeSummaryFactory from '../../../../server/testutils/factories/pagedModelProjectOutcomeSummaryFactory'
+import { baseProjectAppointmentRequest } from '../../../mockApis/projects'
 
 context('Create session appointment - requirement', () => {
   const date = '2025-09-19'
@@ -75,12 +84,12 @@ context('Create session appointment - requirement', () => {
       caseDetailsSummary,
     })
 
-    // When I click on a session in the results
+    // When I visit the session details page
     cy.task('stubFindSession', { session })
 
     ViewSessionPage.visit(session)
 
-    //  And navigate to the find a person page
+    // And navigate to the find a person page
     const sessionDetailsPage = Page.verifyOnPage(ViewSessionPage, session)
 
     sessionDetailsPage.clickAddAnAppointment()
@@ -120,12 +129,12 @@ context('Create session appointment - requirement', () => {
       caseDetailsSummary,
     })
 
-    // When I click on a session in the results
+    // When I visit the session details page
     cy.task('stubFindSession', { session })
 
     ViewSessionPage.visit(session)
 
-    //  And navigate to the find a person page
+    // And navigate to the find a person page
     const sessionDetailsPage = Page.verifyOnPage(ViewSessionPage, session)
 
     sessionDetailsPage.clickAddAnAppointment()
@@ -158,12 +167,12 @@ context('Create session appointment - requirement', () => {
       caseDetailsSummary,
     })
 
-    // When I click on a session in the results
+    // When I visit the session details page
     cy.task('stubFindSession', { session })
 
     ViewSessionPage.visit(session)
 
-    //  And navigate to the find a person page
+    // And navigate to the find a person page
     const sessionDetailsPage = Page.verifyOnPage(ViewSessionPage, session)
 
     sessionDetailsPage.clickAddAnAppointment()
@@ -207,6 +216,64 @@ context('Create session appointment - requirement', () => {
     requirementPage.clickBack()
 
     Page.verifyOnPage(FindAPersonPage)
+  })
+
+  it('navigates back to the session details page and group search', () => {
+    // Given a person on probation has multiple requirements
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({
+      offender,
+      unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+    })
+
+    cy.task('stubGetOffenderSummary', {
+      caseDetailsSummary,
+    })
+
+    const providerCode = 'provider-1'
+    const teamCode = 'team-1'
+    const searchDate = '01/01/2025'
+
+    // When I visit the requirement page
+    const requirementPage = RequirementPage.visitForSession(session, offender, {
+      provider: providerCode,
+      team: teamCode,
+      date: searchDate,
+    })
+    requirementPage.clickBack()
+
+    // Then I should see the find a person page
+    const findAPersonPage = Page.verifyOnPage(FindAPersonPage, session)
+
+    // And the back link should take me to the session details page
+    cy.task('stubFindSession', { session })
+    findAPersonPage.clickBack()
+
+    const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
+
+    const provider = providerSummaryFactory.build({ code: providerCode })
+    const team = providerTeamSummaryFactory.build({ code: teamCode })
+    cy.task('stubGetProviders', { providers: { providers: [provider] } })
+    cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+    const sessionSummary = sessionSummaryFactory.build()
+    cy.task('stubGetSessions', {
+      request: {
+        providerCode: provider.code,
+        teamCode: team.code,
+        startDate: '2025-01-01',
+        endDate: '2025-01-01',
+        username: 'some-name',
+      },
+      sessions: {
+        content: [sessionSummary],
+      },
+    })
+
+    // When I click back to the find a session page
+    viewSessionPage.clickBack()
+
+    // Then I should see the find a session page with original search
+    const searchPage = Page.verifyOnPage(FindASessionPage)
+    searchPage.shouldShowSearchResults(sessionSummary)
   })
 })
 
@@ -337,5 +404,61 @@ context('Create project appointment - requirement', () => {
     requirementPage.clickBack()
 
     Page.verifyOnPage(FindAPersonPage)
+  })
+
+  it('navigates back to the project details page and individual placement search', () => {
+    // Given a person on probation has multiple requirements
+    const caseDetailsSummary = caseDetailsSummaryFactory.build({
+      offender,
+      unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+    })
+
+    cy.task('stubGetOffenderSummary', {
+      caseDetailsSummary,
+    })
+
+    const providerCode = 'provider-1'
+    const teamCode = 'team-1'
+    const date = '01/01/2025'
+
+    // When I visit the requirement page
+    const requirementPage = RequirementPage.visitForProject(project, offender, {
+      provider: providerCode,
+      team: teamCode,
+      date,
+    })
+    requirementPage.clickBack()
+
+    // Then I should see the find a person page
+    const findAPersonPage = Page.verifyOnPage(FindAPersonPage)
+
+    // And the back link should take me to the project details page
+    const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+    const request = {
+      ...baseProjectAppointmentRequest(),
+      projectCodes: [project.projectCode],
+    }
+    cy.task('stubGetAppointments', { request, pagedAppointments })
+    findAPersonPage.clickBack()
+
+    const projectPage = Page.verifyOnPage(ProjectPage, project)
+
+    const provider = providerSummaryFactory.build({ code: providerCode })
+    const team = providerTeamSummaryFactory.build({ code: teamCode })
+    cy.task('stubGetProviders', { providers: { providers: [provider] } })
+    cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: provider.code })
+    const projects = pagedModelProjectOutcomeSummaryFactory.build()
+    cy.task('stubGetProjects', {
+      teamCode: team.code,
+      providerCode: provider.code,
+      projects,
+    })
+
+    // When I click back to the individual placement search page
+    projectPage.clickBack()
+
+    // Then I should see the individual placement search page with original search
+    const searchPage = Page.verifyOnPage(FindIndividualPlacementPage, projects.content)
+    searchPage.shouldShowIndividualPlacements()
   })
 })

--- a/server/controllers/appointments/appointmentsController.test.ts
+++ b/server/controllers/appointments/appointmentsController.test.ts
@@ -63,5 +63,27 @@ describe('AppointmentsController', () => {
         }),
       )
     })
+
+    it('should reuse the existing form id and redirect without creating a new form when form is present in query', async () => {
+      const project = projectFactory.build({ projectCode })
+
+      projectService.getProject.mockResolvedValue(project)
+
+      const requestWithForm = createMock<Request>({
+        params: { crn, deliusEventNumber, projectCode, date },
+        query: { form: formId },
+      })
+
+      const requestHandler = controller.create()
+      await requestHandler(requestWithForm, response, next)
+
+      expect(formService.createNewAppointmentForm).not.toHaveBeenCalled()
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
+          form: formId,
+        }),
+      )
+    })
   })
 })

--- a/server/controllers/appointments/appointmentsController.ts
+++ b/server/controllers/appointments/appointmentsController.ts
@@ -18,18 +18,24 @@ export default class AppointmentsController {
 
       const project = await this.projectService.getProject({ username, projectCode })
 
-      const { key } = await this.formService.createNewAppointmentForm(
-        username,
-        req.query as Record<string, string>,
-        crn,
-        deliusEventNumber,
-        project,
-        date,
-      )
+      const form = req.query?.form?.toString()
+
+      const id =
+        form ||
+        (
+          await this.formService.createNewAppointmentForm(
+            username,
+            req.query as Record<string, string>,
+            crn,
+            deliusEventNumber,
+            project,
+            date,
+          )
+        ).key.id
 
       res.redirect(
         pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
-          form: key.id,
+          form: id,
         }),
       )
     }

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -35,7 +35,7 @@ export const controllers = (services: Services) => {
   )
   const dataController = new DataController(services.providerService)
   const staticController = new StaticController()
-  const personSearchController = new PersonSearchController(services.auditService)
+  const personSearchController = new PersonSearchController(services.auditService, services.appointmentFormService)
   const requirementController = new RequirementController(services.appointmentFormService, services.offenderService)
 
   return {

--- a/server/controllers/personSearchController.test.ts
+++ b/server/controllers/personSearchController.test.ts
@@ -3,6 +3,9 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import AuditService, { Page } from '../services/auditService'
 import PersonSearchController from './personSearchController'
 import probationSearchResultFactory from '../testutils/factories/probationSearchResultFactory'
+import AppointmentFormService from '../services/forms/appointmentFormService'
+import createAppointmentFormFactory from '../testutils/factories/createAppointmentFormFactory'
+import { pathWithQuery } from '../utils/utils'
 
 describe('PersonSearchController', () => {
   const username = 'username'
@@ -12,6 +15,7 @@ describe('PersonSearchController', () => {
   let personSearchController: PersonSearchController
 
   const auditService = createMock<AuditService>()
+  const appointmentFormService = createMock<AppointmentFormService>()
 
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
   const request: DeepMocked<Request> = createMock<Request>({
@@ -20,6 +24,7 @@ describe('PersonSearchController', () => {
       projectCode,
       date,
     },
+    query: {},
   })
 
   const response: DeepMocked<Response> = createMock<Response>({
@@ -38,7 +43,7 @@ describe('PersonSearchController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    personSearchController = new PersonSearchController(auditService)
+    personSearchController = new PersonSearchController(auditService, appointmentFormService)
   })
 
   describe('show', () => {
@@ -78,6 +83,73 @@ describe('PersonSearchController', () => {
       expect(responseWithResults.render).toHaveBeenCalledWith('pages/findAPerson', {
         backLink: '/',
         resultPath: '/some-path',
+      })
+    })
+
+    describe('when a formId exists in the query', () => {
+      it('uses the form originalSearch as the query for backLink and resultPath', async () => {
+        const formId = 'form-1'
+        const requestWithForm: DeepMocked<Request> = createMock<Request>({
+          id: '1',
+          params: { projectCode, date },
+          query: { form: formId },
+        })
+        const form = createAppointmentFormFactory.build({ originalSearch: { provider: 'provider-1', team: 'team-1' } })
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+          backPath: '/',
+          resultPath: '/some-path',
+        })
+        await requestHandler(requestWithForm, response, next)
+
+        expect(appointmentFormService.getForm).toHaveBeenCalledWith(formId, username)
+        expect(response.render).toHaveBeenCalledWith('pages/findAPerson', {
+          backLink: pathWithQuery('/', form.originalSearch),
+          resultPath: pathWithQuery('/some-path', { form: formId }),
+        })
+      })
+
+      it('never appends the formId to backLink', async () => {
+        const formId = 'form-1'
+        const requestWithForm: DeepMocked<Request> = createMock<Request>({
+          id: '1',
+          params: { projectCode, date },
+          query: { form: formId },
+        })
+        const form = createAppointmentFormFactory.build({ originalSearch: { provider: 'provider-1', team: 'team-1' } })
+        appointmentFormService.getForm.mockResolvedValue(form)
+
+        const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+          backPath: '/',
+          resultPath: '/some-path',
+        })
+        await requestHandler(requestWithForm, response, next)
+
+        const renderData = response.render.mock.calls[0][1] as unknown as Record<string, string>
+        expect(renderData.backLink).not.toContain('form=')
+      })
+    })
+
+    describe('when other query properties exist and no formId is present', () => {
+      it('appends them to backLink and resultPath', async () => {
+        const requestWithQuery: DeepMocked<Request> = createMock<Request>({
+          id: '1',
+          params: { projectCode, date },
+          query: { page: '2', sortBy: 'lastName' },
+        })
+
+        const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+          backPath: '/',
+          resultPath: '/some-path',
+        })
+        await requestHandler(requestWithQuery, response, next)
+
+        expect(appointmentFormService.getForm).not.toHaveBeenCalled()
+        expect(response.render).toHaveBeenCalledWith('pages/findAPerson', {
+          backLink: pathWithQuery('/', { page: '2', sortBy: 'lastName' }),
+          resultPath: pathWithQuery('/some-path', { page: '2', sortBy: 'lastName' }),
+        })
       })
     })
   })

--- a/server/controllers/personSearchController.test.ts
+++ b/server/controllers/personSearchController.test.ts
@@ -43,10 +43,13 @@ describe('PersonSearchController', () => {
 
   describe('show', () => {
     it('renders the find a person page', async () => {
-      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, { backPath: '/' })
+      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+        backPath: '/',
+        resultPath: '/some-path',
+      })
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { backLink: '/' })
+      expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { backLink: '/', resultPath: '/some-path' })
     })
 
     it('renders the find a person page and sends an audit message for each result', async () => {
@@ -65,22 +68,17 @@ describe('PersonSearchController', () => {
         render: jest.fn(),
       })
 
-      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, { backPath: '/' })
+      const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
+        backPath: '/',
+        resultPath: '/some-path',
+      })
       await requestHandler(request, responseWithResults, next)
 
       expect(auditService.sendAuditMessage).toHaveBeenCalledTimes(3)
-      expect(responseWithResults.render).toHaveBeenCalledWith('pages/findAPerson', { backLink: '/' })
+      expect(responseWithResults.render).toHaveBeenCalledWith('pages/findAPerson', {
+        backLink: '/',
+        resultPath: '/some-path',
+      })
     })
-  })
-
-  it('renders the find a person page with result path if provided', async () => {
-    const resultPath = '/some-path'
-    const requestHandler = personSearchController.show(Page.SEARCH_SESSIONS_FIND_A_PERSON, {
-      resultPath,
-      backPath: '/',
-    })
-    await requestHandler(request, response, next)
-
-    expect(response.render).toHaveBeenCalledWith('pages/findAPerson', { resultPath, backLink: '/' })
   })
 })

--- a/server/controllers/personSearchController.ts
+++ b/server/controllers/personSearchController.ts
@@ -4,7 +4,7 @@ import AuditService from '../services/auditService'
 export default class PersonSearchController {
   constructor(private readonly auditService: AuditService) {}
 
-  show(auditPageAction: string, { resultPath, backPath }: { resultPath?: string; backPath: string }): RequestHandler {
+  show(auditPageAction: string, { resultPath, backPath }: { resultPath: string; backPath: string }): RequestHandler {
     return async (req: Request, res: Response) => {
       if (res.locals.searchResults.response) {
         const people = res.locals.searchResults.response.content

--- a/server/controllers/personSearchController.ts
+++ b/server/controllers/personSearchController.ts
@@ -1,8 +1,13 @@
 import type { Request, RequestHandler, Response } from 'express'
 import AuditService from '../services/auditService'
+import AppointmentFormService, { CreateAppointmentForm } from '../services/forms/appointmentFormService'
+import { pathWithQuery } from '../utils/utils'
 
 export default class PersonSearchController {
-  constructor(private readonly auditService: AuditService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly formService: AppointmentFormService,
+  ) {}
 
   show(auditPageAction: string, { resultPath, backPath }: { resultPath: string; backPath: string }): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -21,7 +26,19 @@ export default class PersonSearchController {
         })
       }
 
-      return res.render('pages/findAPerson', { resultPath, backLink: backPath })
+      const form = req.query?.form?.toString()
+      let originalSearch = req.query as Record<string, string>
+
+      if (form) {
+        const formData = (await this.formService.getForm(form, res.locals.user.username)) as CreateAppointmentForm
+        originalSearch = formData.originalSearch
+      }
+      const paths = {
+        resultPath: pathWithQuery(resultPath, req.query as Record<string, string>),
+        backLink: pathWithQuery(backPath, originalSearch),
+      }
+
+      return res.render('pages/findAPerson', paths)
     }
   }
 }

--- a/server/controllers/requirementController.test.ts
+++ b/server/controllers/requirementController.test.ts
@@ -58,7 +58,7 @@ describe('RequirementController', () => {
   })
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
     requirementController = new RequirementController(formService, offenderService)
 
     ;(Offender as jest.Mock).mockImplementation(() => person)
@@ -147,6 +147,92 @@ describe('RequirementController', () => {
 
         expect(UnpaidWorkUtils.getUnpaidWorkOptions).toHaveBeenCalledWith(caseDetailsSummary.unpaidWorkDetails, 1)
       })
+
+      it('includes query properties in updatePath and backLink', async () => {
+        request = createMock<Request>({
+          params: {
+            crn: 'X123456',
+            projectCode,
+            date,
+          },
+          query: { form: formId, page: '2' },
+          body: {},
+        })
+
+        const unpaidWorkDetails = unpaidWorkDetailsFactory.build()
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const form = createAppointmentFormFactory.build({ deliusEventNumber: '1' })
+        formService.getForm.mockResolvedValue(form)
+
+        const requestHandler = requirementController.show({ updatePath, backPath })
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'pages/requirement',
+          expect.objectContaining({
+            updatePath: pathWithQuery(updatePath, { form: formId, page: '2' }),
+            backLink: pathWithQuery(backPath, { form: formId, page: '2' }),
+          }),
+        )
+      })
+    })
+
+    describe('when other query properties exist and no form is present', () => {
+      it('appends them to updatePath and backLink', async () => {
+        request = createMock<Request>({
+          params: {
+            crn: 'X123456',
+            projectCode,
+            date,
+          },
+          query: { page: '2' },
+          body: {},
+        })
+
+        const unpaidWorkDetails = unpaidWorkDetailsFactory.build()
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const requestHandler = requirementController.show({ updatePath, backPath })
+        await requestHandler(request, response, next)
+
+        expect(formService.getForm).not.toHaveBeenCalled()
+        expect(response.render).toHaveBeenCalledWith(
+          'pages/requirement',
+          expect.objectContaining({
+            updatePath: pathWithQuery(updatePath, { page: '2' }),
+            backLink: pathWithQuery(backPath, { page: '2' }),
+          }),
+        )
+      })
+    })
+
+    describe('when there are no unpaid work details', () => {
+      it('renders noRequirements with a backLink built from the raw query', async () => {
+        request = createMock<Request>({
+          params: {
+            crn: 'X123456',
+            projectCode,
+            date,
+          },
+          query: { form: formId, page: '2' },
+          body: {},
+        })
+
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const requestHandler = requirementController.show({ updatePath, backPath })
+        await requestHandler(request, response, next)
+
+        expect(formService.getForm).not.toHaveBeenCalled()
+        expect(response.render).toHaveBeenCalledWith('pages/noRequirements', {
+          person,
+          backLink: pathWithQuery(backPath, { form: formId, page: '2' }),
+        })
+      })
     })
   })
 
@@ -157,9 +243,9 @@ describe('RequirementController', () => {
           crn: 'X123456',
           projectCode,
           date,
-          form: undefined,
         },
         body: {},
+        query: {},
       })
 
       const errorSummary = [
@@ -193,6 +279,107 @@ describe('RequirementController', () => {
         errorSummary,
         errors,
         backLink: backPath,
+      })
+    })
+
+    describe('when validation errors exist and a form is present', () => {
+      it('includes the query in the backLink query', async () => {
+        request = createMock<Request>({
+          params: {
+            crn: 'X123456',
+            projectCode,
+            date,
+          },
+          body: {},
+          query: { form: formId, page: '2' },
+        })
+
+        const errorSummary = [
+          {
+            attributes: {
+              'data-cy-error-deliusEventNumber': 'Select a requirement',
+            },
+            href: '#deliusEventNumber',
+            text: 'Select a requirement',
+          },
+        ]
+        const errors = { deliusEventNumber: { text: 'Select a requirement' } }
+        page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+
+        const unpaidWorkDetails = unpaidWorkDetailsFactory.build()
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const unpaidWorkOptions = [
+          { text: 'Option 1', value: 1, details: [{ key: { text: 'foo' }, value: { text: 'bar' } }], checked: false },
+        ]
+        jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
+
+        const form = createAppointmentFormFactory.build({ deliusEventNumber: '1' })
+        formService.getForm.mockResolvedValue(form)
+
+        const requestHandler = requirementController.submit({
+          updatePath,
+          createAppointmentPath: path('/'),
+          backPath,
+        })
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith(
+          'pages/requirement',
+          expect.objectContaining({ backLink: pathWithQuery(backPath, { form: formId, page: '2' }) }),
+        )
+      })
+    })
+
+    describe('when validation errors exist and other query properties are present', () => {
+      it('appends them to the backLink', async () => {
+        request = createMock<Request>({
+          params: {
+            crn: 'X123456',
+            projectCode,
+            date,
+          },
+          body: {},
+          query: { page: '2' },
+        })
+
+        const errorSummary = [
+          {
+            attributes: {
+              'data-cy-error-deliusEventNumber': 'Select a requirement',
+            },
+            href: '#deliusEventNumber',
+            text: 'Select a requirement',
+          },
+        ]
+        const errors = { deliusEventNumber: { text: 'Select a requirement' } }
+        page.validationErrors.mockReturnValue({ hasErrors: true, errors, errorSummary })
+
+        const unpaidWorkDetails = unpaidWorkDetailsFactory.build()
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const unpaidWorkOptions = [
+          { text: 'Option 1', value: 1, details: [{ key: { text: 'foo' }, value: { text: 'bar' } }], checked: false },
+        ]
+        jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
+
+        const requestHandler = requirementController.submit({
+          updatePath,
+          createAppointmentPath: path('/'),
+          backPath,
+        })
+        await requestHandler(request, response, next)
+
+        expect(formService.getForm).not.toHaveBeenCalled()
+        expect(response.render).toHaveBeenCalledWith(
+          'pages/requirement',
+          expect.objectContaining({
+            backLink: pathWithQuery(backPath, { page: '2' }),
+            updatePath: pathWithQuery(updatePath, { page: '2' }),
+          }),
+        )
       })
     })
 
@@ -254,6 +441,33 @@ describe('RequirementController', () => {
 
         expect(response.redirect).toHaveBeenCalledWith(
           paths.sessions.create.createAppointment({ projectCode, crn, date, deliusEventNumber: '1' }),
+        )
+      })
+
+      it('appends other query properties to the create appointment redirect', async () => {
+        const createAppointmentPath = paths.sessions.create.createAppointment
+        request = createMock<Request>({
+          params: {
+            crn,
+            projectCode,
+            date,
+            form: undefined,
+          },
+          query: { page: '2' },
+          body: { deliusEventNumber: '1' },
+        })
+
+        const unpaidWorkDetails = unpaidWorkDetailsFactory.build()
+        const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const requestHandler = requirementController.submit({ updatePath: '/', createAppointmentPath, backPath: '/' })
+        await requestHandler(request, response, next)
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          pathWithQuery(paths.sessions.create.createAppointment({ projectCode, crn, date, deliusEventNumber: '1' }), {
+            page: '2',
+          }),
         )
       })
     })

--- a/server/controllers/requirementController.ts
+++ b/server/controllers/requirementController.ts
@@ -31,7 +31,7 @@ export default class RequirementController {
       if (unpaidWorkDetails.length === 0) {
         return res.render('pages/noRequirements', {
           person,
-          backLink: backPath,
+          backLink: pathWithQuery(backPath, req.query as Record<string, string>),
         })
       }
 
@@ -45,8 +45,8 @@ export default class RequirementController {
       return res.render('pages/requirement', {
         person,
         unpaidWorkOptions,
-        updatePath,
-        backLink: backPath,
+        updatePath: pathWithQuery(updatePath, req.query as Record<string, string>),
+        backLink: pathWithQuery(backPath, req.query as Record<string, string>),
       })
     }
   }
@@ -88,10 +88,10 @@ export default class RequirementController {
         return res.render('pages/requirement', {
           person,
           unpaidWorkOptions,
-          updatePath,
           errorSummary,
           errors,
-          backLink: backPath,
+          updatePath: pathWithQuery(updatePath, req.query as Record<string, string>),
+          backLink: pathWithQuery(backPath, req.query as Record<string, string>),
         })
       }
 
@@ -116,7 +116,7 @@ export default class RequirementController {
         deliusEventNumber: req.body.deliusEventNumber,
       } as unknown as Params<CreateAppointmentPathPattern>
 
-      return res.redirect(createAppointmentPath(params))
+      return res.redirect(pathWithQuery(createAppointmentPath(params), req.query as Record<string, string>))
     }
   }
 }

--- a/server/testutils/factories/createAppointmentFormFactory.ts
+++ b/server/testutils/factories/createAppointmentFormFactory.ts
@@ -16,6 +16,7 @@ export default Factory.define<CreateAppointmentForm>(
       originalSearch: {
         provider: faker.string.alpha(8),
         team: faker.string.alpha(8),
+        date: '01/01/2025',
       },
       supervisor: supervisorSummaryFactory.build(),
       projectTeam: providerTeamSummaryFactory.build(),


### PR DESCRIPTION
## Context

This PR improves navigation and state persistence in the create appointment journey by carrying query parameters (including existing form IDs and original search filters) through person search, requirement selection, and redirects.

[CPB-1175](https://dsdmoj.atlassian.net/browse/CPB-1175)

## Changes in this PR

This was quite fiddly to test the different scenarios, as we now have quite a few pages before creating a form object where we persist search. I added quite a few integration tests, but probably still don't have full coverage!

We might want to consider rewriting this to use localStorage or sessionStorage in the same way as the `FindAPerson` component, which should simplify our navigation significantly and separate concerns slightly. It will also mean any future paths or navigation should be handled without extra work.

For now though, I kept implementation inline with what we have, as I think it will be a big rewrite.

### Screenshots of UI changes


https://github.com/user-attachments/assets/3318e78e-46b3-4a1a-925f-f16b73a5eb95


https://github.com/user-attachments/assets/1368e5e2-4f15-42f7-9a8f-21d79bc227e1



## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1175]: https://dsdmoj.atlassian.net/browse/CPB-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ