### PR TITLE
Add seed data for inductions

### DIFF
--- a/seed_data/seed_data_group.yml
+++ b/seed_data/seed_data_group.yml
@@ -15,6 +15,24 @@ seed_data:
           count: 10
           percentage_with_pickup_specified: 1
           percentage_that_are_rescheduled: 0
+      - projectName: Probationer Induction
+        projectType: PSAI / PPWS
+        pickupPoint: Chelmsford
+        startTime: 10:00
+        endTime: 12:00
+        allocations:
+          count: 10
+          percentage_with_pickup_specified: 1
+          percentage_that_are_rescheduled: 0
+      - projectName: Unpaid Work Placement Induction
+        projectType: UPW PoP Induction
+        pickupPoint: Chelmsford
+        startTime: 09:00
+        endTime: 10:00
+        allocations:
+          count: 10
+          percentage_with_pickup_specified: 1
+          percentage_that_are_rescheduled: 0
     course_completions:
       - Community Campus Test
       - ETE Automated Test Bucket


### PR DESCRIPTION
Add new project types to the seed data file
This will allow us to test the inductions search page with some data

## Context

As part of the changes on [CPB-1172](https://dsdmoj.atlassian.net/browse/CPB-1172) - where we're adding an inductions tab - we'll need some seed data to test with.

## Changes in this PR

Add that data to the yaml file so that we can generate data to test the tabs with

### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1172]: https://dsdmoj.atlassian.net/browse/CPB-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ