### PR TITLE
Fix jest mock resets

### DIFF
--- a/server/controllers/dataController.test.ts
+++ b/server/controllers/dataController.test.ts
@@ -16,6 +16,7 @@ describe('DataController', () => {
   let dataController: DataController
 
   beforeEach(() => {
+    jest.resetAllMocks()
     dataController = new DataController(providerService)
   })
 

--- a/server/pages/courseCompletionIndexPage.test.ts
+++ b/server/pages/courseCompletionIndexPage.test.ts
@@ -76,6 +76,7 @@ describe('CourseCompletionIndexPage', () => {
     const mockStatus = '<strong>Fail</strong>'
 
     beforeEach(() => {
+      jest.resetAllMocks()
       jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue(fakeFormattedDate)
       jest.spyOn(HtmlUtils, 'getAnchor').mockReturnValue(fakeLink)
       jest.spyOn(HtmlUtils, 'getHiddenText').mockReturnValue(mockHiddenText)

--- a/server/pages/courseCompletions/process/appointmentPage.test.ts
+++ b/server/pages/courseCompletions/process/appointmentPage.test.ts
@@ -14,6 +14,7 @@ describe('AppointmentPage', () => {
   const backPath = pathMap[pageName].back
   let page: AppointmentPage
   beforeEach(() => {
+    jest.resetAllMocks()
     page = new AppointmentPage()
   })
 

--- a/server/pages/courseCompletions/process/personPage.test.ts
+++ b/server/pages/courseCompletions/process/personPage.test.ts
@@ -12,6 +12,7 @@ describe('PersonPage', () => {
   const backPath = pathMap[pageName].back
   let page: PersonPage
   beforeEach(() => {
+    jest.resetAllMocks()
     page = new PersonPage()
   })
 

--- a/server/pages/courseCompletions/process/requirementPage.test.ts
+++ b/server/pages/courseCompletions/process/requirementPage.test.ts
@@ -12,6 +12,7 @@ describe('RequirementPage', () => {
   const backPath = pathMap[pageName].back
   let page: RequirementPage
   beforeEach(() => {
+    jest.resetAllMocks()
     page = new RequirementPage()
   })
 

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -16,6 +16,7 @@ describe('AppointmentService', () => {
   let appointmentService: AppointmentService
 
   beforeEach(() => {
+    jest.resetAllMocks()
     appointmentService = new AppointmentService(appointmentClient)
   })
 

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -8,6 +8,7 @@ describe('Audit service', () => {
   let auditService: AuditService
 
   beforeEach(() => {
+    jest.resetAllMocks()
     auditClient = new AuditClient(null) as jest.Mocked<AuditClient>
     auditService = new AuditService(auditClient)
   })

--- a/server/services/providerService.test.ts
+++ b/server/services/providerService.test.ts
@@ -10,6 +10,7 @@ describe('ProviderService', () => {
   let providerService: ProviderService
 
   beforeEach(() => {
+    jest.resetAllMocks()
     providerService = new ProviderService(providerClient)
   })
 


### PR DESCRIPTION
Audited all unit test files for `jest.mock()`/`jest.spyOn()` usage without a mock reset between test cases. 8 files were missing `resetAllMocks`, allowing mock return values/implementations set in one test to leak into subsequent tests.