### PR TITLE
CPB-1024: Remove default start and end times from create appointment form

### DIFF
--- a/e2e-tests/tests/individual-placements/create_appointment.spec.ts
+++ b/e2e-tests/tests/individual-placements/create_appointment.spec.ts
@@ -46,6 +46,7 @@ test('Create an appointment for individual placement session', async ({
   const attendanceOutcomePage = await completeChooseProject(page, chooseProjectPage)
 
   const logHoursPage = await completeAttendedCompliedOutcome(page, attendanceOutcomePage)
+  await logHoursPage.enterStartAndEndTime(project.availability)
   await logHoursPage.continue()
 
   await completeCompliance(page)

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -7,9 +7,11 @@ import Offender from '../../../server/models/offender'
 import { AppointmentOutcomeForm } from '../../../server/services/forms/appointmentFormService'
 
 export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
+  private readonly outcomeErrorMessage = 'You can only create appointments with an attended outcome'
+
   protected override page: AppointmentFormPage = 'confirm-details'
 
-  private readonly formDetails: SummaryListComponent
+  readonly formDetails: SummaryListComponent
 
   readonly alertPractitionerQuestion: RadioOrCheckboxGroupComponent
 
@@ -99,6 +101,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     cy.get('h2').first().should('have.text', 'Confirm details')
   }
 
+  clickOutcomeError() {
+    cy.get(`[role="alert"]`).find('a').contains(this.outcomeErrorMessage).click()
+  }
+
   clickChange(label: string, options?: { exact: boolean }) {
     this.formDetails.clickActionWithLabel(label, options)
   }
@@ -111,6 +117,10 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
 
   shouldShowAlertPractitionerError() {
     cy.get(`[data-cy-error-alertpractitioner]`).should('contain', 'Choose whether you want to send an alert')
+  }
+
+  shouldShowAttendedOutcomeError() {
+    this.shouldShowErrorSummary('outcome', this.outcomeErrorMessage)
   }
 
   shouldNotShowChangeLink(label: string) {

--- a/integration_tests/pages/appointments/confirmDetailsPage.ts
+++ b/integration_tests/pages/appointments/confirmDetailsPage.ts
@@ -103,7 +103,7 @@ export default class ConfirmDetailsPage extends BaseAppointmentFormPage {
     this.formDetails.clickActionWithLabel(label, options)
   }
 
-  override shouldShowErrorSummary(message: string) {
+  shouldShowAPIError(message: string) {
     cy.get('[data-testid="error-summary"]').within(() => {
       cy.get('li').contains(message)
     })

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -32,6 +32,10 @@ export default class SummaryListComponent {
     this.component().should('not.exist')
   }
 
+  shouldHaveFocusOnAction(label: string) {
+    this.getValueWithLabel(label).next('dd').find('a').should('have.focus')
+  }
+
   private component() {
     return this.title ? cy.get('.govuk-summary-card').filter(`:contains(${this.title})`) : cy.get('dl')
   }

--- a/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
+++ b/integration_tests/pages/courseCompletions/process/confirmDetailsPage.ts
@@ -84,7 +84,7 @@ export default class ConfirmDetailsPage extends BaseCourseCompletionsPage {
     this.formDetails.getValueWithLabel('Sensitive').should('contain.text', value)
   }
 
-  override shouldShowErrorSummary(message: string) {
+  shouldShowAPIError(message: string) {
     cy.get('[data-testid="error-summary"]').within(() => {
       cy.get('li').contains(message)
     })

--- a/integration_tests/tests/appointments/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/confirmDetails.cy.ts
@@ -769,7 +769,7 @@ context('Confirm appointment details page', () => {
       page.clickSubmit('Confirm')
 
       // Then I can see the error message
-      page.shouldShowErrorSummary(userMessage)
+      page.shouldShowAPIError(userMessage)
     })
 
     // Scenario: submitting a new appointment that fails validation

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -527,7 +527,7 @@ context('Create appointment - Confirm details', () => {
       page.clickSubmit('Confirm')
 
       // Then I see the error message
-      page.shouldShowErrorSummary(userMessage)
+      page.shouldShowAPIError(userMessage)
     })
 
     // Scenario: submitting a new appointment that fails validation

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -471,10 +471,13 @@ context('Create appointment - Confirm details', () => {
     })
 
     it('creates the appointment for a non-attended outcome and shows the session page with a success message', function test() {
+      // No start or end time is entered for a non-attended outcome, so the form has none saved
       const form = createAppointmentFormFactory.build({
         crn: this.offender.crn,
         project: { code: this.project.projectCode, name: this.project.projectName },
         contactOutcome: contactOutcomeFactory.build({ attended: false }),
+        startTime: undefined,
+        endTime: undefined,
       })
       cy.task('stubGetAppointmentForm', form)
       cy.task('stubCreateAppointment')

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -49,10 +49,10 @@
 //    And I see the session page with a success message
 
 // Scenario: submitting a new appointment - not attended
-//    Given I am on the confirm page for a new appointment
+//    Given I am on the confirm page for a new appointment with a non-attended outcome
 //    When I click confirm
-//    Then the appointment is created
-//    And I see the session page with a success message
+//    Then I see the error message
+//    And clicking the error focuses the Change link for the outcome
 
 // Scenario: submitting a new appointment that fails validation
 //    Given I am on the confirm page for a new appointment
@@ -470,7 +470,7 @@ context('Create appointment - Confirm details', () => {
       viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
     })
 
-    it('creates the appointment for a non-attended outcome and shows the session page with a success message', function test() {
+    it('shows an error message when the contact outcome is not attended', function test() {
       // No start or end time is entered for a non-attended outcome, so the form has none saved
       const form = createAppointmentFormFactory.build({
         crn: this.offender.crn,
@@ -480,16 +480,9 @@ context('Create appointment - Confirm details', () => {
         endTime: undefined,
       })
       cy.task('stubGetAppointmentForm', form)
-      cy.task('stubCreateAppointment')
+      cy.task('stubFindProject', { project: this.project })
 
-      const session = sessionFactory.build({
-        date: form.date,
-        projectCode: this.project.projectCode,
-        projectName: this.project.projectName,
-      })
-      cy.task('stubFindSession', { session })
-
-      // Given I am on the confirm page for a new appointment
+      // Given I am on the confirm page for a new appointment with a non-attended outcome
       const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
 
       // When I choose to send an alert to the practitioner
@@ -498,10 +491,12 @@ context('Create appointment - Confirm details', () => {
       // When I click confirm
       page.clickSubmit('Confirm')
 
-      // Then the appointment is created
-      // And I see the session page with a success message
-      const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
-      viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+      // Then I see the error message
+      page.shouldShowAttendedOutcomeError()
+
+      // And clicking the error focuses the Change link for the outcome
+      page.clickOutcomeError()
+      page.formDetails.shouldHaveFocusOnAction('Outcome')
     })
 
     // Scenario: submitting a new appointment that fails validation

--- a/integration_tests/tests/appointments/create/logHours.cy.ts
+++ b/integration_tests/tests/appointments/create/logHours.cy.ts
@@ -20,6 +20,11 @@
 //    When I click back
 //    Then I see the attendance outcome page
 
+// Scenario: does not pre-fill the start and end time
+//    Given I am on the log hours page for a new appointment
+//    And no start or end time has been entered yet
+//    Then the start and end time fields are empty
+
 import {
   contactOutcomeFactory,
   contactOutcomesFactory,
@@ -106,5 +111,23 @@ context('Create appointment - Log hours', () => {
     // Then I see the attendance outcome page
     const attendancePage = Page.verifyOnPage(AttendanceOutcomePage, { offender: this.offender })
     attendancePage.contactOutcomeOptions.shouldHaveSelectedValue(this.form.contactOutcome.code)
+  })
+
+  // Scenario: does not pre-fill the start and end time
+  it('does not pre-fill the start and end time', function test() {
+    const form = createAppointmentFormFactory.build({
+      crn: this.offender.crn,
+      contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      startTime: undefined,
+      endTime: undefined,
+    })
+    cy.task('stubGetAppointmentForm', form)
+
+    // Given I am on the log hours page for a new appointment
+    // And no start or end time has been entered yet
+    const page = LogHoursPage.visitForCreateAppointment(this.project.projectCode, this.offender)
+
+    // Then the start and end time fields are empty
+    page.shouldShowEnteredTimes({ startTime: '', endTime: '' })
   })
 })

--- a/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
+++ b/integration_tests/tests/courseCompletions/process/confirmDetails.cy.ts
@@ -462,7 +462,7 @@ context('Confirm details page', () => {
       page.clickSubmit()
 
       // Then I can see the error message
-      page.shouldShowErrorSummary(userMessage)
+      page.shouldShowAPIError(userMessage)
     })
 
     it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {

--- a/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
+++ b/integration_tests/tests/group-sessions/bulk-update/confirmDetails.cy.ts
@@ -256,7 +256,7 @@ context('Group Session Bulk Update - Confirm appointment details page', () => {
 
     page.clickSubmit('Confirm')
 
-    page.shouldShowErrorSummary(userMessage)
+    page.shouldShowAPIError(userMessage)
   })
 
   it('shows an error message when submission fails because no option was selected for the alert practitioner options', function test() {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -154,7 +154,12 @@ export type GovUkStatusTagColour = 'grey' | 'red' | 'yellow' | 'green' | 'teal'
 export type GovUKValue = { text?: string; html?: string }
 export type GovUkTitleValue = GovUKValue & { headingLevel?: number }
 
-export type GovUKActionItem = { href: string; text: string; visuallyHiddenText: string }
+export type GovUKActionItem = {
+  href: string
+  text: string
+  visuallyHiddenText: string
+  attributes?: Record<string, string>
+}
 
 export type GovUkSummaryList = {
   card?: {

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -9,7 +9,6 @@ import AppointmentFormService from '../../services/forms/appointmentFormService'
 import appointmentOutcomeFormFactory from '../../testutils/factories/appointmentOutcomeFormFactory'
 import { contactOutcomeFactory } from '../../testutils/factories/contactOutcomeFactory'
 import projectFactory from '../../testutils/factories/projectFactory'
-import projectAvailabilityFactory from '../../testutils/factories/projectAvailabilityFactory'
 import ProjectService from '../../services/projectService'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
 import * as ErrorUtils from '../../utils/errorUtils'
@@ -376,14 +375,11 @@ describe('ConfirmController', () => {
         )
       })
 
-      it('uses the project default availability when the outcome is not attended, ignoring any edited form value', async () => {
+      it('submits undefined when the outcome is not attended, ignoring any edited form value', async () => {
         mockPageInstance.exitForm.mockReturnValue('next')
         mockPageInstance.isAlertSelected.mockReturnValue(true)
 
-        const project = projectFactory.build({
-          projectCode,
-          availability: [projectAvailabilityFactory.build({ startTime: '09:00', endTime: '11:00' })],
-        })
+        const project = projectFactory.build({ projectCode })
         const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
         const requestWithNewAppointment = createMock<Request>({
           params: { projectCode },
@@ -407,10 +403,7 @@ describe('ConfirmController', () => {
         await requestHandler(requestWithNewAppointment, response, next)
 
         expect(appointmentService.createAppointment).toHaveBeenCalledWith(
-          expect.objectContaining({
-            startTime: project.availability[0].startTime,
-            endTime: project.availability[0].endTime,
-          }),
+          expect.objectContaining({ startTime: undefined, endTime: undefined }),
           'user-name',
         )
       })

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -169,13 +169,12 @@ export default class ConfirmController implements IAppointmentFormPageController
       }
 
       const didAttend = form.contactOutcome.attended
-      const defaultAvailability = project.availability[0]
 
       const payload = {
         ...NotesUtils.requestBody(form, undefined, true),
         alertActive: page.isAlertSelected(req.body),
-        startTime: didAttend ? form.startTime : defaultAvailability?.startTime,
-        endTime: didAttend ? form.endTime : defaultAvailability?.endTime,
+        startTime: didAttend ? form.startTime : undefined,
+        endTime: didAttend ? form.endTime : undefined,
         contactOutcomeCode: form.contactOutcome.code,
         attendanceData: didAttend ? form.attendanceData : undefined,
         supervisorOfficerCode: form.supervisor.code,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -142,7 +142,10 @@ export default class ConfirmController implements IAppointmentFormPageController
         crn: (form as CreateAppointmentForm).crn,
       })
 
-      const { errors, hasErrors, errorSummary } = page.validationErrors(req.body)
+      const { errors, hasErrors, errorSummary } = page.validationErrors(req.body, {
+        form,
+        outcomeShouldBeAttended: true,
+      })
       const preventDoubleClick = true
       const pathData = { ...appointmentParams, date: form.date }
 
@@ -222,7 +225,10 @@ export default class ConfirmController implements IAppointmentFormPageController
       const formId = _req.body.form?.toString()
       const form = await this.appointmentFormService.getForm(formId, res.locals.user.username)
 
-      const { errors, hasErrors, errorSummary } = page.validationErrors(_req.body)
+      const { errors, hasErrors, errorSummary } = page.validationErrors(_req.body, {
+        form,
+        outcomeShouldBeAttended: false,
+      })
       const preventDoubleClick = true
       const pathData = { ...appointmentOrSessionParams, date: this.getDate(appointmentOrSession) }
 

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -204,6 +204,7 @@ describe('ConfirmPage', () => {
                 href: pathWithQuery,
                 text: 'Change',
                 visuallyHiddenText: 'attendance outcome',
+                attributes: { id: 'outcome' },
               },
             ],
           },
@@ -297,6 +298,7 @@ describe('ConfirmPage', () => {
                 href: pathWithQuery,
                 text: 'Change',
                 visuallyHiddenText: 'attendance outcome',
+                attributes: { id: 'outcome' },
               },
             ],
           },
@@ -558,6 +560,7 @@ describe('ConfirmPage', () => {
                 href: pathWithQuery,
                 text: 'Change',
                 visuallyHiddenText: 'attendance outcome',
+                attributes: { id: 'outcome' },
               },
             ],
           },
@@ -1098,8 +1101,11 @@ describe('ConfirmPage', () => {
   describe('validationErrors', () => {
     it('returns error when no alert option is selected', () => {
       const page = new ConfirmPage()
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
 
-      const { errors } = page.validationErrors({ alertPractitioner: undefined })
+      const { errors } = page.validationErrors({ alertPractitioner: undefined }, { form })
       expect(errors).toEqual({
         alertPractitioner: { text: 'Choose whether you want to send an alert' },
       })
@@ -1107,7 +1113,54 @@ describe('ConfirmPage', () => {
     it('returns no error when an alert option is selected', () => {
       const page = new ConfirmPage()
 
-      const { errors } = page.validationErrors({ alertPractitioner: 'yes' })
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' }, { form })
+
+      expect(errors).toEqual({})
+    })
+
+    it('returns error when contact outcome did not attend and outcome should be attended', () => {
+      const page = new ConfirmPage()
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' }, { form, outcomeShouldBeAttended: true })
+      expect(errors).toEqual({
+        outcome: { text: 'You can only create appointments with an attended outcome' },
+      })
+    })
+
+    it('returns error when contact outcome is undefined and outcome should be attended', () => {
+      const page = new ConfirmPage()
+      const form = appointmentOutcomeFormFactory.build({ contactOutcome: undefined })
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' }, { form, outcomeShouldBeAttended: true })
+      expect(errors).toEqual({
+        outcome: { text: 'You can only create appointments with an attended outcome' },
+      })
+    })
+
+    it('returns no error when contact outcome did not attend and outcome should not be attended', () => {
+      const page = new ConfirmPage()
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' }, { form, outcomeShouldBeAttended: false })
+      expect(errors).toEqual({})
+    })
+
+    it('defaults outcomeShouldBeAttended to false when not provided', () => {
+      const page = new ConfirmPage()
+      const form = appointmentOutcomeFormFactory.build({
+        contactOutcome: contactOutcomeFactory.build({ attended: false }),
+      })
+
+      const { errors } = page.validationErrors({ alertPractitioner: 'yes' }, { form })
       expect(errors).toEqual({})
     })
   })

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -33,22 +33,30 @@ interface ViewData {
 
 interface Query {
   alertPractitioner?: YesOrNo
+  outcome?: string
 }
 
 type ItemsOptions = { includeDateItem: boolean }
+type ValidationContext = { form: AppointmentOutcomeForm; outcomeShouldBeAttended?: boolean }
 
-export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
+export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, ValidationContext> {
   protected page: AppointmentPage = 'confirm-details'
 
   protected getForm(form: AppointmentOutcomeForm): AppointmentOutcomeForm {
     return form
   }
 
-  protected getValidationErrors(query: Query, _additionalParams?: unknown): ValidationErrors<Query> {
+  protected getValidationErrors(query: Query, additionalParams?: ValidationContext): ValidationErrors<Query> {
+    const outcomeShouldBeAttended = additionalParams?.outcomeShouldBeAttended ?? false
+    const form = additionalParams?.form
     const validationErrors: ValidationErrors<Query> = {}
 
     if (!query.alertPractitioner) {
       validationErrors.alertPractitioner = { text: 'Choose whether you want to send an alert' }
+    }
+
+    if (outcomeShouldBeAttended && !form?.contactOutcome?.attended) {
+      validationErrors.outcome = { text: 'You can only create appointments with an attended outcome' }
     }
 
     return validationErrors
@@ -249,6 +257,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query> {
                 href: this.buildPath(pathData, 'attendance-outcome', formId),
                 text: 'Change',
                 visuallyHiddenText: 'attendance outcome',
+                attributes: { id: 'outcome' },
               },
             ],
           },

--- a/server/services/forms/appointmentFormService.test.ts
+++ b/server/services/forms/appointmentFormService.test.ts
@@ -145,8 +145,6 @@ describe('AppointmentFormService', () => {
         projectTeam: { code: project.teamCode, name: project.teamName },
         project: { code: project.projectCode, name: project.projectName },
         date,
-        startTime: project.availability[0].startTime,
-        endTime: project.availability[0].endTime,
       }
 
       expect(formClient.save).toHaveBeenCalledWith(

--- a/server/services/forms/appointmentFormService.ts
+++ b/server/services/forms/appointmentFormService.ts
@@ -126,8 +126,6 @@ export default class AppointmentFormService extends BaseFormService<AppointmentO
       key: this.getFormKey(randomUUID()),
       data: {
         ...this.projectData(project),
-        startTime: project.availability[0].startTime,
-        endTime: project.availability[0].endTime,
         originalSearch: query,
         crn,
         deliusEventNumber,


### PR DESCRIPTION
## Context

Removes reliance on project “availability” start/end times when creating appointments, so time is no longer pre-populated with project availability defaults.

As start and end times could now be undefined, adding pre-submit validation that an outcome must be attended, to prevent sending undefined times. This is also enforced by #714.

[CPB-1024](https://dsdmoj.atlassian.net/browse/CPB-1204)

## Changes in this PR

- Stop pre-populating new appointment forms with project.availability[0].startTime/endTime.
- Add confirm-page validation to prevent creating appointments with a non-attended outcome, and add an id attribute to the “Outcome” change link to support error-summary focus. This may be slight overkill, and unreachable once (#714 is merged), but masks a not very helpful API error should start and end times e undefined given a non-attended route.

### Screenshots of UI changes

Start and end times are always blank for create an appointment: 
<img width="1495" height="852" alt="Log hours page of create an appointment form" src="https://github.com/user-attachments/assets/880d3966-2a39-4c03-aecf-c0943ea1448c" />

validation error prevents submit if a non-attended outcome is selected for a new appointment:

https://github.com/user-attachments/assets/a0631164-5d10-4882-a793-d4c4dedcf351


## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1024]: https://dsdmoj.atlassian.net/browse/CPB-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ