### PR TITLE
CPB-1191: Disallow `<` and `>` characters in notes

### DIFF
--- a/server/pages/appointments/attendanceOutcomePage.test.ts
+++ b/server/pages/appointments/attendanceOutcomePage.test.ts
@@ -245,6 +245,22 @@ describe('AttendanceOutcomePage', () => {
           text: 'Notes must be 4000 characters or less',
         })
       })
+
+      it.each(['<', '>'])('should have errors if notes contains disallowed character %s', (character: string) => {
+        const notes = faker.string.alpha(100) + character
+        const page = new AttendanceOutcomePage()
+
+        const { errors } = page.validationErrors(
+          { attendanceOutcome: contactOutcomes[0].code, notes },
+          {
+            form: appointmentOutcomeFormFactory.build(),
+            contactOutcomes,
+          },
+        )
+        expect(errors.notes).toEqual({
+          text: 'Remove any < and > characters from the notes',
+        })
+      })
     })
   })
 

--- a/server/pages/appointments/attendanceOutcomePage.ts
+++ b/server/pages/appointments/attendanceOutcomePage.ts
@@ -74,8 +74,12 @@ export default class AttendanceOutcomePage extends BaseAppointmentUpdatePage<
       }
     }
 
-    if (body.notes && body.notes.length > 4000) {
-      validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
+    if (body.notes) {
+      if (body.notes.length > 4000) {
+        validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
+      } else if (body.notes.match(/<|>/g)) {
+        validationErrors.notes = { text: 'Remove any < and > characters from the notes' }
+      }
     }
 
     return validationErrors

--- a/server/pages/courseCompletions/process/outcomePage.test.ts
+++ b/server/pages/courseCompletions/process/outcomePage.test.ts
@@ -199,6 +199,24 @@ describe('OutcomePage', () => {
         })
         expect(result.hasErrors).toBe(true)
       })
+
+      it.each(['<', '>'])('should return an error if notes contains disallowed character %s', (character: string) => {
+        jest.spyOn(GovukFrontendDateInput, 'dateIsComplete').mockReturnValue(true)
+        jest.spyOn(GovukFrontendDateInput, 'dateIsValid').mockReturnValue(true)
+        const notes = 'a'.repeat(100) + character
+        const result = page.validationErrors({
+          hours: '2',
+          minutes: '20',
+          'date-day': '01',
+          'date-month': '05',
+          'date-year': '2025',
+          notes,
+        })
+        expect(result.errors.notes).toEqual({
+          text: 'Remove any < and > characters from the notes',
+        })
+        expect(result.hasErrors).toBe(true)
+      })
     })
   })
 

--- a/server/pages/courseCompletions/process/outcomePage.ts
+++ b/server/pages/courseCompletions/process/outcomePage.ts
@@ -66,8 +66,12 @@ export default class OutcomePage extends BaseCourseCompletionFormPage<OutcomePag
   private getNotesErrors(body: OutcomePageBody) {
     const validationErrors = {} as ValidationErrors<OutcomePageBody>
 
-    if (body.notes && body.notes.length > 4000) {
-      validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
+    if (body.notes) {
+      if (body.notes.length > 4000) {
+        validationErrors.notes = { text: 'Notes must be 4000 characters or less' }
+      } else if (body.notes.match(/<|>/g)) {
+        validationErrors.notes = { text: 'Remove any < and > characters from the notes' }
+      }
     }
 
     return validationErrors

--- a/server/views/partials/notesQuestions.njk
+++ b/server/views/partials/notesQuestions.njk
@@ -6,7 +6,7 @@
   id: "notes",
   value: notes,
   hint: {
-    text: "Write clearly and concisely. Include any practical details, positive progress, support needs, incidents, behaviour or work quality."
+    text: "Write clearly and concisely. Include any practical details, positive progress, support needs, incidents, behaviour or work quality. Do not use the characters < or >."
   },
   errorMessage: errors.notes,
   label: {


### PR DESCRIPTION
## Context

See [CPB-1191](https://dsdmoj.atlassian.net/browse/CPB-1191).

Currently, users sometimes include copied emails in the notes field when recording appointment outcomes, which causes a user-unfriendly error message upon submission of the appointment:

<img width="1183" height="201" alt="" src="https://github.com/user-attachments/assets/d62c14f5-adb0-4bdf-a41d-fbacbbf50ebd" />

Providing more understandable feedback to the user at the point where they add notes will improve their experience.

## Changes in this PR

- Recording an appointment outcome now returns a validation error to the user if angle brackets are used within the notes field.
- The hint text has been updated to tell the user that angle brackets are disallowed before they encounter the error.

### Screenshots of UI changes

For a single update:
<img width="2978" height="4204" alt="" src="https://github.com/user-attachments/assets/3489b10a-91ca-4089-98d6-344b0f34e2e4" />

For a bulk update:
<img width="2978" height="4340" alt="" src="https://github.com/user-attachments/assets/fa26c69d-b82e-4a3e-a3d3-5bc2e1085e92" />


## Pre merge

- [x] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1191]: https://dsdmoj.atlassian.net/browse/CPB-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ