### PR TITLE
CPB-1178: Add ability to view requirement and person on confirm details page

### DIFF
--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -75,6 +75,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     this.formDetails.shouldNotContainValueWithLabel('Compliance')
   }
 
+  shouldNotShowRequirement(): void {
+    this.formDetails.shouldNotContainRowWithLabel('Requirement')
+  }
+
   shouldShowFormTitle() {
     cy.get('h2').first().should('have.text', 'Confirm details')
   }

--- a/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
@@ -116,6 +116,8 @@ context('Create appointment - Attendance outcome', () => {
     page.completeForm(notAttendedOutcome.code)
 
     // When I submit the form
+    cy.task('stubFindProject', { project: this.project })
+
     page.clickSubmit()
 
     // Then I see the confirm details page

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -7,6 +7,10 @@
 //    Given I am on the confirm page for a new appointment
 //    Then I can see all completed answers
 
+// Scenario: does not show a requirement item when the person has one requirement
+//    Given I am on the confirm page for a new appointment for a person with one requirement
+//    Then I do not see a requirement item
+
 // Scenario: navigating back from confirm - attended
 //    Given I am on the confirm page for a new appointment with an attended outcome
 //    When I click back
@@ -27,6 +31,11 @@
 //    Then I see the date displayed correctly
 //    When I click the date change link
 //    Then I see the date page with the entered date
+
+// Scenario: navigating back to the requirement page via the requirement change link
+//    Given I am on the confirm page for a new appointment for a person with multiple requirements
+//    When I click the requirement change link
+//    Then I see the requirement page
 
 // Scenario: submitting a new appointment - attended
 //    Given I am on the confirm page for a new appointment
@@ -63,6 +72,8 @@ import offenderFullFactory from '../../../../server/testutils/factories/offender
 import projectFactory from '../../../../server/testutils/factories/projectFactory'
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import sessionFactory from '../../../../server/testutils/factories/sessionFactory'
+import unpaidWorkDetailsFactory from '../../../../server/testutils/factories/unpaidWorkDetailsFactory'
+import Offender from '../../../../server/models/offender'
 import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
 import ChooseProjectPage from '../../../pages/appointments/chooseProjectPage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
@@ -71,6 +82,7 @@ import DatePage from '../../../pages/appointments/datePage'
 import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
 import Page from '../../../pages/page'
+import RequirementPage from '../../../pages/requirementPage'
 import ViewSessionPage from '../../../pages/viewSessionPage'
 
 context('Create appointment - Confirm details', () => {
@@ -81,6 +93,7 @@ context('Create appointment - Confirm details', () => {
 
     const project = projectFactory.build()
     cy.wrap(project).as('project')
+    cy.task('stubFindProject', { project })
 
     const offender = offenderFullFactory.build()
     cy.wrap(offender).as('offender')
@@ -131,6 +144,24 @@ context('Create appointment - Confirm details', () => {
       page.shouldShowCompletedDetails()
       page.shouldNotShowAttendanceDetails()
       page.shouldShowHoursCreditedText('0')
+    })
+
+    // Scenario: does not show a requirement item when the person has one requirement
+    it('does not show a requirement item when the person has one requirement', function test() {
+      const caseDetailsSummary = caseDetailsSummaryFactory.build({
+        offender: this.offender,
+        unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(1),
+      })
+      cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+      const form = createAppointmentFormFactory.build({ crn: this.offender.crn })
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the confirm page for a new appointment for a person with one requirement
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // Then I do not see a requirement item
+      page.shouldNotShowRequirement()
     })
   })
 
@@ -191,7 +222,6 @@ context('Create appointment - Confirm details', () => {
       })
       cy.task('stubGetAppointmentForm', form)
 
-      cy.task('stubFindProject', { project: this.project })
       cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: this.project.providerCode })
       cy.task('stubGetSupervisors', {
         teamCode: team.code,
@@ -216,7 +246,6 @@ context('Create appointment - Confirm details', () => {
       cy.task('stubGetAppointmentForm', form)
 
       const team = providerTeamSummaryFactory.build({ code: form.projectTeam.code })
-      cy.task('stubFindProject', { project: this.project })
       cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: this.project.providerCode })
 
       const projects = projectFactory.buildList(1, { projectCode: form.project.code })
@@ -242,7 +271,6 @@ context('Create appointment - Confirm details', () => {
       cy.task('stubGetAppointmentForm', form)
 
       const team = providerTeamSummaryFactory.build({ code: form.projectTeam.code })
-      cy.task('stubFindProject', { project: this.project })
       cy.task('stubGetTeams', { teams: { providers: [team] }, providerCode: this.project.providerCode })
 
       const projects = projectFactory.buildList(1, { projectCode: form.project.code })
@@ -345,7 +373,6 @@ context('Create appointment - Confirm details', () => {
 
     // Scenario: navigating back to the date page via the date change link
     it('navigates to the date page when editing date', function test() {
-      cy.task('stubFindProject', { project: this.project })
       const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date: '2025-09-18' })
       cy.task('stubGetAppointmentForm', form)
 
@@ -362,6 +389,27 @@ context('Create appointment - Confirm details', () => {
       const datePage = Page.verifyOnPage(DatePage, { offender: this.offender })
       datePage.shouldHaveValue('18/09/2025')
     })
+
+    it('navigates to the requirement page when editing requirement', function test() {
+      // Given the person has multiple requirements
+      const caseDetailsSummary = caseDetailsSummaryFactory.build({
+        offender: this.offender,
+        unpaidWorkDetails: unpaidWorkDetailsFactory.buildList(2),
+      })
+      cy.task('stubGetOffenderSummary', { caseDetailsSummary })
+
+      const form = createAppointmentFormFactory.build({ crn: this.offender.crn, date: '2025-09-18' })
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I click the requirement change link
+      page.clickChange('Requirement')
+
+      // Then I see the requirement page
+      Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+    })
   })
 
   describe('submitting the appointment', function describe() {
@@ -373,7 +421,6 @@ context('Create appointment - Confirm details', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
       cy.task('stubGetAppointmentForm', form)
-      cy.task('stubFindProject', { project: this.project })
       cy.task('stubCreateAppointment')
 
       const session = sessionFactory.build({
@@ -405,7 +452,6 @@ context('Create appointment - Confirm details', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: false }),
       })
       cy.task('stubGetAppointmentForm', form)
-      cy.task('stubFindProject', { project: this.project })
       cy.task('stubCreateAppointment')
 
       const session = sessionFactory.build({
@@ -438,7 +484,6 @@ context('Create appointment - Confirm details', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
       cy.task('stubGetAppointmentForm', form)
-      cy.task('stubFindProject', { project: this.project })
 
       // And the API returns a 400 error
       const userMessage = 'Invalid appointment data'
@@ -465,7 +510,6 @@ context('Create appointment - Confirm details', () => {
         contactOutcome: contactOutcomeFactory.build({ attended: true }),
       })
       cy.task('stubGetAppointmentForm', form)
-      cy.task('stubFindProject', { project: this.project })
 
       // Given I am on the confirm page for a new appointment
       const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -37,6 +37,11 @@
 //    When I click the requirement change link
 //    Then I see the requirement page
 
+// Scenario: navigating back to the find a person page via the person change link
+//    Given I am on the confirm page for a new appointment
+//    When I click the person change link
+//    Then I see the find a person page
+
 // Scenario: submitting a new appointment - attended
 //    Given I am on the confirm page for a new appointment
 //    When I click confirm
@@ -79,6 +84,7 @@ import ChooseProjectPage from '../../../pages/appointments/chooseProjectPage'
 import ChooseSupervisorPage from '../../../pages/appointments/chooseSupervisorPage'
 import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
 import DatePage from '../../../pages/appointments/datePage'
+import FindAPersonPage from '../../../pages/findAPersonPage'
 import LogCompliancePage from '../../../pages/appointments/logCompliancePage'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
 import Page from '../../../pages/page'
@@ -409,6 +415,20 @@ context('Create appointment - Confirm details', () => {
 
       // Then I see the requirement page
       Page.verifyOnPage(RequirementPage, new Offender(this.offender).name)
+    })
+
+    it('navigates to the find a person page when editing person', function test() {
+      const form = createAppointmentFormFactory.build({ crn: this.offender.crn })
+      cy.task('stubGetAppointmentForm', form)
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I click the person change link
+      page.clickChange('Person')
+
+      // Then I see the find a person page
+      Page.verifyOnPage(FindAPersonPage)
     })
   })
 

--- a/integration_tests/tests/appointments/create/logCompliance.cy.ts
+++ b/integration_tests/tests/appointments/create/logCompliance.cy.ts
@@ -80,6 +80,7 @@ context('Create appointment - Log compliance', () => {
     page.completeForm()
 
     // When I submit the form
+    cy.task('stubFindProject', { project: this.project })
     page.clickSubmit()
 
     // Then I see the confirm details page

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -44,11 +44,13 @@ describe('ConfirmController', () => {
     preventDoubleClick: true,
     someKey: 'some value',
   }
+  const submittedItems = [{ key: { text: 'Some item' }, value: { text: 'Some value' } }]
 
   let mockPageInstance: {
     validationErrors: jest.Mock
     commonViewData: jest.Mock
-    viewData: jest.Mock
+    alertQuestionDetails: jest.Mock
+    formItems: jest.Mock
     paths: jest.Mock
     offenderHeading: jest.Mock
     isAlertSelected: jest.Mock
@@ -73,7 +75,8 @@ describe('ConfirmController', () => {
         errorSummary: [],
       }),
       commonViewData: jest.fn().mockReturnValue(pageViewData),
-      viewData: jest.fn().mockReturnValue(pageViewData),
+      alertQuestionDetails: jest.fn().mockReturnValue(pageViewData),
+      formItems: jest.fn(),
       paths: jest.fn().mockReturnValue({}),
       offenderHeading: jest.fn().mockReturnValue({ title: 'Some Name', caption: 'X123456' }),
       isAlertSelected: jest.fn().mockReturnValue(true),
@@ -125,11 +128,13 @@ describe('ConfirmController', () => {
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
       const heading = { title: 'Some Name', caption: 'X123456' }
 
-      const viewDataSpy = jest.fn().mockReturnValue(pageViewData)
+      const alertQuestionDetailsSpy = jest.fn().mockReturnValue(pageViewData)
+      const formItemsSpy = jest.fn().mockReturnValue(submittedItems)
       const pathsSpy = jest.fn().mockReturnValue(navigationPaths)
       const offenderHeadingSpy = jest.fn().mockReturnValue(heading)
       mockPageInstance.paths.mockImplementation(pathsSpy)
-      mockPageInstance.viewData.mockImplementation(viewDataSpy)
+      mockPageInstance.alertQuestionDetails.mockImplementation(alertQuestionDetailsSpy)
+      mockPageInstance.formItems.mockImplementation(formItemsSpy)
       mockPageInstance.offenderHeading.mockImplementation(offenderHeadingSpy)
 
       const response = createMock<Response>({ locals: { user: { username: 'user-name' }, errorMessages: [] } })
@@ -144,10 +149,11 @@ describe('ConfirmController', () => {
         form,
         formId,
       })
-      expect(viewDataSpy).toHaveBeenCalledWith(
-        undefined,
-        { projectCode, appointmentId: 'create', date: form.date },
+      expect(alertQuestionDetailsSpy).toHaveBeenCalledWith(undefined, form)
+      expect(formItemsSpy).toHaveBeenCalledWith(
         form,
+        { projectCode, appointmentId: 'create', date: form.date },
+        undefined,
         formId,
         { includeDateItem: true },
       )
@@ -156,6 +162,7 @@ describe('ConfirmController', () => {
         heading,
         ...navigationPaths,
         ...pageViewData,
+        submittedItems,
         errorList: undefined,
         preventDoubleClick: true,
       })
@@ -167,7 +174,7 @@ describe('ConfirmController', () => {
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
 
       mockPageInstance.paths.mockReturnValue({})
-      mockPageInstance.viewData.mockReturnValue(pageViewData)
+      mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
       mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
 
       const response = createMock<Response>({
@@ -193,7 +200,7 @@ describe('ConfirmController', () => {
       const form = appointmentOutcomeFormFactory.build()
 
       mockPageInstance.commonViewData.mockReturnValue({})
-      mockPageInstance.viewData.mockReturnValue(pageViewData)
+      mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
       const appointment = appointmentFactory.build()
 
       const response = createMock<Response>()
@@ -216,7 +223,7 @@ describe('ConfirmController', () => {
       const appointment = appointmentFactory.build()
 
       mockPageInstance.commonViewData.mockReturnValue({})
-      mockPageInstance.viewData.mockReturnValue(pageViewData)
+      mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
 
       appointmentService.getAppointment.mockResolvedValue(appointment)
       appointmentFormService.getForm.mockResolvedValue(form)

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -51,6 +51,7 @@ describe('ConfirmController', () => {
     commonViewData: jest.Mock
     alertQuestionDetails: jest.Mock
     formItems: jest.Mock
+    createFormItems: jest.Mock
     paths: jest.Mock
     offenderHeading: jest.Mock
     isAlertSelected: jest.Mock
@@ -77,6 +78,7 @@ describe('ConfirmController', () => {
       commonViewData: jest.fn().mockReturnValue(pageViewData),
       alertQuestionDetails: jest.fn().mockReturnValue(pageViewData),
       formItems: jest.fn(),
+      createFormItems: jest.fn().mockReturnValue([]),
       paths: jest.fn().mockReturnValue({}),
       offenderHeading: jest.fn().mockReturnValue({ title: 'Some Name', caption: 'X123456' }),
       isAlertSelected: jest.fn().mockReturnValue(true),
@@ -126,30 +128,43 @@ describe('ConfirmController', () => {
       const form = appointmentOutcomeFormFactory.build({ date: '2026-01-01' })
       const navigationPaths = { backLink: '/back', updatePath: '/update' }
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
+      const project = projectFactory.build({ projectCode })
       const heading = { title: 'Some Name', caption: 'X123456' }
+      const unpaidWorkItems = [{ key: { text: 'Requirement' }, value: { html: 'some requirement summary' } }]
 
       const alertQuestionDetailsSpy = jest.fn().mockReturnValue(pageViewData)
       const formItemsSpy = jest.fn().mockReturnValue(submittedItems)
+      const createFormItemsSpy = jest.fn().mockReturnValue(unpaidWorkItems)
       const pathsSpy = jest.fn().mockReturnValue(navigationPaths)
       const offenderHeadingSpy = jest.fn().mockReturnValue(heading)
       mockPageInstance.paths.mockImplementation(pathsSpy)
       mockPageInstance.alertQuestionDetails.mockImplementation(alertQuestionDetailsSpy)
       mockPageInstance.formItems.mockImplementation(formItemsSpy)
+      mockPageInstance.createFormItems.mockImplementation(createFormItemsSpy)
       mockPageInstance.offenderHeading.mockImplementation(offenderHeadingSpy)
 
       const response = createMock<Response>({ locals: { user: { username: 'user-name' }, errorMessages: [] } })
       appointmentFormService.getForm.mockResolvedValue(form)
       offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+      projectService.getProject.mockResolvedValue(project)
 
       const requestHandler = confirmController.create()
       await requestHandler(request, response, next)
 
+      expect(projectService.getProject).toHaveBeenCalledWith({ username: 'user-name', projectCode })
       expect(pathsSpy).toHaveBeenCalledWith({
         pathData: { projectCode, appointmentId: 'create' },
         form,
         formId,
       })
       expect(alertQuestionDetailsSpy).toHaveBeenCalledWith(undefined, form)
+      expect(createFormItemsSpy).toHaveBeenCalledWith({
+        form,
+        pathData: { projectCode, appointmentId: 'create', date: form.date },
+        formId,
+        offenderSummary: caseDetailsSummary,
+        projectType: project.projectType.group,
+      })
       expect(formItemsSpy).toHaveBeenCalledWith(
         form,
         { projectCode, appointmentId: 'create', date: form.date },
@@ -162,7 +177,7 @@ describe('ConfirmController', () => {
         heading,
         ...navigationPaths,
         ...pageViewData,
-        submittedItems,
+        submittedItems: [...unpaidWorkItems, ...submittedItems],
         errorList: undefined,
         preventDoubleClick: true,
       })
@@ -172,16 +187,19 @@ describe('ConfirmController', () => {
       const errorMessages = ['Start time is required', 'End time is required']
       const form = appointmentOutcomeFormFactory.build({ date: '2026-01-01' })
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
+      const project = projectFactory.build({ projectCode })
 
       mockPageInstance.paths.mockReturnValue({})
       mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
       mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
+      mockPageInstance.formItems.mockReturnValue(submittedItems)
 
       const response = createMock<Response>({
         locals: { user: { username: 'user-name' }, errorMessages },
       })
       appointmentFormService.getForm.mockResolvedValue(form)
       offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+      projectService.getProject.mockResolvedValue(project)
 
       const requestHandler = confirmController.create()
       await requestHandler(request, response, next)
@@ -501,6 +519,70 @@ describe('ConfirmController', () => {
         error,
         '/update/path',
       )
+    })
+
+    describe('given validation errors', () => {
+      it('renders the page with submittedItems built from createFormItems and formItems', async () => {
+        const project = projectFactory.build({ projectCode })
+        const caseDetailsSummary = caseDetailsSummaryFactory.build()
+        const unpaidWorkItems = [{ key: { text: 'Requirement' }, value: { html: 'some requirement summary' } }]
+
+        const createFormItemsSpy = jest.fn().mockReturnValue(unpaidWorkItems)
+        const formItemsSpy = jest.fn().mockReturnValue(submittedItems)
+        mockPageInstance.createFormItems.mockImplementation(createFormItemsSpy)
+        mockPageInstance.formItems.mockImplementation(formItemsSpy)
+        mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
+        mockPageInstance.validationErrors.mockReturnValue({
+          hasErrors: true,
+          errors: { alertPractitioner: { text: 'error' } },
+          errorSummary: [{ text: 'error', href: '#alertPractitioner' }],
+        })
+
+        const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
+        const requestWithNewAppointment = createMock<Request>({
+          params: { projectCode },
+          query: { form: formId },
+          flash: jest.fn(),
+        })
+
+        const form = createAppointmentFormFactory.build({
+          project: { code: projectCode, name: 'Project name' },
+          date: '2026-06-09',
+          deliusEventNumber: '1001',
+          contactOutcome: contactOutcomeFactory.build({ attended: true }),
+        })
+
+        projectService.getProject.mockResolvedValue(project)
+        appointmentFormService.getForm.mockResolvedValue(form)
+        offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
+
+        const requestHandler = confirmController.submitCreate()
+        await requestHandler(requestWithNewAppointment, response, next)
+
+        expect(createFormItemsSpy).toHaveBeenCalledWith({
+          form,
+          pathData: { projectCode, appointmentId: 'create', date: form.date },
+          formId,
+          offenderSummary: caseDetailsSummary,
+          projectType: project.projectType.group,
+        })
+        expect(formItemsSpy).toHaveBeenCalledWith(
+          form,
+          { projectCode, appointmentId: 'create', date: form.date },
+          undefined,
+          formId,
+          { includeDateItem: true },
+        )
+        expect(response.render).toHaveBeenCalledWith('appointments/update/confirm', {
+          heading: { title: 'Some Name', caption: 'X123456' },
+          ...pageViewData,
+          submittedItems: [...unpaidWorkItems, ...submittedItems],
+          errorSummary: [{ text: 'error', href: '#alertPractitioner' }],
+          errors: { alertPractitioner: { text: 'error' } },
+          preventDoubleClick: true,
+        })
+        expect(appointmentService.createAppointment).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -36,13 +36,21 @@ export default class ConfirmController implements IAppointmentFormPageController
       const appointmentParams = { projectCode: req.params.projectCode.toString(), appointmentId: 'create' }
 
       const formId = req.query.form?.toString()
-      const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
+      const form = (await this.appointmentFormService.getForm(
+        formId,
+        res.locals.user.username,
+      )) as CreateAppointmentForm
       const page = new ConfirmPage()
 
       const navigationPaths = page.paths({
         pathData: appointmentParams,
         form,
         formId,
+      })
+
+      const { projectType } = await this.projectService.getProject({
+        username: res.locals.user.username,
+        projectCode: req.params.projectCode,
       })
 
       const offenderSummary = await this.offenderService.getOffenderSummary({
@@ -53,12 +61,22 @@ export default class ConfirmController implements IAppointmentFormPageController
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
       const pathData = { ...appointmentParams, date: form.date }
+      const submittedItems = [
+        ...page.createFormItems({
+          form,
+          pathData,
+          formId,
+          offenderSummary,
+          projectType: projectType.group,
+        }),
+        ...page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+      ]
 
       res.render('appointments/update/confirm', {
         heading: page.offenderHeading(offenderSummary.offender),
         ...navigationPaths,
         ...page.alertQuestionDetails(undefined, form),
-        submittedItems: page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+        submittedItems,
         errorList,
         preventDoubleClick,
       })
@@ -129,11 +147,21 @@ export default class ConfirmController implements IAppointmentFormPageController
       const pathData = { ...appointmentParams, date: form.date }
 
       if (hasErrors) {
+        const submittedItems = [
+          ...page.createFormItems({
+            form,
+            pathData,
+            formId,
+            offenderSummary,
+            projectType: project.projectType.group,
+          }),
+          ...page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+        ]
         return res.render('appointments/update/confirm', {
           heading: page.offenderHeading(offenderSummary.offender),
           ...navigationPaths,
           ...page.alertQuestionDetails(undefined, form),
-          submittedItems: page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+          submittedItems,
           errorSummary,
           errors,
           preventDoubleClick,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -57,7 +57,8 @@ export default class ConfirmController implements IAppointmentFormPageController
       res.render('appointments/update/confirm', {
         heading: page.offenderHeading(offenderSummary.offender),
         ...navigationPaths,
-        ...page.viewData(undefined, pathData, form, formId, { includeDateItem: true }),
+        ...page.alertQuestionDetails(undefined, form),
+        submittedItems: page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
         errorList,
         preventDoubleClick,
       })
@@ -83,7 +84,8 @@ export default class ConfirmController implements IAppointmentFormPageController
 
       res.render('appointments/update/confirm', {
         ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
-        ...page.viewData(appointmentOrSession, pathData, form, formId),
+        ...page.alertQuestionDetails(appointmentOrSession, form),
+        submittedItems: page.formItems(form, pathData, appointmentOrSession, formId),
         errorList,
         preventDoubleClick,
       })
@@ -130,7 +132,8 @@ export default class ConfirmController implements IAppointmentFormPageController
         return res.render('appointments/update/confirm', {
           heading: page.offenderHeading(offenderSummary.offender),
           ...navigationPaths,
-          ...page.viewData(undefined, pathData, form, formId, { includeDateItem: true }),
+          ...page.alertQuestionDetails(undefined, form),
+          submittedItems: page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
           errorSummary,
           errors,
           preventDoubleClick,
@@ -199,7 +202,8 @@ export default class ConfirmController implements IAppointmentFormPageController
       if (hasErrors) {
         return res.render('appointments/update/confirm', {
           ...page.commonViewData({ pathData, appointmentOrSession, form, formId }),
-          ...page.viewData(appointmentOrSession, pathData, form, formId),
+          ...page.alertQuestionDetails(appointmentOrSession, form),
+          submittedItems: page.formItems(form, pathData, appointmentOrSession, formId),
           errorSummary,
           errors,
           preventDoubleClick,

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -20,17 +20,15 @@ describe('ConfirmPage', () => {
     jest.resetAllMocks()
   })
 
-  describe('viewData', () => {
+  describe('alertQuestionDetails', () => {
     let page: ConfirmPage
     let appointment: AppointmentDto
     let form: AppointmentOutcomeForm
-    const pathWithQuery = '/path?'
 
     beforeEach(() => {
       page = new ConfirmPage()
       appointment = appointmentFactory.build({ sensitive: false })
       form = appointmentOutcomeFormFactory.build()
-      jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
     })
 
     describe('alertPractitionerItems', () => {
@@ -40,7 +38,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.alertQuestionDetails({ appointment }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -50,7 +48,7 @@ describe('ConfirmPage', () => {
         })
         const items = [{ text: 'Yes', value: 'yes' }]
         jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue(items)
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.alertQuestionDetails({ appointment }, form)
         expect(result.alertPractitionerItems).toEqual(items)
       })
 
@@ -64,7 +62,7 @@ describe('ConfirmPage', () => {
 
         const determineCheckedValueSpy = jest.spyOn(GovUkRadioGroup, 'determineCheckedValue')
 
-        const result = page.viewData({ session }, { projectCode: 'XY', date: '2026-01-02' }, formWithSession)
+        const result = page.alertQuestionDetails({ session }, formWithSession)
 
         expect(determineCheckedValueSpy).toHaveBeenCalledWith(undefined)
         expect(result.alertPractitionerItems).toEqual(items)
@@ -74,7 +72,7 @@ describe('ConfirmPage', () => {
         const yesNoItemsSpy = jest.spyOn(GovUkRadioGroup, 'yesNoItems').mockReturnValue([])
         jest.spyOn(GovUkRadioGroup, 'determineCheckedValue').mockReturnValue(undefined)
 
-        page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, form)
+        page.alertQuestionDetails(undefined, form)
 
         expect(yesNoItemsSpy).toHaveBeenCalledWith({ checkedValue: undefined })
       })
@@ -85,7 +83,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: true },
         })
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.alertQuestionDetails({ appointment }, form)
         expect(result.alertDiaryText).toContain('also')
       })
 
@@ -93,7 +91,7 @@ describe('ConfirmPage', () => {
         form = appointmentOutcomeFormFactory.build({
           contactOutcome: { code: 'some-code', willAlertEnforcementDiary: false },
         })
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
+        const result = page.alertQuestionDetails({ appointment }, form)
         expect(result.alertDiaryText).not.toContain('also')
       })
     })
@@ -102,325 +100,114 @@ describe('ConfirmPage', () => {
       form = appointmentOutcomeFormFactory.build({
         contactOutcome: { code: 'some-code', willAlertEnforcementDiary: value },
       })
-      const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, form)
+      const result = page.alertQuestionDetails({ appointment }, form)
       expect(result.showWillAlertPractitionerMessage).toEqual(value)
     })
+  })
 
-    describe('submittedItems', () => {
-      afterEach(() => {
-        jest.restoreAllMocks()
+  describe('formItems', () => {
+    let page: ConfirmPage
+    let appointment: AppointmentDto
+    const pathWithQuery = '/path?'
+
+    beforeEach(() => {
+      page = new ConfirmPage()
+      appointment = appointmentFactory.build({ sensitive: false })
+      jest.spyOn(Utils, 'pathWithQuery').mockReturnValue(pathWithQuery)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should return an object containing summary list items for non attended outcome', async () => {
+      const hours = '0'
+      jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
+      jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Not entered')
+
+      const notes = 'some notes'
+      const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+        notes,
+        isSensitive: undefined,
       })
-
-      it('should return an object containing summary list items for non attended outcome', async () => {
-        const hours = '0'
-        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
-        jest.spyOn(Utils, 'yesNoDisplayValue').mockReturnValue('Not entered')
-
-        const notes = 'some notes'
-        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-          notes,
-          isSensitive: undefined,
-        })
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
-        expect(result.submittedItems).toEqual([
-          {
-            key: {
-              text: 'Supervising officer',
-            },
-            value: {
-              text: submitted.supervisor.fullName,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'supervising officer',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Project team',
-            },
-            value: {
-              text: submitted.projectTeam.name,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'project team',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Project',
-            },
-            value: {
-              text: submitted.project.name,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'project',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Outcome',
-            },
-            value: {
-              html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'attendance outcome',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Notes',
-            },
-            value: {
-              text: notes,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'notes',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Sensitive',
-            },
-            value: {
-              text: 'Not entered',
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'sensitivity',
-                },
-              ],
-            },
-          },
-        ])
-      })
-
-      it('should display start and end time with logged hours for attendance outcomes', async () => {
-        const hours = '8 hours'
-        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
-
-        const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-        })
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
-        expect(result.submittedItems).toContainEqual(
-          expect.objectContaining({
-            key: {
-              text: 'Start and end time',
-            },
-            value: {
-              html: `<p>09:00 - 17:00</p><p>Hours credited: ${hours}</p>`,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'start and end time',
-                },
-              ],
-            },
-          }),
-        )
-      })
-
-      it('should contain "Outcome" item with contact outcome name when outcome is attended', () => {
-        const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-        })
-
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
-
-        expect(result.submittedItems).toContainEqual(
-          expect.objectContaining({
-            key: {
-              text: 'Outcome',
-            },
-            value: {
-              text: submitted.contactOutcome.name,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'attendance outcome',
-                },
-              ],
-            },
-          }),
-        )
-      })
-
-      it('should include a Date item when the includeDateItem option is true', () => {
-        jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue('20 January 2026')
-
-        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({ contactOutcome, date: '2026-01-20' })
-
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted, undefined, {
-          includeDateItem: true,
-        })
-
-        expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith('2026-01-20')
-        expect(result.submittedItems).toContainEqual({
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
+      expect(result).toEqual([
+        {
           key: {
-            text: 'Date',
+            text: 'Supervising officer',
           },
           value: {
-            text: '20 January 2026',
+            text: submitted.supervisor.fullName,
           },
           actions: {
             items: [
               {
                 href: pathWithQuery,
                 text: 'Change',
-                visuallyHiddenText: 'date',
+                visuallyHiddenText: 'supervising officer',
               },
             ],
           },
-        })
-      })
-
-      it('should not include a Date item when the includeDateItem option is not provided', () => {
-        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({ contactOutcome })
-
-        const result = page.viewData({ appointment }, { projectCode: 'XY', appointmentId: '1' }, submitted)
-
-        expect(result.submittedItems).not.toContainEqual(expect.objectContaining({ key: { text: 'Date' } }))
-      })
-
-      describe('compliance answers', () => {
-        describe('when workQuality is NOT_APPLICABLE', () => {
-          it('returns `Not applicable`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({
-              attendanceData: { workQuality: 'NOT_APPLICABLE' },
-            })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Work quality - Not applicable')
-          })
-        })
-
-        describe('when workQuality is GOOD', () => {
-          it('returns `Good`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({
-              attendanceData: { workQuality: 'GOOD' },
-            })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Work quality - Good')
-          })
-        })
-
-        describe('when behaviour is NOT_APPLICABLE', () => {
-          it('returns `Not applicable`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({
-              attendanceData: { behaviour: 'NOT_APPLICABLE' },
-            })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Behaviour - Not applicable')
-          })
-        })
-
-        describe('when behaviour is GOOD', () => {
-          it('returns `Good`', () => {
-            const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { behaviour: 'GOOD' } })
-
-            const result = page.getComplianceAnswers(formComplianceAnswers)
-            expect(result).toMatch('Behaviour - Good')
-          })
-        })
-      })
-
-      it('should contain compliance data if contact outcome is attended', () => {
-        const contactOutcome = contactOutcomeFactory.build({ attended: true })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-          attendanceData: { workQuality: 'GOOD', behaviour: 'NOT_APPLICABLE' },
-        })
-        const result = page.viewData(
-          { appointment },
-          { projectCode: 'XY', appointmentId: '1' },
-          submitted,
-        ).submittedItems
-
-        expect(result).toContainEqual({
+        },
+        {
           key: {
-            text: 'Compliance',
+            text: 'Project team',
           },
           value: {
-            html: 'Work quality - Good<br>Behaviour - Not applicable',
+            text: submitted.projectTeam.name,
           },
           actions: {
             items: [
               {
                 href: pathWithQuery,
                 text: 'Change',
-                visuallyHiddenText: 'compliance',
+                visuallyHiddenText: 'project team',
               },
             ],
           },
-        })
-      })
-
-      it('should contain notes if contact outcome is attended', () => {
-        const contactOutcome = contactOutcomeFactory.build({ attended: true })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-          notes: 'test',
-        })
-        const result = page.viewData(
-          { appointment },
-          { projectCode: 'XY', appointmentId: '1' },
-          submitted,
-        ).submittedItems
-
-        expect(result).toContainEqual({
+        },
+        {
+          key: {
+            text: 'Project',
+          },
+          value: {
+            text: submitted.project.name,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'project',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Outcome',
+          },
+          value: {
+            html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'attendance outcome',
+              },
+            ],
+          },
+        },
+        {
           key: {
             text: 'Notes',
           },
           value: {
-            text: 'test',
+            text: notes,
           },
           actions: {
             items: [
@@ -431,204 +218,417 @@ describe('ConfirmPage', () => {
               },
             ],
           },
-        })
+        },
+        {
+          key: {
+            text: 'Sensitive',
+          },
+          value: {
+            text: 'Not entered',
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'sensitivity',
+              },
+            ],
+          },
+        },
+      ])
+    })
+
+    it('should display start and end time with logged hours for attendance outcomes', async () => {
+      const hours = '8 hours'
+      jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
+
+      const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+      })
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          key: {
+            text: 'Start and end time',
+          },
+          value: {
+            html: `<p>09:00 - 17:00</p><p>Hours credited: ${hours}</p>`,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'start and end time',
+              },
+            ],
+          },
+        }),
+      )
+    })
+
+    it('should contain "Outcome" item with contact outcome name when outcome is attended', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
       })
 
-      it('should return submittedItems with session change links when appointmentOrSession is a session and outcome is not attended', () => {
-        const summaryOne = appointmentSummaryFactory.build({
-          offender: offenderFullFactory.build({ forename: 'Alex', surname: 'Smith', crn: 'CRN001' }),
-        })
-        const summaryTwo = appointmentSummaryFactory.build({
-          offender: offenderFullFactory.build({ forename: 'Sam', surname: 'Jones', crn: 'CRN002' }),
-        })
-        const session = sessionFactory.build({
-          appointmentSummaries: [summaryOne, summaryTwo],
-        })
-        const hours = '0'
-        jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
-        jest.spyOn(paths.sessions, 'update')
-        jest.spyOn(paths.appointments, 'update')
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
 
-        const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome,
-          notes: 'some notes',
-          isSensitive: undefined,
-          appointments: [
-            { id: summaryTwo.id, deliusVersion: 'v2' },
-            { id: summaryOne.id, deliusVersion: 'v1' },
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          key: {
+            text: 'Outcome',
+          },
+          value: {
+            text: submitted.contactOutcome.name,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'attendance outcome',
+              },
+            ],
+          },
+        }),
+      )
+    })
+
+    it('should include a Date item when the includeDateItem option is true', () => {
+      jest.spyOn(DateTimeFormats, 'isoDateToUIDate').mockReturnValue('20 January 2026')
+
+      const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({ contactOutcome, date: '2026-01-20' })
+
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment }, undefined, {
+        includeDateItem: true,
+      })
+
+      expect(DateTimeFormats.isoDateToUIDate).toHaveBeenCalledWith('2026-01-20')
+      expect(result).toContainEqual({
+        key: {
+          text: 'Date',
+        },
+        value: {
+          text: '20 January 2026',
+        },
+        actions: {
+          items: [
+            {
+              href: pathWithQuery,
+              text: 'Change',
+              visuallyHiddenText: 'date',
+            },
           ],
-        })
+        },
+      })
+    })
 
-        const pathData = { projectCode: 'XY', date: '2026-01-01' }
-        const result = page.viewData({ session }, pathData, submitted)
-        const expectedPeople = 'Sam Jones (CRN002) <br/>Alex Smith (CRN001)'
+    it('should not include a Date item when the includeDateItem option is not provided', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({ contactOutcome })
 
-        expect(result.submittedItems).toEqual([
-          {
-            key: {
-              text: 'People',
-            },
-            value: {
-              html: expectedPeople,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'people',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Supervising officer',
-            },
-            value: {
-              text: submitted.supervisor.fullName,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'supervising officer',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Project team',
-            },
-            value: {
-              text: submitted.projectTeam.name,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'project team',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Project',
-            },
-            value: {
-              text: submitted.project.name,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'project',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Outcome',
-            },
-            value: {
-              html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'attendance outcome',
-                },
-              ],
-            },
-          },
-          {
-            key: {
-              text: 'Notes',
-            },
-            value: {
-              text: 'some notes',
-            },
-            actions: {
-              items: [
-                {
-                  href: pathWithQuery,
-                  text: 'Change',
-                  visuallyHiddenText: 'notes',
-                },
-              ],
-            },
-          },
-        ])
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
 
-        expect(paths.sessions.update).toHaveBeenCalledWith({
-          ...pathData,
-          page: 'choose-supervisor',
+      expect(result).not.toContainEqual(expect.objectContaining({ key: { text: 'Date' } }))
+    })
+
+    describe('compliance answers', () => {
+      describe('when workQuality is NOT_APPLICABLE', () => {
+        it('returns `Not applicable`', () => {
+          const formComplianceAnswers = appointmentOutcomeFormFactory.build({
+            attendanceData: { workQuality: 'NOT_APPLICABLE' },
+          })
+
+          const result = page.getComplianceAnswers(formComplianceAnswers)
+          expect(result).toMatch('Work quality - Not applicable')
         })
-        expect(paths.sessions.update).toHaveBeenCalledWith({
-          ...pathData,
-          page: 'attendance-outcome',
-        })
-        expect(paths.appointments.update).not.toHaveBeenCalled()
       })
 
-      it('should return empty people html when no appointment ids match session summaries', () => {
-        const session = sessionFactory.build()
+      describe('when workQuality is GOOD', () => {
+        it('returns `Good`', () => {
+          const formComplianceAnswers = appointmentOutcomeFormFactory.build({
+            attendanceData: { workQuality: 'GOOD' },
+          })
 
-        const submitted = appointmentOutcomeFormFactory.build({
-          contactOutcome: contactOutcomeFactory.build({ attended: false, enforceable: false }),
-          appointments: [
-            { id: 999001, deliusVersion: 'v1' },
-            { id: 999002, deliusVersion: 'v2' },
+          const result = page.getComplianceAnswers(formComplianceAnswers)
+          expect(result).toMatch('Work quality - Good')
+        })
+      })
+
+      describe('when behaviour is NOT_APPLICABLE', () => {
+        it('returns `Not applicable`', () => {
+          const formComplianceAnswers = appointmentOutcomeFormFactory.build({
+            attendanceData: { behaviour: 'NOT_APPLICABLE' },
+          })
+
+          const result = page.getComplianceAnswers(formComplianceAnswers)
+          expect(result).toMatch('Behaviour - Not applicable')
+        })
+      })
+
+      describe('when behaviour is GOOD', () => {
+        it('returns `Good`', () => {
+          const formComplianceAnswers = appointmentOutcomeFormFactory.build({ attendanceData: { behaviour: 'GOOD' } })
+
+          const result = page.getComplianceAnswers(formComplianceAnswers)
+          expect(result).toMatch('Behaviour - Good')
+        })
+      })
+    })
+
+    it('should contain compliance data if contact outcome is attended', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: true })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+        attendanceData: { workQuality: 'GOOD', behaviour: 'NOT_APPLICABLE' },
+      })
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
+
+      expect(result).toContainEqual({
+        key: {
+          text: 'Compliance',
+        },
+        value: {
+          html: 'Work quality - Good<br>Behaviour - Not applicable',
+        },
+        actions: {
+          items: [
+            {
+              href: pathWithQuery,
+              text: 'Change',
+              visuallyHiddenText: 'compliance',
+            },
           ],
-        })
+        },
+      })
+    })
 
-        const result = page.viewData({ session }, { projectCode: '', date: '' }, submitted)
+    it('should contain notes if contact outcome is attended', () => {
+      const contactOutcome = contactOutcomeFactory.build({ attended: true })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+        notes: 'test',
+      })
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, { appointment })
 
-        expect(result.submittedItems).toContainEqual(
-          expect.objectContaining({
-            key: { text: 'People' },
-            value: { html: '' },
-          }),
-        )
+      expect(result).toContainEqual({
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          text: 'test',
+        },
+        actions: {
+          items: [
+            {
+              href: pathWithQuery,
+              text: 'Change',
+              visuallyHiddenText: 'notes',
+            },
+          ],
+        },
+      })
+    })
+
+    it('should return submittedItems with session change links when appointmentOrSession is a session and outcome is not attended', () => {
+      const summaryOne = appointmentSummaryFactory.build({
+        offender: offenderFullFactory.build({ forename: 'Alex', surname: 'Smith', crn: 'CRN001' }),
+      })
+      const summaryTwo = appointmentSummaryFactory.build({
+        offender: offenderFullFactory.build({ forename: 'Sam', surname: 'Jones', crn: 'CRN002' }),
+      })
+      const session = sessionFactory.build({
+        appointmentSummaries: [summaryOne, summaryTwo],
+      })
+      const hours = '0'
+      jest.spyOn(DateTimeFormats, 'timeBetween').mockReturnValue(hours)
+      jest.spyOn(paths.sessions, 'update')
+      jest.spyOn(paths.appointments, 'update')
+
+      const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome,
+        notes: 'some notes',
+        isSensitive: undefined,
+        appointments: [
+          { id: summaryTwo.id, deliusVersion: 'v2' },
+          { id: summaryOne.id, deliusVersion: 'v1' },
+        ],
       })
 
-      it('should not include offender item when appointment or session is undefined', () => {
-        const submitted = appointmentOutcomeFormFactory.build()
+      const pathData = { projectCode: 'XY', date: '2026-01-01' }
+      const result = page.formItems(submitted, pathData, { session })
+      const expectedPeople = 'Sam Jones (CRN002) <br/>Alex Smith (CRN001)'
 
-        const result = page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, submitted)
+      expect(result).toEqual([
+        {
+          key: {
+            text: 'People',
+          },
+          value: {
+            html: expectedPeople,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'people',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Supervising officer',
+          },
+          value: {
+            text: submitted.supervisor.fullName,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'supervising officer',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Project team',
+          },
+          value: {
+            text: submitted.projectTeam.name,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'project team',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Project',
+          },
+          value: {
+            text: submitted.project.name,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'project',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Outcome',
+          },
+          value: {
+            html: `<p>${submitted.contactOutcome.name}</p><p>Hours credited: 0</p>`,
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'attendance outcome',
+              },
+            ],
+          },
+        },
+        {
+          key: {
+            text: 'Notes',
+          },
+          value: {
+            text: 'some notes',
+          },
+          actions: {
+            items: [
+              {
+                href: pathWithQuery,
+                text: 'Change',
+                visuallyHiddenText: 'notes',
+              },
+            ],
+          },
+        },
+      ])
 
-        const peopleItem = result.submittedItems.find(item => item.key.text === 'People')
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        ...pathData,
+        page: 'choose-supervisor',
+      })
+      expect(paths.sessions.update).toHaveBeenCalledWith({
+        ...pathData,
+        page: 'attendance-outcome',
+      })
+      expect(paths.appointments.update).not.toHaveBeenCalled()
+    })
 
-        expect(peopleItem).toBeUndefined()
+    it('should return empty people html when no appointment ids match session summaries', () => {
+      const session = sessionFactory.build()
+
+      const submitted = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false, enforceable: false }),
+        appointments: [
+          { id: 999001, deliusVersion: 'v1' },
+          { id: 999002, deliusVersion: 'v2' },
+        ],
       })
 
-      it('should not include offender item when session is undefined', () => {
-        const submitted = appointmentOutcomeFormFactory.build()
+      const result = page.formItems(submitted, { projectCode: '', date: '' }, { session })
 
-        const result = page.viewData({}, { projectCode: 'XY', appointmentId: '1' }, submitted)
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          key: { text: 'People' },
+          value: { html: '' },
+        }),
+      )
+    })
 
-        const peopleItem = result.submittedItems.find(item => item.key.text === 'People')
+    it('should not include offender item when appointment or session is undefined', () => {
+      const submitted = appointmentOutcomeFormFactory.build()
 
-        expect(peopleItem).toBeUndefined()
-      })
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, undefined)
 
-      it('should pass undefined appointment  when appointmentOrSession is undefined', () => {
-        const checkYourAnswersRowsSpy = jest.spyOn(NotesUtils, 'checkYourAnswersRows').mockReturnValue([])
-        const submitted = appointmentOutcomeFormFactory.build()
+      const peopleItem = result.find(item => item.key.text === 'People')
 
-        page.viewData(undefined, { projectCode: 'XY', appointmentId: '1' }, submitted)
+      expect(peopleItem).toBeUndefined()
+    })
 
-        expect(checkYourAnswersRowsSpy).toHaveBeenCalledWith(submitted, expect.any(String), undefined, true)
-      })
+    it('should not include offender item when session is undefined', () => {
+      const submitted = appointmentOutcomeFormFactory.build()
+
+      const result = page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, {})
+
+      const peopleItem = result.find(item => item.key.text === 'People')
+
+      expect(peopleItem).toBeUndefined()
+    })
+
+    it('should pass undefined appointment  when appointmentOrSession is undefined', () => {
+      const checkYourAnswersRowsSpy = jest.spyOn(NotesUtils, 'checkYourAnswersRows').mockReturnValue([])
+      const submitted = appointmentOutcomeFormFactory.build()
+
+      page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, undefined)
+
+      expect(checkYourAnswersRowsSpy).toHaveBeenCalledWith(submitted, expect.any(String), undefined, true)
     })
   })
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -17,6 +17,9 @@ import appointmentSummaryFactory from '../../testutils/factories/appointmentSumm
 import NotesUtils from '../../utils/components/notesUtils'
 import UnpaidWorkUtils from '../../utils/unpaidWorkUtils'
 import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
+import Offender from '../../models/offender'
+
+jest.mock('../../models/offender')
 
 describe('ConfirmPage', () => {
   beforeEach(() => {
@@ -453,6 +456,11 @@ describe('ConfirmPage', () => {
       jest.spyOn(paths.sessions, 'update')
       jest.spyOn(paths.appointments, 'update')
 
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      offenderMock
+        .mockImplementationOnce(() => ({ details: { description: 'Sam Jones (CRN002)' } }))
+        .mockImplementationOnce(() => ({ details: { description: 'Alex Smith (CRN001)' } }))
+
       const contactOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
       const submitted = appointmentOutcomeFormFactory.build({
         contactOutcome,
@@ -640,41 +648,116 @@ describe('ConfirmPage', () => {
 
     beforeEach(() => {
       page = new ConfirmPage()
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      offenderMock.mockImplementation(() => ({ details: { description: 'John Smith (X123456)' } }))
     })
 
-    it('returns an empty array when unpaidWorkDetails is an empty array', () => {
+    it('returns only a person item when unpaidWorkDetails is an empty array', () => {
       const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
+      const offender = offenderFullFactory.build()
 
       const result = page.createFormItems({
         form,
         pathData: { projectCode: 'XY', appointmentId: '1' },
         formId: 'formId',
-        offenderSummary: caseDetailsSummaryFactory.build({ unpaidWorkDetails: [] }),
+        offenderSummary: caseDetailsSummaryFactory.build({ offender, unpaidWorkDetails: [] }),
         projectType: 'INDIVIDUAL',
       })
 
-      expect(result).toEqual([])
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
+                  form: 'formId',
+                }),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+      ])
     })
 
-    it('returns an empty array when unpaidWorkDetails has fewer than 2 items', () => {
+    it('returns only a person item when unpaidWorkDetails has fewer than 2 items', () => {
       const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
       const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
+      const offender = offenderFullFactory.build({ forename: 'John', surname: 'Smith', crn: 'X123456' })
 
       const result = page.createFormItems({
         form,
         pathData: { projectCode: 'XY', appointmentId: '1' },
         formId: 'formId',
-        offenderSummary: caseDetailsSummaryFactory.build({ unpaidWorkDetails: [requirement] }),
+        offenderSummary: caseDetailsSummaryFactory.build({ offender, unpaidWorkDetails: [requirement] }),
         projectType: 'INDIVIDUAL',
       })
 
-      expect(result).toEqual([])
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
+                  form: 'formId',
+                }),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+      ])
+    })
+
+    it('returns a person item using the sessions find a person path when projectType is GROUP', () => {
+      const form = {
+        ...appointmentOutcomeFormFactory.build(),
+        crn: 'X123456',
+        deliusEventNumber: '1',
+        date: '2026-01-20',
+      }
+      const offender = offenderFullFactory.build()
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', date: '2026-01-20' },
+        formId: 'formId',
+        offenderSummary: caseDetailsSummaryFactory.build({ offender, unpaidWorkDetails: [] }),
+        projectType: 'GROUP',
+      })
+
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(
+                  paths.sessions.create.findAPerson({ projectCode: 'XY', date: '2026-01-20' }),
+                  { form: 'formId' },
+                ),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+      ])
     })
 
     it('returns an unpaid work summary item using the projects requirement path when projectType is INDIVIDUAL', () => {
       const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
       const otherRequirement = unpaidWorkDetailsFactory.build({ eventNumber: 2 })
+      const offender = offenderFullFactory.build()
       const offenderSummary = caseDetailsSummaryFactory.build({
+        offender,
         unpaidWorkDetails: [requirement, otherRequirement],
       })
       const form = {
@@ -706,13 +789,32 @@ describe('ConfirmPage', () => {
           form: 'formId',
         }),
       )
-      expect(result).toEqual([unpaidWorkItem])
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
+                  form: 'formId',
+                }),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+        unpaidWorkItem,
+      ])
     })
 
     it('returns an unpaid work summary item using the sessions requirement path when projectType is GROUP', () => {
       const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
       const otherRequirement = unpaidWorkDetailsFactory.build({ eventNumber: 2 })
+      const offender = offenderFullFactory.build()
       const offenderSummary = caseDetailsSummaryFactory.build({
+        offender,
         unpaidWorkDetails: [requirement, otherRequirement],
       })
       const form = {
@@ -747,7 +849,25 @@ describe('ConfirmPage', () => {
           },
         ),
       )
-      expect(result).toEqual([unpaidWorkItem])
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(
+                  paths.sessions.create.findAPerson({ projectCode: 'XY', date: '2026-01-20' }),
+                  { form: 'formId' },
+                ),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+        unpaidWorkItem,
+      ])
     })
 
     it('passes an undefined requirement when no unpaidWorkDetails match the deliusEventNumber', () => {
@@ -759,7 +879,9 @@ describe('ConfirmPage', () => {
         deliusEventNumber: '1',
         date: '2026-01-20',
       }
+      const offender = offenderFullFactory.build()
       const offenderSummary = caseDetailsSummaryFactory.build({
+        offender,
         unpaidWorkDetails: [nonMatchingDetail, otherNonMatchingDetail],
       })
       const unpaidWorkItem = {
@@ -785,7 +907,24 @@ describe('ConfirmPage', () => {
           form: 'formId',
         }),
       )
-      expect(result).toEqual([unpaidWorkItem])
+      expect(result).toEqual([
+        {
+          key: { text: 'Person' },
+          value: { text: 'John Smith (X123456)' },
+          actions: {
+            items: [
+              {
+                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
+                  form: 'formId',
+                }),
+                text: 'Change',
+                visuallyHiddenText: 'person',
+              },
+            ],
+          },
+        },
+        unpaidWorkItem,
+      ])
     })
   })
 
@@ -984,6 +1123,9 @@ describe('ConfirmPage', () => {
         }),
       })
 
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      offenderMock.mockImplementation(() => ({ details: { description: 'John Smith (X123456)' } }))
+
       const result = page.deliusVersionChangedMessage([appointment])
 
       expect(result).toBe(
@@ -1009,6 +1151,11 @@ describe('ConfirmPage', () => {
           }),
         }),
       ]
+
+      const offenderMock: jest.Mock = Offender as unknown as jest.Mock<Offender>
+      offenderMock
+        .mockImplementationOnce(() => ({ details: { description: 'John Smith (X123456)' } }))
+        .mockImplementationOnce(() => ({ details: { description: 'Jane Doe (Y654321)' } }))
 
       const result = page.deliusVersionChangedMessage(appointments)
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -7,6 +7,7 @@ import * as Utils from '../../utils/utils'
 import { YesOrNo } from '../../@types/user-defined'
 import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
+import unpaidWorkDetailsFactory from '../../testutils/factories/unpaidWorkDetailsFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 import projectFactory from '../../testutils/factories/projectFactory'
@@ -14,6 +15,8 @@ import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import offenderFullFactory from '../../testutils/factories/offenderFullFactory'
 import appointmentSummaryFactory from '../../testutils/factories/appointmentSummaryFactory'
 import NotesUtils from '../../utils/components/notesUtils'
+import UnpaidWorkUtils from '../../utils/unpaidWorkUtils'
+import caseDetailsSummaryFactory from '../../testutils/factories/caseDetailsSummaryFactory'
 
 describe('ConfirmPage', () => {
   beforeEach(() => {
@@ -629,6 +632,160 @@ describe('ConfirmPage', () => {
       page.formItems(submitted, { projectCode: 'XY', appointmentId: '1' }, undefined)
 
       expect(checkYourAnswersRowsSpy).toHaveBeenCalledWith(submitted, expect.any(String), undefined, true)
+    })
+  })
+
+  describe('createFormItems', () => {
+    let page: ConfirmPage
+
+    beforeEach(() => {
+      page = new ConfirmPage()
+    })
+
+    it('returns an empty array when unpaidWorkDetails is an empty array', () => {
+      const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', appointmentId: '1' },
+        formId: 'formId',
+        offenderSummary: caseDetailsSummaryFactory.build({ unpaidWorkDetails: [] }),
+        projectType: 'INDIVIDUAL',
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when unpaidWorkDetails has fewer than 2 items', () => {
+      const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
+      const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', appointmentId: '1' },
+        formId: 'formId',
+        offenderSummary: caseDetailsSummaryFactory.build({ unpaidWorkDetails: [requirement] }),
+        projectType: 'INDIVIDUAL',
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an unpaid work summary item using the projects requirement path when projectType is INDIVIDUAL', () => {
+      const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
+      const otherRequirement = unpaidWorkDetailsFactory.build({ eventNumber: 2 })
+      const offenderSummary = caseDetailsSummaryFactory.build({
+        unpaidWorkDetails: [requirement, otherRequirement],
+      })
+      const form = {
+        ...appointmentOutcomeFormFactory.build(),
+        crn: 'X123456',
+        deliusEventNumber: '1',
+        date: '2026-01-20',
+      }
+      const unpaidWorkItem = {
+        key: { text: 'Requirement' },
+        value: { html: 'some requirement summary' },
+        actions: { items: [{ href: '/change-path', text: 'Change', visuallyHiddenText: 'requirement' }] },
+      }
+      const unpaidWorkSummaryItemSpy = jest
+        .spyOn(UnpaidWorkUtils, 'unpaidWorkSummaryItem')
+        .mockReturnValue(unpaidWorkItem)
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', appointmentId: '1' },
+        formId: 'formId',
+        offenderSummary,
+        projectType: 'INDIVIDUAL',
+      })
+
+      expect(unpaidWorkSummaryItemSpy).toHaveBeenCalledWith(
+        requirement,
+        Utils.pathWithQuery(paths.projects.create.requirement({ projectCode: 'XY', crn: form.crn }), {
+          form: 'formId',
+        }),
+      )
+      expect(result).toEqual([unpaidWorkItem])
+    })
+
+    it('returns an unpaid work summary item using the sessions requirement path when projectType is GROUP', () => {
+      const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
+      const otherRequirement = unpaidWorkDetailsFactory.build({ eventNumber: 2 })
+      const offenderSummary = caseDetailsSummaryFactory.build({
+        unpaidWorkDetails: [requirement, otherRequirement],
+      })
+      const form = {
+        ...appointmentOutcomeFormFactory.build(),
+        crn: 'X123456',
+        deliusEventNumber: '1',
+        date: '2026-01-20',
+      }
+      const unpaidWorkItem = {
+        key: { text: 'Requirement' },
+        value: { html: 'some requirement summary' },
+        actions: { items: [{ href: '/change-path', text: 'Change', visuallyHiddenText: 'requirement' }] },
+      }
+      const unpaidWorkSummaryItemSpy = jest
+        .spyOn(UnpaidWorkUtils, 'unpaidWorkSummaryItem')
+        .mockReturnValue(unpaidWorkItem)
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', date: '2026-01-20' },
+        offenderSummary,
+        formId: 'formId',
+        projectType: 'GROUP',
+      })
+
+      expect(unpaidWorkSummaryItemSpy).toHaveBeenCalledWith(
+        requirement,
+        Utils.pathWithQuery(
+          paths.sessions.create.requirement({ projectCode: 'XY', date: '2026-01-20', crn: form.crn }),
+          {
+            form: 'formId',
+          },
+        ),
+      )
+      expect(result).toEqual([unpaidWorkItem])
+    })
+
+    it('passes an undefined requirement when no unpaidWorkDetails match the deliusEventNumber', () => {
+      const nonMatchingDetail = unpaidWorkDetailsFactory.build({ eventNumber: 2 })
+      const otherNonMatchingDetail = unpaidWorkDetailsFactory.build({ eventNumber: 3 })
+      const form = {
+        ...appointmentOutcomeFormFactory.build(),
+        crn: 'X123456',
+        deliusEventNumber: '1',
+        date: '2026-01-20',
+      }
+      const offenderSummary = caseDetailsSummaryFactory.build({
+        unpaidWorkDetails: [nonMatchingDetail, otherNonMatchingDetail],
+      })
+      const unpaidWorkItem = {
+        key: { text: 'Requirement' },
+        value: { html: 'some requirement summary' },
+        actions: { items: [{ href: '/change-path', text: 'Change', visuallyHiddenText: 'requirement' }] },
+      }
+      const unpaidWorkSummaryItemSpy = jest
+        .spyOn(UnpaidWorkUtils, 'unpaidWorkSummaryItem')
+        .mockReturnValue(unpaidWorkItem)
+
+      const result = page.createFormItems({
+        form,
+        pathData: { projectCode: 'XY', appointmentId: '1' },
+        formId: 'formId',
+        offenderSummary,
+        projectType: 'INDIVIDUAL',
+      })
+
+      expect(unpaidWorkSummaryItemSpy).toHaveBeenCalledWith(
+        undefined,
+        Utils.pathWithQuery(paths.projects.create.requirement({ projectCode: 'XY', crn: form.crn }), {
+          form: 'formId',
+        }),
+      )
+      expect(result).toEqual([unpaidWorkItem])
     })
   })
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -98,20 +98,57 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     offenderSummary: CaseDetailsSummaryDto
     projectType: ProjectTypeDto['group']
   }): GovUkSummaryListItem[] {
+    const pathNamespace = projectType === 'INDIVIDUAL' ? 'projects' : 'sessions'
+
+    const personPath = this.pathWithFormId(
+      paths[pathNamespace].create.findAPerson({ projectCode: pathData.projectCode, date: form.date }),
+      formId,
+    )
+    const personItem: GovUkSummaryListItem = {
+      key: {
+        text: 'Person',
+      },
+      value: {
+        text: new Offender(offenderSummary.offender).details.description,
+      },
+      actions: {
+        items: [
+          {
+            href: personPath,
+            text: 'Change',
+            visuallyHiddenText: 'person',
+          },
+        ],
+      },
+    }
+
+    return [personItem, ...this.requirementItems({ form, pathData, formId, offenderSummary, pathNamespace })]
+  }
+
+  private requirementItems({
+    form,
+    pathData,
+    formId,
+    offenderSummary,
+    pathNamespace,
+  }: {
+    form: CreateAppointmentForm
+    pathData: AppointmentOrSessionParams
+    formId: string
+    offenderSummary: CaseDetailsSummaryDto
+    pathNamespace: 'projects' | 'sessions'
+  }): GovUkSummaryListItem[] {
     const { unpaidWorkDetails } = offenderSummary
     if (unpaidWorkDetails.length < 2) {
       return []
     }
-
-    const pathNamespace = projectType === 'INDIVIDUAL' ? 'projects' : 'sessions'
 
     const requirement = unpaidWorkDetails.find(detail => detail.eventNumber === Number(form.deliusEventNumber))
     const requirementPath = this.pathWithFormId(
       paths[pathNamespace].create.requirement({ projectCode: pathData.projectCode, date: form.date, crn: form.crn }),
       formId,
     )
-    const unpaidWorkItem = UnpaidWorkUtils.unpaidWorkSummaryItem(requirement, requirementPath)
-    return [unpaidWorkItem]
+    return [UnpaidWorkUtils.unpaidWorkSummaryItem(requirement, requirementPath)]
   }
 
   formItems(

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -21,7 +21,6 @@ interface ViewData {
   alertPractitionerItems: GovUkRadioOrCheckboxOption[]
   showWillAlertPractitionerMessage: boolean
   alertDiaryText: string
-  submittedItems: GovUkSummaryListItem[]
 }
 
 interface Query {
@@ -47,18 +46,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     return validationErrors
   }
 
-  viewData(
-    appointmentOrSession: AppointmentOrSession | undefined,
-    pathData: AppointmentOrSessionParams,
-    form: AppointmentOutcomeForm,
-    formId?: string,
-    itemsOptions?: ItemsOptions,
-  ): ViewData {
+  alertQuestionDetails(appointmentOrSession: AppointmentOrSession | undefined, form: AppointmentOutcomeForm): ViewData {
     const showWillAlertPractitionerMessage = form.contactOutcome?.willAlertEnforcementDiary ?? false
     const alertValue = this.appointmentAlertValue(appointmentOrSession)
 
     return {
-      submittedItems: this.formItems(form, pathData, appointmentOrSession, formId, itemsOptions),
       showWillAlertPractitionerMessage,
       alertPractitionerItems: GovUkRadioGroup.yesNoItems({
         checkedValue: GovUkRadioGroup.determineCheckedValue(alertValue),
@@ -85,32 +77,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     return `The ${appointmentText} for ${appointmentIdentifiers.join(', ')} ${haveHas} already been updated in the database. Try again.`
   }
 
-  protected nextPage(): AppointmentPage | undefined {
-    return undefined
-  }
-
-  protected backPage(_params: AppointmentOrSessionParams, form?: AppointmentOutcomeForm): AppointmentPage {
-    if (form && form.contactOutcome?.attended) {
-      return 'log-compliance'
-    }
-    return 'attendance-outcome'
-  }
-
-  private getStartAndEndTime(form: AppointmentOutcomeForm) {
-    const { startTime, endTime } = form
-    const hours = DateTimeFormats.timeBetween(startTime, endTime)
-
-    return HtmlUtils.getElementsWithContent(
-      [DateTimeFormats.timePeriod(startTime, endTime), this.hoursCreditedText(hours)],
-      'p',
-    )
-  }
-
-  private hoursCreditedText(hours: string) {
-    return `Hours credited: ${hours}`
-  }
-
-  private formItems(
+  formItems(
     form: AppointmentOutcomeForm,
     pathData: AppointmentOrSessionParams,
     appointmentOrSession: AppointmentOrSession | undefined,
@@ -268,6 +235,31 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
     )
 
     return items
+  }
+
+  protected nextPage(): AppointmentPage | undefined {
+    return undefined
+  }
+
+  protected backPage(_params: AppointmentOrSessionParams, form?: AppointmentOutcomeForm): AppointmentPage {
+    if (form && form.contactOutcome?.attended) {
+      return 'log-compliance'
+    }
+    return 'attendance-outcome'
+  }
+
+  private getStartAndEndTime(form: AppointmentOutcomeForm) {
+    const { startTime, endTime } = form
+    const hours = DateTimeFormats.timeBetween(startTime, endTime)
+
+    return HtmlUtils.getElementsWithContent(
+      [DateTimeFormats.timePeriod(startTime, endTime), this.hoursCreditedText(hours)],
+      'p',
+    )
+  }
+
+  private hoursCreditedText(hours: string) {
+    return `Hours credited: ${hours}`
   }
 
   private outcomeValue(contactOutcome?: ContactOutcomeDto) {

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -1,4 +1,10 @@
-import { AppointmentDto, AppointmentSummaryDto, ContactOutcomeDto } from '../../@types/shared'
+import {
+  AppointmentDto,
+  AppointmentSummaryDto,
+  ContactOutcomeDto,
+  ProjectTypeDto,
+  CaseDetailsSummaryDto,
+} from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOrSessionParams,
@@ -7,7 +13,7 @@ import {
   ValidationErrors,
   YesOrNo,
 } from '../../@types/user-defined'
-import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
+import { AppointmentOutcomeForm, CreateAppointmentForm } from '../../services/forms/appointmentFormService'
 import GovUkRadioGroup from '../../forms/GovUkRadioGroup'
 import Offender from '../../models/offender'
 import AppointmentUtils from '../../utils/appointmentUtils'
@@ -16,6 +22,8 @@ import HtmlUtils from '../../utils/htmlUtils'
 import NotesUtils from '../../utils/components/notesUtils'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
 import { AppointmentPage } from './pathMap'
+import UnpaidWorkUtils from '../../utils/unpaidWorkUtils'
+import paths from '../../paths'
 
 interface ViewData {
   alertPractitionerItems: GovUkRadioOrCheckboxOption[]
@@ -75,6 +83,35 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
       return offender.details.description
     })
     return `The ${appointmentText} for ${appointmentIdentifiers.join(', ')} ${haveHas} already been updated in the database. Try again.`
+  }
+
+  createFormItems({
+    form,
+    pathData,
+    formId,
+    offenderSummary,
+    projectType,
+  }: {
+    form: CreateAppointmentForm
+    pathData: AppointmentOrSessionParams
+    formId: string
+    offenderSummary: CaseDetailsSummaryDto
+    projectType: ProjectTypeDto['group']
+  }): GovUkSummaryListItem[] {
+    const { unpaidWorkDetails } = offenderSummary
+    if (unpaidWorkDetails.length < 2) {
+      return []
+    }
+
+    const pathNamespace = projectType === 'INDIVIDUAL' ? 'projects' : 'sessions'
+
+    const requirement = unpaidWorkDetails.find(detail => detail.eventNumber === Number(form.deliusEventNumber))
+    const requirementPath = this.pathWithFormId(
+      paths[pathNamespace].create.requirement({ projectCode: pathData.projectCode, date: form.date, crn: form.crn }),
+      formId,
+    )
+    const unpaidWorkItem = UnpaidWorkUtils.unpaidWorkSummaryItem(requirement, requirementPath)
+    return [unpaidWorkItem]
   }
 
   formItems(

--- a/server/pages/courseCompletions/process/confirmPage.ts
+++ b/server/pages/courseCompletions/process/confirmPage.ts
@@ -15,6 +15,7 @@ import DateTimeFormats from '../../../utils/dateTimeUtils'
 import NotesUtils from '../../../utils/components/notesUtils'
 import BaseCourseCompletionFormPage from './baseCourseCompletionFormPage'
 import { CourseCompletionPage } from './pathMap'
+import UnpaidWorkUtils from '../../../utils/unpaidWorkUtils'
 
 interface Body {
   alertPractitioner?: YesOrNo
@@ -57,15 +58,6 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
   }
 
   personItems({ courseCompletionId, form, formId, unpaidWorkDetails }: PersonItems): GovUkSummaryListItem[] {
-    const requirementDetails = unpaidWorkDetails
-      ? [
-          `Offence: ${unpaidWorkDetails.mainOffence.description}`,
-          `Event number: ${unpaidWorkDetails.eventNumber}`,
-          `Sentence date: ${DateTimeFormats.isoDateToUIDate(unpaidWorkDetails.sentenceDate)}`,
-          `Status: ${unpaidWorkDetails.upwStatus}`,
-        ].join('<br>')
-      : undefined
-
     return [
       {
         key: {
@@ -87,26 +79,10 @@ export default class ConfirmPage extends BaseCourseCompletionFormPage<Body> {
           ],
         },
       },
-      {
-        key: {
-          text: 'Requirement',
-        },
-        value: {
-          html: requirementDetails,
-        },
-        actions: {
-          items: [
-            {
-              href: this.pathWithFormId(
-                paths.courseCompletions.process({ page: 'requirement', id: courseCompletionId }),
-                formId,
-              ),
-              text: 'Change',
-              visuallyHiddenText: 'requirement',
-            },
-          ],
-        },
-      },
+      UnpaidWorkUtils.unpaidWorkSummaryItem(
+        unpaidWorkDetails,
+        this.pathWithFormId(paths.courseCompletions.process({ page: 'requirement', id: courseCompletionId }), formId),
+      ),
     ]
   }
 

--- a/server/utils/unpaidWorkUtils.test.ts
+++ b/server/utils/unpaidWorkUtils.test.ts
@@ -3,6 +3,10 @@ import unpaidWorkDetailsFactory from '../testutils/factories/unpaidWorkDetailsFa
 import UnpaidWorkUtils from './unpaidWorkUtils'
 
 describe('UnpaidWorkUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('unpaidWorkHoursDetails', () => {
     it('returns formatted hours details without totalHoursRemaining', () => {
       const unpaidWorkDetail = unpaidWorkDetailsFactory.build({
@@ -77,6 +81,57 @@ describe('UnpaidWorkUtils', () => {
       const [result] = UnpaidWorkUtils.getUnpaidWorkOptions(unpaidWorkDetails, upwDetails.eventNumber)
 
       expect(result.checked).toBe(true)
+    })
+  })
+
+  describe('unpaidWorkSummaryItem', () => {
+    it('returns a summary item with requirement details when unpaidWorkDetails is provided', () => {
+      const upwDetails = unpaidWorkDetailsFactory.build({
+        sentenceDate: '2020-03-15',
+        upwStatus: 'Being worked',
+      })
+
+      const result = UnpaidWorkUtils.unpaidWorkSummaryItem(upwDetails, '/change-path')
+
+      expect(result).toEqual({
+        key: {
+          text: 'Requirement',
+        },
+        value: {
+          html: `Offence: ${upwDetails.mainOffence.description}<br>Event number: ${upwDetails.eventNumber}<br>Sentence date: 15 March 2020<br>Status: Being worked`,
+        },
+        actions: {
+          items: [
+            {
+              href: '/change-path',
+              text: 'Change',
+              visuallyHiddenText: 'requirement',
+            },
+          ],
+        },
+      })
+    })
+
+    it('returns a summary item with undefined value html when unpaidWorkDetails is undefined', () => {
+      const result = UnpaidWorkUtils.unpaidWorkSummaryItem(undefined, '/change-path')
+
+      expect(result).toEqual({
+        key: {
+          text: 'Requirement',
+        },
+        value: {
+          html: undefined,
+        },
+        actions: {
+          items: [
+            {
+              href: '/change-path',
+              text: 'Change',
+              visuallyHiddenText: 'requirement',
+            },
+          ],
+        },
+      })
     })
   })
 })

--- a/server/utils/unpaidWorkUtils.ts
+++ b/server/utils/unpaidWorkUtils.ts
@@ -50,6 +50,37 @@ export default class UnpaidWorkUtils {
     })
   }
 
+  static unpaidWorkSummaryItem(unpaidWorkDetails: UnpaidWorkDetailsDto | undefined, changePath: string) {
+    const requirementDetails = unpaidWorkDetails ? UnpaidWorkUtils.summaryString(unpaidWorkDetails) : undefined
+
+    return {
+      key: {
+        text: 'Requirement',
+      },
+      value: {
+        html: requirementDetails,
+      },
+      actions: {
+        items: [
+          {
+            href: changePath,
+            text: 'Change',
+            visuallyHiddenText: 'requirement',
+          },
+        ],
+      },
+    }
+  }
+
+  private static summaryString(unpaidWorkDetails: UnpaidWorkDetailsDto) {
+    return [
+      `Offence: ${unpaidWorkDetails.mainOffence.description}`,
+      `Event number: ${unpaidWorkDetails.eventNumber}`,
+      `Sentence date: ${DateTimeFormats.isoDateToUIDate(unpaidWorkDetails.sentenceDate)}`,
+      `Status: ${unpaidWorkDetails.upwStatus}`,
+    ].join('<br>')
+  }
+
   private static buildDetailsRows(details: Record<string, string>) {
     return Object.entries(details).map(([key, value]) => {
       return {


### PR DESCRIPTION
## Context

This adds the selected person and requirement to the confirm details set of creating an appointment, with the ability to change.

[CPB-1178](https://dsdmoj.atlassian.net/browse/CPB-1178)

## Changes in this PR

- Split out view data methods
- Add an additional method to pre-pend create form summary list items
- Add requirement and date items

Requirement will only be shown where a person has multiple requirements - as the admin will not be shown the question otherwise.

## Yet to be handled
- Changing a person is not saving to the form (#712 )
- Copilot feedback on optional formId - see my comment

### Screenshots of UI changes

**With 1 requirement**

<img width="1568" height="933" alt="Screenshot 2026-08-10 at 11 21 20" src="https://github.com/user-attachments/assets/affd49d5-30d5-482a-8540-904e8760403d" />

With multiple requirements

<img width="1562" height="961" alt="Screenshot 2026-08-10 at 11 23 22" src="https://github.com/user-attachments/assets/ae39c8a1-4357-458a-b5f8-4d0512681487" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1178]: https://dsdmoj.atlassian.net/browse/CPB-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ