### PR TITLE
CPB-1178: Fix changed offender not persisting

### DIFF
--- a/server/controllers/appointments/appointmentsController.test.ts
+++ b/server/controllers/appointments/appointmentsController.test.ts
@@ -4,6 +4,7 @@ import AppointmentsController from './appointmentsController'
 import AppointmentFormService, { APPOINTMENT_UPDATE_FORM_TYPE } from '../../services/forms/appointmentFormService'
 import ProjectService from '../../services/projectService'
 import projectFactory from '../../testutils/factories/projectFactory'
+import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import paths from '../../paths'
 import { pathWithQuery } from '../../utils/utils'
 
@@ -64,10 +65,12 @@ describe('AppointmentsController', () => {
       )
     })
 
-    it('should reuse the existing form id and redirect without creating a new form when form is present in query', async () => {
+    it('should update the existing form with the new crn and deliusEventNumber and redirect without creating a new form when form is present in query', async () => {
       const project = projectFactory.build({ projectCode })
+      const existingFormData = appointmentOutcomeFormFactory.build()
 
       projectService.getProject.mockResolvedValue(project)
+      formService.getForm.mockResolvedValue(existingFormData)
 
       const requestWithForm = createMock<Request>({
         params: { crn, deliusEventNumber, projectCode, date },
@@ -78,6 +81,12 @@ describe('AppointmentsController', () => {
       await requestHandler(requestWithForm, response, next)
 
       expect(formService.createNewAppointmentForm).not.toHaveBeenCalled()
+      expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
+      expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, {
+        ...existingFormData,
+        deliusEventNumber,
+        crn,
+      })
 
       expect(response.redirect).toHaveBeenCalledWith(
         pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {

--- a/server/controllers/appointments/appointmentsController.ts
+++ b/server/controllers/appointments/appointmentsController.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import AppointmentFormService from '../../services/forms/appointmentFormService'
+import AppointmentFormService, { CreateAppointmentForm } from '../../services/forms/appointmentFormService'
 import paths from '../../paths'
 import { pathWithQuery } from '../../utils/utils'
 import ProjectService from '../../services/projectService'
@@ -20,18 +20,26 @@ export default class AppointmentsController {
 
       const form = req.query?.form?.toString()
 
-      const id =
-        form ||
-        (
-          await this.formService.createNewAppointmentForm(
-            username,
-            req.query as Record<string, string>,
-            crn,
-            deliusEventNumber,
-            project,
-            date,
-          )
-        ).key.id
+      let id = form
+
+      if (form) {
+        const formData = (await this.formService.getForm(form, username)) as CreateAppointmentForm
+        await this.formService.saveForm(form, username, {
+          ...formData,
+          deliusEventNumber,
+          crn,
+        })
+      } else {
+        const newForm = await this.formService.createNewAppointmentForm(
+          username,
+          req.query as Record<string, string>,
+          crn,
+          deliusEventNumber,
+          project,
+          date,
+        )
+        id = newForm.key.id
+      }
 
       res.redirect(
         pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {

--- a/server/controllers/requirementController.test.ts
+++ b/server/controllers/requirementController.test.ts
@@ -269,7 +269,7 @@ describe('RequirementController', () => {
       ]
       jest.spyOn(UnpaidWorkUtils, 'getUnpaidWorkOptions').mockReturnValue(unpaidWorkOptions)
 
-      const requestHandler = requirementController.submit({ updatePath, createAppointmentPath: path('/'), backPath })
+      const requestHandler = requirementController.submit({ updatePath, nextPath: path('/'), backPath })
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('pages/requirement', {
@@ -320,7 +320,7 @@ describe('RequirementController', () => {
 
         const requestHandler = requirementController.submit({
           updatePath,
-          createAppointmentPath: path('/'),
+          nextPath: path('/'),
           backPath,
         })
         await requestHandler(request, response, next)
@@ -367,7 +367,7 @@ describe('RequirementController', () => {
 
         const requestHandler = requirementController.submit({
           updatePath,
-          createAppointmentPath: path('/'),
+          nextPath: path('/'),
           backPath,
         })
         await requestHandler(request, response, next)
@@ -384,7 +384,9 @@ describe('RequirementController', () => {
     })
 
     describe('when form exists', () => {
-      it('saves form data and redirects to date page', async () => {
+      it('redirects to provided next page with params', async () => {
+        const createAppointmentPath = paths.sessions.create.createAppointment
+
         request = createMock<Request>({
           params: {
             crn,
@@ -404,15 +406,14 @@ describe('RequirementController', () => {
 
         const requestHandler = requirementController.submit({
           updatePath,
-          createAppointmentPath: path('/'),
+          nextPath: createAppointmentPath,
           backPath: '/',
         })
         await requestHandler(request, response, next)
 
-        expect(formService.saveForm).toHaveBeenCalledWith(formId, username, { ...form, deliusEventNumber: '1' })
         expect(response.redirect).toHaveBeenCalledWith(
-          pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
-            form: formId,
+          pathWithQuery(paths.sessions.create.createAppointment({ projectCode, crn, date, deliusEventNumber: '1' }), {
+            form: '1',
           }),
         )
       })
@@ -436,7 +437,11 @@ describe('RequirementController', () => {
         const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
         offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
 
-        const requestHandler = requirementController.submit({ updatePath: '/', createAppointmentPath, backPath: '/' })
+        const requestHandler = requirementController.submit({
+          updatePath: '/',
+          nextPath: createAppointmentPath,
+          backPath: '/',
+        })
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(
@@ -461,7 +466,11 @@ describe('RequirementController', () => {
         const caseDetailsSummary = caseDetailsSummaryFactory.build({ unpaidWorkDetails: [unpaidWorkDetails] })
         offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
 
-        const requestHandler = requirementController.submit({ updatePath: '/', createAppointmentPath, backPath: '/' })
+        const requestHandler = requirementController.submit({
+          updatePath: '/',
+          nextPath: createAppointmentPath,
+          backPath: '/',
+        })
         await requestHandler(request, response, next)
 
         expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/requirementController.ts
+++ b/server/controllers/requirementController.ts
@@ -6,7 +6,6 @@ import UnpaidWorkUtils from '../utils/unpaidWorkUtils'
 import RequirementPage from '../pages/appointments/requirementPage'
 import AppointmentFormService, { CreateAppointmentForm } from '../services/forms/appointmentFormService'
 import { pathWithQuery } from '../utils/utils'
-import paths from '../paths'
 
 export default class RequirementController {
   constructor(
@@ -54,11 +53,11 @@ export default class RequirementController {
   submit<CreateAppointmentPathPattern extends `/${string}`>({
     backPath,
     updatePath,
-    createAppointmentPath,
+    nextPath,
   }: {
     backPath: string
     updatePath: string
-    createAppointmentPath: Path<CreateAppointmentPathPattern>
+    nextPath: Path<CreateAppointmentPathPattern>
   }): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn, projectCode, date } = req.params
@@ -95,20 +94,6 @@ export default class RequirementController {
         })
       }
 
-      if (form) {
-        const formData = (await this.formService.getForm(form, res.locals.user.username)) as CreateAppointmentForm
-        this.formService.saveForm(form, res.locals.user.username, {
-          ...formData,
-          deliusEventNumber: req.body.deliusEventNumber,
-        })
-
-        return res.redirect(
-          pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
-            form,
-          }),
-        )
-      }
-
       const params = {
         crn,
         projectCode,
@@ -116,7 +101,7 @@ export default class RequirementController {
         deliusEventNumber: req.body.deliusEventNumber,
       } as unknown as Params<CreateAppointmentPathPattern>
 
-      return res.redirect(pathWithQuery(createAppointmentPath(params), req.query as Record<string, string>))
+      return res.redirect(pathWithQuery(nextPath(params), req.query as Record<string, string>))
     }
   }
 }

--- a/server/paths/requirementPagePaths.test.ts
+++ b/server/paths/requirementPagePaths.test.ts
@@ -11,7 +11,7 @@ describe('buildRequirementPaths', () => {
 
     expect(result.backPath).toBe('/sessions/PROJECT/2025-01-01/create/find-a-person')
     expect(result.updatePath).toBe('/sessions/PROJECT/2025-01-01/create/X123456/requirement')
-    expect(result.createAppointmentPath).toBe(paths.sessions.create.createAppointment)
+    expect(result.nextPath).toBe(paths.sessions.create.createAppointment)
   })
 
   it('builds project requirement paths from the create namespace', () => {
@@ -22,6 +22,6 @@ describe('buildRequirementPaths', () => {
 
     expect(result.backPath).toBe('/projects/PROJECT/create/find-a-person')
     expect(result.updatePath).toBe('/projects/PROJECT/create/X123456/requirement')
-    expect(result.createAppointmentPath).toBe(paths.projects.create.createAppointment)
+    expect(result.nextPath).toBe(paths.projects.create.createAppointment)
   })
 })

--- a/server/paths/requirementPagePaths.ts
+++ b/server/paths/requirementPagePaths.ts
@@ -18,6 +18,6 @@ export default function buildRequirementPagePaths<
   return {
     backPath: paths.findAPerson(params),
     updatePath: paths.requirement(params),
-    createAppointmentPath: paths.createAppointment,
+    nextPath: paths.createAppointment,
   }
 }


### PR DESCRIPTION
## Context

Previously, we were only storing the CRN on the in progress form at the point of create. This change resolves that.

[CPB-1178](https://dsdmoj.atlassian.net/browse/CPB-1178)

## Changes in this PR

This repurposes the `createAppointment()` handler to update any in progress form with the `CRN` and `deliusEventNumber` path params, rather than solely handling create.

This means we can remove the logic for handling conditional redirect from the requirement controller, which makes it more reusable for the person page journey.

### Screenshots of UI changes


https://github.com/user-attachments/assets/41582980-8a5e-4422-8293-7cd47ffd99f6

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1178]: https://dsdmoj.atlassian.net/browse/CPB-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ