### PR TITLE
CPB-1201 Only show attended outcomes when creating an appointment

### DIFF
--- a/integration_tests/pages/appointments/attendanceOutcomePage.ts
+++ b/integration_tests/pages/appointments/attendanceOutcomePage.ts
@@ -21,6 +21,10 @@ export default class AttendanceOutcomePage extends BaseAppointmentFormPage {
     this.notesQuestions.completeForm(expectIsSensitiveQuestion)
   }
 
+  shouldNotShowOutcome(contactOutcomeCode: string) {
+    this.contactOutcomeOptions.shouldNotHaveVisibleOptionWithValue(contactOutcomeCode)
+  }
+
   protected override customCheckOnPage(): void {
     cy.get('legend').should('contain.text', 'Log attendance')
   }

--- a/integration_tests/pages/components/radioOrCheckboxGroupComponent.ts
+++ b/integration_tests/pages/components/radioOrCheckboxGroupComponent.ts
@@ -32,4 +32,8 @@ export default class RadioOrCheckboxGroupComponent {
   shouldNotBeVisible() {
     this.getAll().should('not.exist')
   }
+
+  shouldNotHaveVisibleOptionWithValue(value: string): void {
+    cy.get(`input[name="${this.name}"][value="${value}"]`).should('not.exist')
+  }
 }

--- a/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
@@ -15,11 +15,9 @@
 //    When I submit the form
 //    Then I see the log hours page
 
-// Scenario: can complete the form for a non-attended outcome
+// Scenario: should not show non-attended outcomes
 //    Given I am on the attendance outcome page for a new appointment
-//    And I select a non-attended outcome
-//    When I submit the form
-//    Then I see the confirm details page
+//    Then I should not see non-attended outcomes
 
 // Scenario: can navigate back to the previous page
 //    Given I am on the attendance outcome page for a new appointment
@@ -38,7 +36,6 @@ import projectOutcomeSummaryFactory from '../../../../server/testutils/factories
 import providerTeamSummaryFactory from '../../../../server/testutils/factories/providerTeamSummaryFactory'
 import AttendanceOutcomePage from '../../../pages/appointments/attendanceOutcomePage'
 import ChooseProjectPage from '../../../pages/appointments/chooseProjectPage'
-import ConfirmDetailsPage from '../../../pages/appointments/confirmDetailsPage'
 import LogHoursPage from '../../../pages/appointments/logHoursPage'
 import Page from '../../../pages/page'
 
@@ -101,27 +98,20 @@ context('Create appointment - Attendance outcome', () => {
     Page.verifyOnPage(LogHoursPage, { offender: this.offender })
   })
 
-  // Scenario: can complete the form for a non-attended outcome
-  it('can submit the form and continue to confirm details when not attended', function test() {
-    const notAttendedOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+  // Scenario: should not show non-attended outcomes
+  it('should not show non-attended outcomes', function test() {
+    const nonAttendedOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+    const attendedOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
     cy.task('stubGetContactOutcomes', {
-      contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [notAttendedOutcome] }),
+      contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [nonAttendedOutcome, attendedOutcome] }),
     })
     cy.task('stubSaveAppointmentForm')
 
     // Given I am on the attendance outcome page for a new appointment
     const page = AttendanceOutcomePage.visitForCreateAppointment(this.project.projectCode, this.offender)
 
-    // And I select a non-attended outcome
-    page.completeForm(notAttendedOutcome.code)
-
-    // When I submit the form
-    cy.task('stubFindProject', { project: this.project })
-
-    page.clickSubmit()
-
-    // Then I see the confirm details page
-    Page.verifyOnPage(ConfirmDetailsPage, { offender: this.offender })
+    // Then I should not see non-attended outcomes
+    page.shouldNotShowOutcome(nonAttendedOutcome.code)
   })
 
   // Scenario: can navigate back to the previous page

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -298,7 +298,12 @@ context('Create appointment - Confirm details', () => {
     })
 
     it('navigates to the attendance outcome page when editing outcome', function test() {
-      const contactOutcomes = contactOutcomesFactory.build()
+      const contactOutcomes = contactOutcomesFactory.build({
+        contactOutcomes: [
+          contactOutcomeFactory.build({ attended: true }),
+          contactOutcomeFactory.build({ attended: true }),
+        ],
+      })
       const [selected] = contactOutcomes.contactOutcomes
 
       const form = createAppointmentFormFactory.build({

--- a/server/controllers/appointments/attendanceOutcomeController.test.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.test.ts
@@ -19,7 +19,11 @@ describe('AttendanceOutcomeController', () => {
   const appointmentId = '1'
   const contactOutcomes = contactOutcomesFactory.build()
 
-  const request = createMock<Request>({ params: { appointmentId }, query: { form: 'some-id' }, body: undefined })
+  const request = createMock<Request>({
+    params: { appointmentId },
+    query: { form: 'some-id' },
+    body: undefined,
+  })
   const response = createMock<Response>({ locals: { user: { username: userName } } })
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 

--- a/server/controllers/appointments/attendanceOutcomeController.ts
+++ b/server/controllers/appointments/attendanceOutcomeController.ts
@@ -28,9 +28,19 @@ export default class AttendanceOutcomeController extends BaseAppointmentControll
     return 'appointments/update/attendanceOutcome'
   }
 
-  protected async getContextData({ res, form }: ContextDataParams): Promise<AttendanceOutcomeContext> {
+  protected async getContextData({
+    res,
+    form,
+    excludeNonAttendedOutcomes,
+  }: ContextDataParams): Promise<AttendanceOutcomeContext> {
     const outcomes = await this.referenceDataService.getAvailableContactOutcomes(res.locals.user.username)
-    return { contactOutcomes: outcomes.contactOutcomes, form }
+    let { contactOutcomes } = outcomes
+
+    if (excludeNonAttendedOutcomes) {
+      contactOutcomes = outcomes.contactOutcomes.filter(outcome => outcome.attended)
+    }
+
+    return { contactOutcomes, form }
   }
 
   protected async getStepViewData({

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -34,6 +34,7 @@ export type ContextDataParams = {
   res: Response
   form: AppointmentOutcomeForm
   appointmentOrSession?: AppointmentOrSession
+  excludeNonAttendedOutcomes?: boolean
 }
 
 export default abstract class BaseAppointmentController<
@@ -55,7 +56,7 @@ export default abstract class BaseAppointmentController<
         appointmentId: NEW_APPOINTMENT_ID,
         date: form.date,
       }
-      const contextData = await this.getContextData({ req, res, form })
+      const contextData = await this.getContextData({ req, res, form, excludeNonAttendedOutcomes: true })
 
       const paths = this.page.paths({
         pathData: appointmentParams,


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1201?atlOrigin=eyJpIjoiN2FhZjBjNjQ5MTcwNGVjN2E5ZWZmYWQ3NTJhNzY5NDMiLCJwIjoiaiJ9)

## Context
We're going on the assumption that if a case admin is creating an appointment it will be to log somebody who has attended, therefore, we can remove the non-attended outcomes from this page.

### Screenshots of UI changes

#### Create appointment - attendance
<img width="1294" height="1048" alt="Screenshot 2026-08-10 at 17 05 40" src="https://github.com/user-attachments/assets/9289a939-a956-47fc-8fab-ddc47471b5d1" />

#### Update appointment - attendance
<img width="1296" height="1282" alt="image" src="https://github.com/user-attachments/assets/7ad5056b-00fa-47e7-8b8f-69d71da095a6" />

## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
