### PR TITLE
CPB-1175: Add back link to no requirements found page

### DIFF
--- a/server/views/pages/noRequirements.njk
+++ b/server/views/pages/noRequirements.njk
@@ -1,7 +1,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {%- from "moj/components/alert/macro.njk" import mojAlert -%}
 
 {% extends "../partials/layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
## Context

Adds a back link to the no requirements found page.

[CPB-1175](https://dsdmoj.atlassian.net/browse/CPB-1175)

## Changes in this PR

We were already passing a back link to this template (for use in the `Find another person` link), so we simply need to add the nunjucks macro for the back link to make this work.

### Screenshots of UI changes


https://github.com/user-attachments/assets/10c2a540-e254-44b5-8e22-af2c54670bce



## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->


[CPB-1175]: https://dsdmoj.atlassian.net/browse/CPB-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ