### PR TITLE
Ensure only attended outcomes appear when validating create attendance page

### DIFF
--- a/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
+++ b/integration_tests/tests/appointments/create/attendanceOutcome.cy.ts
@@ -66,6 +66,11 @@ context('Create appointment - Attendance outcome', () => {
 
   // Scenario: Validating the attendance outcome page
   it('shows validation messages', function test() {
+    const nonAttendedOutcome = contactOutcomeFactory.build({ attended: false, enforceable: false })
+    const attendedOutcome = contactOutcomeFactory.build({ attended: true, enforceable: false })
+    cy.task('stubGetContactOutcomes', {
+      contactOutcomes: contactOutcomesFactory.build({ contactOutcomes: [nonAttendedOutcome, attendedOutcome] }),
+    })
     // Given I am on the attendance outcome page for a new appointment
     const page = AttendanceOutcomePage.visitForCreateAppointment(this.project.projectCode, this.offender)
 
@@ -74,6 +79,7 @@ context('Create appointment - Attendance outcome', () => {
     page.clickSubmit()
 
     // Then I see the same page with errors
+    page.shouldNotShowOutcome(nonAttendedOutcome.code)
     page.shouldShowErrorSummary('attendanceOutcome', 'Select an attendance outcome')
   })
 

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -139,7 +139,7 @@ export default abstract class BaseAppointmentController<
         crn: (form as CreateAppointmentForm).crn,
       })
 
-      const contextData = await this.getContextData({ req, res, form })
+      const contextData = await this.getContextData({ req, res, form, excludeNonAttendedOutcomes: true })
       const { errors, hasErrors, errorSummary } = this.page.validationErrors(req.body, contextData)
 
       if (hasErrors) {


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-1201?atlOrigin=eyJpIjoiNmIyM2U1MmE1OGM2NDlmMmIyMDQ4ODg4NjQ4N2ZjNTkiLCJwIjoiaiJ9)

## Context
In an earlier change the attendance page was updated to only show attended outcomes. This needs to be reflected when re-rendering the page after a failed validation.

<!-- Include a brief description of why the change is needed and what it does (which doesn't need a ticket to explain it) -->
<!-- Is there a JIRA ticket you can link to? -->

### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
