### PR TITLE
Spike/rework create paths

### DIFF
--- a/integration_tests/pages/appointments/baseAppointmentFormPage.ts
+++ b/integration_tests/pages/appointments/baseAppointmentFormPage.ts
@@ -53,14 +53,30 @@ export default abstract class BaseAppointmentFormPage extends Page {
     return page
   }
 
-  protected createAppointmentPath = (projectCode: string) =>
-    pathWithQuery(
-      paths.appointments.create({
+  static visitForSessionCreateAppointment<T extends BaseAppointmentFormPage, A extends unknown[]>(
+    this: new (offender: Pick<AppointmentDto, 'offender'>, ...args: A) => T,
+    projectCode: string,
+    offender: OffenderDto,
+    date: string,
+    ...args: A
+  ): T {
+    const page = new this({ offender }, ...args)
+    cy.visit(page.createAppointmentPath(projectCode, date))
+    page.checkOnPage()
+    return page
+  }
+
+  protected createAppointmentPath = (projectCode: string, date?: string) => {
+    const namespace = date ? 'sessions' : 'projects'
+    return pathWithQuery(
+      paths[namespace].create.formSteps({
         projectCode,
+        date,
         page: this.page,
       }),
       { form: '123' },
     )
+  }
 
   protected appointmentPath = (appointment: AppointmentDto) =>
     pathWithQuery(

--- a/integration_tests/tests/appointments/create/confirmDetails.cy.ts
+++ b/integration_tests/tests/appointments/create/confirmDetails.cy.ts
@@ -90,6 +90,9 @@ import LogHoursPage from '../../../pages/appointments/logHoursPage'
 import Page from '../../../pages/page'
 import RequirementPage from '../../../pages/requirementPage'
 import ViewSessionPage from '../../../pages/viewSessionPage'
+import ProjectPage from '../../../pages/projects/projectPage'
+import { baseProjectAppointmentRequest } from '../../../mockApis/projects'
+import pagedModelAppointmentSummaryFactory from '../../../../server/testutils/factories/pagedModelAppointmentSummaryFactory'
 
 context('Create appointment - Confirm details', () => {
   beforeEach(() => {
@@ -97,7 +100,7 @@ context('Create appointment - Confirm details', () => {
     cy.task('stubSignIn')
     cy.signIn()
 
-    const project = projectFactory.build()
+    const project = projectFactory.build({ projectType: { group: 'INDIVIDUAL' } })
     cy.wrap(project).as('project')
     cy.task('stubFindProject', { project })
 
@@ -456,7 +459,12 @@ context('Create appointment - Confirm details', () => {
       cy.task('stubFindSession', { session })
 
       // Given I am on the confirm page for a new appointment
-      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+      const page = ConfirmDetailsPage.visitForSessionCreateAppointment(
+        this.project.projectCode,
+        this.offender,
+        form.date,
+        form,
+      )
 
       // When I choose to send an alert to the practitioner
       page.alertPractitionerQuestion.checkOptionWithValue('yes')
@@ -468,6 +476,40 @@ context('Create appointment - Confirm details', () => {
       // And I see the session page with a success message
       const viewSessionPage = Page.verifyOnPage(ViewSessionPage, session)
       viewSessionPage.shouldShowSuccessMessage('Attendance recorded')
+    })
+
+    // Scenario: submitting a new appointment
+    it('creates the appointment for an attended outcome and shows the project page with a success message', function test() {
+      const form = createAppointmentFormFactory.build({
+        crn: this.offender.crn,
+        project: { code: this.project.projectCode, name: this.project.projectName },
+        contactOutcome: contactOutcomeFactory.build({ attended: true }),
+      })
+      cy.task('stubGetAppointmentForm', form)
+      cy.task('stubCreateAppointment')
+
+      // Given I am on the confirm page for a new appointment
+      const page = ConfirmDetailsPage.visitForCreateAppointment(this.project.projectCode, this.offender, form)
+
+      // When I choose to send an alert to the practitioner
+      page.alertPractitionerQuestion.checkOptionWithValue('yes')
+
+      const pagedAppointments = pagedModelAppointmentSummaryFactory.build()
+
+      const request = {
+        ...baseProjectAppointmentRequest(),
+        projectCodes: [this.project.projectCode],
+      }
+
+      cy.task('stubGetAppointments', { request, pagedAppointments })
+
+      // When I click confirm
+      page.clickSubmit('Confirm')
+
+      // Then the appointment is created
+      // And I see the session page with a success message
+      const viewProjectPage = Page.verifyOnPage(ProjectPage, this.project)
+      viewProjectPage.shouldShowSuccessMessage('Attendance recorded')
     })
 
     it('shows an error message when the contact outcome is not attended', function test() {

--- a/server/@types/user-defined/index.d.ts
+++ b/server/@types/user-defined/index.d.ts
@@ -122,6 +122,11 @@ export interface AppointmentOrSessionParams {
   projectCode: string
 }
 
+export interface CreateAppointmentPathParams {
+  projectCode: string
+  date?: string
+}
+
 export interface Session extends ProjectDto {
   appointmentSummaries: Array<AppointmentSummaryDto>
   date: string

--- a/server/controllers/appointments/appointmentsController.test.ts
+++ b/server/controllers/appointments/appointmentsController.test.ts
@@ -35,7 +35,7 @@ describe('AppointmentsController', () => {
   })
 
   describe('create', () => {
-    it('should create a new appointment form and redirect to the choose project page', async () => {
+    it('should create a new appointment form and redirect to the session create path when a date is present', async () => {
       const project = projectFactory.build({ projectCode })
 
       projectService.getProject.mockResolvedValue(project)
@@ -59,7 +59,30 @@ describe('AppointmentsController', () => {
       )
 
       expect(response.redirect).toHaveBeenCalledWith(
-        pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
+        pathWithQuery(paths.sessions.create.formSteps({ projectCode, date, page: 'date' }), {
+          form: formId,
+        }),
+      )
+    })
+
+    it('should redirect to the project create path when no date is present', async () => {
+      const project = projectFactory.build({ projectCode })
+      const requestWithoutDate = createMock<Request>({
+        params: { crn, deliusEventNumber, projectCode },
+        query: { provider: 'provider-code' },
+      })
+
+      projectService.getProject.mockResolvedValue(project)
+      formService.createNewAppointmentForm.mockResolvedValue({
+        key: { id: formId, type: APPOINTMENT_UPDATE_FORM_TYPE },
+        data: undefined,
+      })
+
+      const requestHandler = controller.create()
+      await requestHandler(requestWithoutDate, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        pathWithQuery(paths.projects.create.formSteps({ projectCode, page: 'date' }), {
           form: formId,
         }),
       )
@@ -89,7 +112,7 @@ describe('AppointmentsController', () => {
       })
 
       expect(response.redirect).toHaveBeenCalledWith(
-        pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
+        pathWithQuery(paths.sessions.create.formSteps({ projectCode, date, page: 'date' }), {
           form: formId,
         }),
       )

--- a/server/controllers/appointments/appointmentsController.ts
+++ b/server/controllers/appointments/appointmentsController.ts
@@ -41,11 +41,11 @@ export default class AppointmentsController {
         id = newForm.key.id
       }
 
-      res.redirect(
-        pathWithQuery(paths.appointments.create({ projectCode, page: 'date' }), {
-          form: id,
-        }),
-      )
+      const createPath = date
+        ? paths.sessions.create.formSteps({ projectCode, date, page: 'date' })
+        : paths.projects.create.formSteps({ projectCode, page: 'date' })
+
+      res.redirect(pathWithQuery(createPath, { form: id }))
     }
   }
 }

--- a/server/controllers/appointments/baseAppointmentController.test.ts
+++ b/server/controllers/appointments/baseAppointmentController.test.ts
@@ -54,7 +54,7 @@ describe('BaseAppointmentController', () => {
       const heading = { title: 'Some Name', caption: 'X123456' }
 
       formService.getForm.mockResolvedValue(form)
-      page.paths.mockReturnValue(paths)
+      page.createPaths.mockReturnValue(paths)
       offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
       page.offenderHeading.mockReturnValue(heading)
 
@@ -63,11 +63,10 @@ describe('BaseAppointmentController', () => {
 
       expect(formService.getForm).toHaveBeenCalledWith(formId, userName)
 
-      expect(page.paths).toHaveBeenCalledWith({
+      expect(page.createPaths).toHaveBeenCalledWith({
         pathData: {
           projectCode,
-          appointmentId: 'create',
-          date: form.date,
+          date: undefined,
         },
         form,
         formId,
@@ -100,7 +99,7 @@ describe('BaseAppointmentController', () => {
       const heading = { title: 'Some Name', caption: 'X123456' }
 
       formService.getForm.mockResolvedValue(form)
-      page.paths.mockReturnValue(paths)
+      page.createPaths.mockReturnValue(paths)
       page.validationErrors.mockReturnValue({ errors, hasErrors: true, errorSummary })
       offenderService.getOffenderSummary.mockResolvedValue(caseDetailsSummary)
       page.offenderHeading.mockReturnValue(heading)
@@ -128,10 +127,10 @@ describe('BaseAppointmentController', () => {
       const nextPath = '/next-page'
 
       formService.getForm.mockResolvedValue(form)
-      page.paths.mockReturnValue(paths)
+      page.createPaths.mockReturnValue(paths)
       page.validationErrors.mockReturnValue({ errors: {}, hasErrors: false, errorSummary: [] })
       page.updateForm.mockReturnValue(updatedForm)
-      page.next.mockReturnValue(nextPath)
+      page.nextForCreate.mockReturnValue(nextPath)
 
       const requestHandler = controller.submitCreate()
       await requestHandler(requestWithBody, response, next)
@@ -139,10 +138,9 @@ describe('BaseAppointmentController', () => {
       expect(page.updateForm).toHaveBeenCalledWith(form, body, {})
       expect(formService.saveForm).toHaveBeenCalledWith(formId, userName, updatedForm)
 
-      expect(page.next).toHaveBeenCalledWith({
+      expect(page.nextForCreate).toHaveBeenCalledWith({
         projectCode,
-        appointmentId: 'create',
-        date: form.date,
+        date: undefined,
         form: updatedForm,
         formId,
       })

--- a/server/controllers/appointments/baseAppointmentController.ts
+++ b/server/controllers/appointments/baseAppointmentController.ts
@@ -9,11 +9,11 @@ import SessionService from '../../services/sessionService'
 import {
   AppointmentOrSessionParams,
   AppointmentOrSession,
+  CreateAppointmentPathParams,
   ValidationErrors,
   IAppointmentFormPageController,
 } from '../../@types/user-defined'
 import getAppointmentOrSession from '../shared/getAppointmentOrSession'
-import { NEW_APPOINTMENT_ID } from '../../pages/appointments/pathMap'
 import OffenderService from '../../services/offenderService'
 import { CaseDetailsSummaryDto } from '../../@types/shared'
 
@@ -51,15 +51,14 @@ export default abstract class BaseAppointmentController<
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { formId, form } = await this.getForm(req, res)
-      const appointmentParams = {
+      const pathData: CreateAppointmentPathParams = {
         projectCode: req.params.projectCode.toString(),
-        appointmentId: NEW_APPOINTMENT_ID,
-        date: form.date,
+        date: req.params.date,
       }
       const contextData = await this.getContextData({ req, res, form, excludeNonAttendedOutcomes: true })
 
-      const paths = this.page.paths({
-        pathData: appointmentParams,
+      const paths = this.page.createPaths({
+        pathData,
         form,
         formId,
       })
@@ -123,13 +122,12 @@ export default abstract class BaseAppointmentController<
   submitCreate(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { formId, form } = await this.getForm(req, res)
-      const appointmentParams = {
+      const pathData: CreateAppointmentPathParams = {
         projectCode: req.params.projectCode.toString(),
-        appointmentId: NEW_APPOINTMENT_ID,
-        date: form.date,
+        date: req.params.date,
       }
-      const paths = this.page.paths({
-        pathData: appointmentParams,
+      const paths = this.page.createPaths({
+        pathData,
         form,
         formId,
       })
@@ -168,8 +166,8 @@ export default abstract class BaseAppointmentController<
       await this.appointmentFormService.saveForm(formId, res.locals.user.username, updatedForm)
 
       return res.redirect(
-        this.page.next({
-          ...appointmentParams,
+        this.page.nextForCreate({
+          ...pathData,
           form: updatedForm,
           formId,
         }),

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -51,10 +51,11 @@ describe('ConfirmController', () => {
     alertQuestionDetails: jest.Mock
     formItems: jest.Mock
     createFormItems: jest.Mock
-    paths: jest.Mock
+    createPaths: jest.Mock
     offenderHeading: jest.Mock
     isAlertSelected: jest.Mock
     exitForm: jest.Mock
+    exitFormForCreate: jest.Mock
     updatePath: jest.Mock
   }
   let confirmController: ConfirmController
@@ -78,10 +79,11 @@ describe('ConfirmController', () => {
       alertQuestionDetails: jest.fn().mockReturnValue(pageViewData),
       formItems: jest.fn(),
       createFormItems: jest.fn().mockReturnValue([]),
-      paths: jest.fn().mockReturnValue({}),
+      createPaths: jest.fn().mockReturnValue({}),
       offenderHeading: jest.fn().mockReturnValue({ title: 'Some Name', caption: 'X123456' }),
       isAlertSelected: jest.fn().mockReturnValue(true),
       exitForm: jest.fn().mockReturnValue('/default'),
+      exitFormForCreate: jest.fn().mockReturnValue('/default'),
       updatePath: jest.fn().mockReturnValue('/default'),
     }
 
@@ -132,9 +134,9 @@ describe('ConfirmController', () => {
 
       const alertQuestionDetailsSpy = jest.fn().mockReturnValue(pageViewData)
       const createFormItemsSpy = jest.fn().mockReturnValue(submittedItems)
-      const pathsSpy = jest.fn().mockReturnValue(navigationPaths)
+      const createPathsSpy = jest.fn().mockReturnValue(navigationPaths)
       const offenderHeadingSpy = jest.fn().mockReturnValue(heading)
-      mockPageInstance.paths.mockImplementation(pathsSpy)
+      mockPageInstance.createPaths.mockImplementation(createPathsSpy)
       mockPageInstance.alertQuestionDetails.mockImplementation(alertQuestionDetailsSpy)
       mockPageInstance.createFormItems.mockImplementation(createFormItemsSpy)
       mockPageInstance.offenderHeading.mockImplementation(offenderHeadingSpy)
@@ -148,15 +150,15 @@ describe('ConfirmController', () => {
       await requestHandler(request, response, next)
 
       expect(projectService.getProject).toHaveBeenCalledWith({ username: 'user-name', projectCode })
-      expect(pathsSpy).toHaveBeenCalledWith({
-        pathData: { projectCode, appointmentId: 'create' },
+      expect(createPathsSpy).toHaveBeenCalledWith({
+        pathData: { projectCode, date: undefined },
         form,
         formId,
       })
       expect(alertQuestionDetailsSpy).toHaveBeenCalledWith(undefined, form)
       expect(createFormItemsSpy).toHaveBeenCalledWith({
         form,
-        pathData: { projectCode, appointmentId: 'create', date: form.date },
+        pathData: { projectCode },
         formId,
         offenderSummary: caseDetailsSummary,
         projectType: project.projectType.group,
@@ -178,7 +180,7 @@ describe('ConfirmController', () => {
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
       const project = projectFactory.build({ projectCode })
 
-      mockPageInstance.paths.mockReturnValue({})
+      mockPageInstance.createPaths.mockReturnValue({})
       mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
       mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
 
@@ -251,7 +253,7 @@ describe('ConfirmController', () => {
       const project = projectFactory.build({ projectCode })
       const nextPath = 'next'
       const exitFormSpy = jest.fn().mockReturnValue(nextPath)
-      mockPageInstance.exitForm.mockImplementation(exitFormSpy)
+      mockPageInstance.exitFormForCreate.mockImplementation(exitFormSpy)
       mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -290,17 +292,13 @@ describe('ConfirmController', () => {
         }),
         'user-name',
       )
-      expect(exitFormSpy).toHaveBeenCalledWith(
-        { projectCode, appointmentId: 'create', date: form.date },
-        project,
-        form.originalSearch,
-      )
+      expect(exitFormSpy).toHaveBeenCalledWith({ projectCode, date: undefined }, form.originalSearch)
       expect(response.redirect).toHaveBeenCalledWith(nextPath)
       expect(requestWithNewAppointment.flash).toHaveBeenCalledWith('success', 'Attendance recorded')
     })
 
     it('should create appointment data without attendance data if did not attend', async () => {
-      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.exitFormForCreate.mockReturnValue('next')
       mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const project = projectFactory.build({ projectCode })
@@ -332,7 +330,7 @@ describe('ConfirmController', () => {
 
     describe('start and end times', () => {
       it('uses the form value when the outcome is attended', async () => {
-        mockPageInstance.exitForm.mockReturnValue('next')
+        mockPageInstance.exitFormForCreate.mockReturnValue('next')
         mockPageInstance.isAlertSelected.mockReturnValue(true)
 
         const project = projectFactory.build({ projectCode })
@@ -365,7 +363,7 @@ describe('ConfirmController', () => {
       })
 
       it('submits undefined when the outcome is not attended, ignoring any edited form value', async () => {
-        mockPageInstance.exitForm.mockReturnValue('next')
+        mockPageInstance.exitFormForCreate.mockReturnValue('next')
         mockPageInstance.isAlertSelected.mockReturnValue(true)
 
         const project = projectFactory.build({ projectCode })
@@ -399,7 +397,7 @@ describe('ConfirmController', () => {
     })
 
     it('should set the audit subject to the CRN', async () => {
-      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.exitFormForCreate.mockReturnValue('next')
       mockPageInstance.isAlertSelected.mockReturnValue(true)
 
       const project = projectFactory.build({ projectCode })
@@ -427,7 +425,7 @@ describe('ConfirmController', () => {
     })
 
     it.each([true, false])('uses the alert value selected by the user', async (userSelectedValue: boolean) => {
-      mockPageInstance.exitForm.mockReturnValue('next')
+      mockPageInstance.exitFormForCreate.mockReturnValue('next')
       mockPageInstance.isAlertSelected.mockReturnValue(userSelectedValue)
 
       const project = projectFactory.build({ projectCode })
@@ -471,7 +469,7 @@ describe('ConfirmController', () => {
       }
 
       mockPageInstance.isAlertSelected.mockReturnValue(true)
-      mockPageInstance.updatePath.mockReturnValue('/update/path')
+      mockPageInstance.createPaths.mockReturnValue({ updatePath: '/update/path' })
 
       const project = projectFactory.build({ projectCode })
       const response = createMock<Response>({ locals: { user: { username: 'user-name' } } })
@@ -540,7 +538,7 @@ describe('ConfirmController', () => {
 
         expect(createFormItemsSpy).toHaveBeenCalledWith({
           form,
-          pathData: { projectCode, appointmentId: 'create', date: form.date },
+          pathData: { projectCode },
           formId,
           offenderSummary: caseDetailsSummary,
           projectType: project.projectType.group,

--- a/server/controllers/appointments/confirmController.test.ts
+++ b/server/controllers/appointments/confirmController.test.ts
@@ -129,16 +129,13 @@ describe('ConfirmController', () => {
       const caseDetailsSummary = caseDetailsSummaryFactory.build()
       const project = projectFactory.build({ projectCode })
       const heading = { title: 'Some Name', caption: 'X123456' }
-      const unpaidWorkItems = [{ key: { text: 'Requirement' }, value: { html: 'some requirement summary' } }]
 
       const alertQuestionDetailsSpy = jest.fn().mockReturnValue(pageViewData)
-      const formItemsSpy = jest.fn().mockReturnValue(submittedItems)
-      const createFormItemsSpy = jest.fn().mockReturnValue(unpaidWorkItems)
+      const createFormItemsSpy = jest.fn().mockReturnValue(submittedItems)
       const pathsSpy = jest.fn().mockReturnValue(navigationPaths)
       const offenderHeadingSpy = jest.fn().mockReturnValue(heading)
       mockPageInstance.paths.mockImplementation(pathsSpy)
       mockPageInstance.alertQuestionDetails.mockImplementation(alertQuestionDetailsSpy)
-      mockPageInstance.formItems.mockImplementation(formItemsSpy)
       mockPageInstance.createFormItems.mockImplementation(createFormItemsSpy)
       mockPageInstance.offenderHeading.mockImplementation(offenderHeadingSpy)
 
@@ -164,19 +161,12 @@ describe('ConfirmController', () => {
         offenderSummary: caseDetailsSummary,
         projectType: project.projectType.group,
       })
-      expect(formItemsSpy).toHaveBeenCalledWith(
-        form,
-        { projectCode, appointmentId: 'create', date: form.date },
-        undefined,
-        formId,
-        { includeDateItem: true },
-      )
       expect(offenderHeadingSpy).toHaveBeenCalledWith(caseDetailsSummary.offender)
       expect(response.render).toHaveBeenCalledWith('appointments/update/confirm', {
         heading,
         ...navigationPaths,
         ...pageViewData,
-        submittedItems: [...unpaidWorkItems, ...submittedItems],
+        submittedItems,
         errorList: undefined,
         preventDoubleClick: true,
       })
@@ -191,7 +181,6 @@ describe('ConfirmController', () => {
       mockPageInstance.paths.mockReturnValue({})
       mockPageInstance.alertQuestionDetails.mockReturnValue(pageViewData)
       mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
-      mockPageInstance.formItems.mockReturnValue(submittedItems)
 
       const response = createMock<Response>({
         locals: { user: { username: 'user-name' }, errorMessages },
@@ -515,15 +504,12 @@ describe('ConfirmController', () => {
     })
 
     describe('given validation errors', () => {
-      it('renders the page with submittedItems built from createFormItems and formItems', async () => {
+      it('renders the page with submittedItems built from createFormItems', async () => {
         const project = projectFactory.build({ projectCode })
         const caseDetailsSummary = caseDetailsSummaryFactory.build()
-        const unpaidWorkItems = [{ key: { text: 'Requirement' }, value: { html: 'some requirement summary' } }]
 
-        const createFormItemsSpy = jest.fn().mockReturnValue(unpaidWorkItems)
-        const formItemsSpy = jest.fn().mockReturnValue(submittedItems)
+        const createFormItemsSpy = jest.fn().mockReturnValue(submittedItems)
         mockPageInstance.createFormItems.mockImplementation(createFormItemsSpy)
-        mockPageInstance.formItems.mockImplementation(formItemsSpy)
         mockPageInstance.offenderHeading.mockReturnValue({ title: 'Some Name', caption: 'X123456' })
         mockPageInstance.validationErrors.mockReturnValue({
           hasErrors: true,
@@ -559,17 +545,10 @@ describe('ConfirmController', () => {
           offenderSummary: caseDetailsSummary,
           projectType: project.projectType.group,
         })
-        expect(formItemsSpy).toHaveBeenCalledWith(
-          form,
-          { projectCode, appointmentId: 'create', date: form.date },
-          undefined,
-          formId,
-          { includeDateItem: true },
-        )
         expect(response.render).toHaveBeenCalledWith('appointments/update/confirm', {
           heading: { title: 'Some Name', caption: 'X123456' },
           ...pageViewData,
-          submittedItems: [...unpaidWorkItems, ...submittedItems],
+          submittedItems,
           errorSummary: [{ text: 'error', href: '#alertPractitioner' }],
           errors: { alertPractitioner: { text: 'error' } },
           preventDoubleClick: true,

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -9,6 +9,7 @@ import { AppointmentDto, UpdateAppointmentDto } from '../../@types/shared'
 import {
   AppointmentOrSession,
   AppointmentOrSessionParams,
+  CreateAppointmentPathParams,
   IAppointmentFormPageController,
 } from '../../@types/user-defined'
 import ProjectService from '../../services/projectService'
@@ -33,7 +34,10 @@ export default class ConfirmController implements IAppointmentFormPageController
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const appointmentParams = { projectCode: req.params.projectCode.toString(), appointmentId: 'create' }
+      const pathData: CreateAppointmentPathParams = {
+        projectCode: req.params.projectCode.toString(),
+        date: req.params.date,
+      }
 
       const formId = req.query.form?.toString()
       const form = (await this.appointmentFormService.getForm(
@@ -42,8 +46,8 @@ export default class ConfirmController implements IAppointmentFormPageController
       )) as CreateAppointmentForm
       const page = new ConfirmPage()
 
-      const navigationPaths = page.paths({
-        pathData: appointmentParams,
+      const navigationPaths = page.createPaths({
+        pathData,
         form,
         formId,
       })
@@ -60,7 +64,6 @@ export default class ConfirmController implements IAppointmentFormPageController
 
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
-      const pathData = { ...appointmentParams, date: form.date }
       const submittedItems = page.createFormItems({
         form,
         pathData,
@@ -115,21 +118,20 @@ export default class ConfirmController implements IAppointmentFormPageController
         res.locals.user.username,
       )) as CreateAppointmentForm
 
-      const appointmentParams = {
+      const pathData: CreateAppointmentPathParams = {
         projectCode: req.params.projectCode.toString(),
-        appointmentId: 'create',
-        date: form.date,
+        date: req.params.date,
       }
 
       const page = new ConfirmPage()
 
       const project = await this.projectService.getProject({
         username: res.locals.user.username,
-        projectCode: appointmentParams.projectCode,
+        projectCode: pathData.projectCode,
       })
 
-      const navigationPaths = page.paths({
-        pathData: appointmentParams,
+      const navigationPaths = page.createPaths({
+        pathData,
         form,
         formId,
       })
@@ -144,7 +146,6 @@ export default class ConfirmController implements IAppointmentFormPageController
         outcomeShouldBeAttended: true,
       })
       const preventDoubleClick = true
-      const pathData = { ...appointmentParams, date: form.date }
 
       if (hasErrors) {
         const submittedItems = page.createFormItems({
@@ -190,9 +191,9 @@ export default class ConfirmController implements IAppointmentFormPageController
         }
 
         req.flash('success', 'Attendance recorded')
-        return res.redirect(page.exitForm(appointmentParams, project, form.originalSearch))
+        return res.redirect(page.exitFormForCreate(pathData, form.originalSearch))
       } catch (error) {
-        return catchApiValidationErrorOrPropagate(req, res, error, page.updatePath(appointmentParams, formId))
+        return catchApiValidationErrorOrPropagate(req, res, error, navigationPaths.updatePath)
       }
     }
   }

--- a/server/controllers/appointments/confirmController.ts
+++ b/server/controllers/appointments/confirmController.ts
@@ -61,16 +61,13 @@ export default class ConfirmController implements IAppointmentFormPageController
       const errorList = generateErrorTextList(res.locals.errorMessages)
       const preventDoubleClick = true
       const pathData = { ...appointmentParams, date: form.date }
-      const submittedItems = [
-        ...page.createFormItems({
-          form,
-          pathData,
-          formId,
-          offenderSummary,
-          projectType: projectType.group,
-        }),
-        ...page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
-      ]
+      const submittedItems = page.createFormItems({
+        form,
+        pathData,
+        formId,
+        offenderSummary,
+        projectType: projectType.group,
+      })
 
       res.render('appointments/update/confirm', {
         heading: page.offenderHeading(offenderSummary.offender),
@@ -150,16 +147,13 @@ export default class ConfirmController implements IAppointmentFormPageController
       const pathData = { ...appointmentParams, date: form.date }
 
       if (hasErrors) {
-        const submittedItems = [
-          ...page.createFormItems({
-            form,
-            pathData,
-            formId,
-            offenderSummary,
-            projectType: project.projectType.group,
-          }),
-          ...page.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
-        ]
+        const submittedItems = page.createFormItems({
+          form,
+          pathData,
+          formId,
+          offenderSummary,
+          projectType: project.projectType.group,
+        })
         return res.render('appointments/update/confirm', {
           heading: page.offenderHeading(offenderSummary.offender),
           ...navigationPaths,

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -57,6 +57,61 @@ describe('BaseAppointmentUpdatePage', () => {
     })
   })
 
+  describe('nextForCreate()', () => {
+    it('throws an error when nextPage returns undefined', () => {
+      const page = new PageWithoutNavigationPages()
+
+      expect(() => page.nextForCreate({ projectCode: 'P123' })).toThrow('No next page configured')
+    })
+
+    it('returns the project create path with formId when no date is provided', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.nextForCreate({ projectCode: 'P123', formId: 'form-1' })
+
+      expect(result).toBe(
+        `${paths.projects.create.formSteps({ projectCode: 'P123', page: 'confirm-details' })}?form=form-1`,
+      )
+    })
+
+    it('returns the session create path with formId when a date is provided', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.nextForCreate({ projectCode: 'P123', date: '2026-06-10', formId: 'form-1' })
+
+      expect(result).toBe(
+        `${paths.sessions.create.formSteps({ projectCode: 'P123', date: '2026-06-10', page: 'confirm-details' })}?form=form-1`,
+      )
+    })
+  })
+
+  describe('exitFormForCreate()', () => {
+    it('returns a project link when no date is present', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.exitFormForCreate({ projectCode: 'P123' })
+
+      expect(result).toBe(paths.projects.show({ projectCode: 'P123' }))
+    })
+
+    it('returns a session link when a date is present', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.exitFormForCreate({ projectCode: 'P123', date: '2026-06-10' })
+
+      expect(result).toBe(paths.sessions.show({ projectCode: 'P123', date: '2026-06-10' }))
+    })
+
+    it('includes original search params in the link', () => {
+      const page = new PageWithNextPage()
+      const originalSearch = { provider: 'provider' }
+
+      const result = page.exitFormForCreate({ projectCode: 'P123' }, originalSearch)
+
+      expect(result).toBe(`${paths.projects.show({ projectCode: 'P123' })}?provider=provider`)
+    })
+  })
+
   describe('viewData', () => {
     describe('heading', () => {
       it('returns heading containing offender details when appointment is provided', () => {
@@ -211,6 +266,64 @@ describe('BaseAppointmentUpdatePage', () => {
       })
 
       expect(result.backLink).toBe('/appointments/P123/1/choose-supervisor?form=form-1&provider=provider&team=team')
+    })
+  })
+
+  describe('createPaths()', () => {
+    it('returns backLink, updatePath and form for the project variant', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.createPaths({
+        pathData: { projectCode: 'P123' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result).toEqual({
+        backLink: `${paths.projects.create.formSteps({ projectCode: 'P123', page: 'choose-supervisor' })}?form=form-1`,
+        updatePath: `${paths.projects.create.formSteps({ projectCode: 'P123', page: 'attendance-outcome' })}?form=form-1`,
+        form: 'form-1',
+      })
+    })
+
+    it('returns backLink, updatePath and form for the session variant', () => {
+      const page = new PageWithNextPage()
+
+      const result = page.createPaths({
+        pathData: { projectCode: 'P123', date: '2026-06-10' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result).toEqual({
+        backLink: `${paths.sessions.create.formSteps({ projectCode: 'P123', date: '2026-06-10', page: 'choose-supervisor' })}?form=form-1`,
+        updatePath: `${paths.sessions.create.formSteps({ projectCode: 'P123', date: '2026-06-10', page: 'attendance-outcome' })}?form=form-1`,
+        form: 'form-1',
+      })
+    })
+
+    it('exits the form to the project page when there is no back page configured and no date', () => {
+      const page = new PageWithoutNavigationPages()
+
+      const result = page.createPaths({
+        pathData: { projectCode: 'P123' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result.backLink).toBe(paths.projects.show({ projectCode: 'P123' }))
+    })
+
+    it('exits the form to the session page when there is no back page configured and a date is present', () => {
+      const page = new PageWithoutNavigationPages()
+
+      const result = page.createPaths({
+        pathData: { projectCode: 'P123', date: '2026-06-10' },
+        form,
+        formId: 'form-1',
+      })
+
+      expect(result.backLink).toBe(paths.sessions.show({ projectCode: 'P123', date: '2026-06-10' }))
     })
   })
 

--- a/server/pages/appointments/baseAppointmentUpdatePage.test.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.test.ts
@@ -47,14 +47,6 @@ describe('BaseAppointmentUpdatePage', () => {
 
       expect(() => page.next({ projectCode: 'P123' })).toThrow('Path must have an appointment ID or session date')
     })
-
-    it('returns the create path with formId when appointmentId is "create"', () => {
-      const page = new PageWithNextPage()
-
-      const result = page.next({ projectCode: 'P123', appointmentId: 'create', formId: 'form-1' })
-
-      expect(result).toBe(`${paths.appointments.create({ projectCode: 'P123', page: 'confirm-details' })}?form=form-1`)
-    })
   })
 
   describe('nextForCreate()', () => {
@@ -234,22 +226,6 @@ describe('BaseAppointmentUpdatePage', () => {
       expect(result).toEqual({
         backLink: `${paths.sessions.update({ projectCode: 'P123', date: '2026-06-10', page: 'choose-supervisor' })}?form=form-1`,
         updatePath: `${paths.sessions.update({ projectCode: 'P123', date: '2026-06-10', page: 'attendance-outcome' })}?form=form-1`,
-        form: 'form-1',
-      })
-    })
-
-    it('returns backLink and updatePath using the create path when appointmentId is "create"', () => {
-      const page = new PageWithNextPage()
-
-      const result = page.paths({
-        pathData: { projectCode: 'P123', appointmentId: 'create' },
-        form,
-        formId: 'form-1',
-      })
-
-      expect(result).toEqual({
-        backLink: `${paths.appointments.create({ projectCode: 'P123', page: 'choose-supervisor' })}?form=form-1`,
-        updatePath: `${paths.appointments.create({ projectCode: 'P123', page: 'attendance-outcome' })}?form=form-1`,
         form: 'form-1',
       })
     })

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -3,6 +3,7 @@ import {
   AppointmentOrSession,
   AppointmentOrSessionParams,
   AppointmentUpdatePagePathData,
+  CreateAppointmentPathParams,
   GovUkSummaryList,
   PageHeader,
 } from '../../@types/user-defined'
@@ -47,6 +48,13 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     originalSearch?: Record<string, string>,
   ): string {
     if (project?.projectType.group === 'GROUP') {
+      return SessionUtils.getSessionPath(pathData, originalSearch)
+    }
+    return pathWithQuery(paths.projects.show({ projectCode: pathData.projectCode }), originalSearch)
+  }
+
+  exitFormForCreate(pathData: CreateAppointmentPathParams, originalSearch?: Record<string, string>): string {
+    if (pathData.date) {
       return SessionUtils.getSessionPath(pathData, originalSearch)
     }
     return pathWithQuery(paths.projects.show({ projectCode: pathData.projectCode }), originalSearch)
@@ -98,6 +106,78 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     }
 
     throw new Error('Path must have an appointment ID or session date')
+  }
+
+  protected nextPageForCreate(form?: AppointmentOutcomeForm): AppointmentPage | undefined {
+    return this.nextPage(form)
+  }
+
+  protected backPageForCreate(
+    pathData: CreateAppointmentPathParams,
+    form?: AppointmentOutcomeForm,
+  ): AppointmentPage | undefined {
+    return this.backPage(pathData, form)
+  }
+
+  nextForCreate({
+    projectCode,
+    date,
+    formId,
+    form,
+  }: {
+    projectCode: string
+    date?: string
+    formId?: string
+    form?: AppointmentOutcomeForm
+  }): string {
+    const nextPage = this.nextPageForCreate(form)
+
+    if (!nextPage) {
+      throw new Error('No next page configured')
+    }
+
+    return this.buildCreatePath({ projectCode, date }, nextPage, formId)
+  }
+
+  createPaths({
+    pathData,
+    form,
+    formId,
+  }: {
+    pathData: CreateAppointmentPathParams
+    form: AppointmentOutcomeForm
+    formId?: string
+  }): AppointmentUpdatePagePathData {
+    return {
+      backLink: this.backPathForCreate(pathData, formId, form),
+      updatePath: this.buildCreatePath(pathData, this.page, formId),
+      form: formId,
+    }
+  }
+
+  private backPathForCreate(
+    pathData: CreateAppointmentPathParams,
+    formId?: string,
+    form?: AppointmentOutcomeForm,
+  ): string {
+    const backPage = this.backPageForCreate(pathData, form)
+
+    if (!backPage) {
+      return this.exitFormForCreate(pathData)
+    }
+
+    return this.buildCreatePath(pathData, backPage, formId)
+  }
+
+  protected buildCreatePath(pathData: CreateAppointmentPathParams, page: AppointmentPage, formId?: string): string {
+    if (pathData.date) {
+      return this.pathWithFormId(
+        paths.sessions.create.formSteps({ projectCode: pathData.projectCode, date: pathData.date, page }),
+        formId,
+      )
+    }
+
+    return this.pathWithFormId(paths.projects.create.formSteps({ projectCode: pathData.projectCode, page }), formId)
   }
 
   updateForm(form: AppointmentOutcomeForm, query: TBody, context: TContext): AppointmentOutcomeForm {

--- a/server/pages/appointments/baseAppointmentUpdatePage.ts
+++ b/server/pages/appointments/baseAppointmentUpdatePage.ts
@@ -12,7 +12,7 @@ import Offender from '../../models/offender'
 import paths from '../../paths'
 import SessionUtils from '../../utils/sessionUtils'
 import { pathWithQuery } from '../../utils/utils'
-import { AppointmentPage, NEW_APPOINTMENT_ID } from './pathMap'
+import { AppointmentPage } from './pathMap'
 import PageWithValidation from '../pageWithValidation'
 import DateTimeFormats from '../../utils/dateTimeUtils'
 
@@ -77,10 +77,6 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
 
     if (!nextPage) {
       throw new Error('No next page configured')
-    }
-
-    if (appointmentId === NEW_APPOINTMENT_ID) {
-      return this.pathWithFormId(paths.appointments.create({ projectCode, page: nextPage }), formId)
     }
 
     if (appointmentId) {
@@ -286,9 +282,6 @@ export default abstract class BaseAppointmentUpdatePage<TBody = unknown, TContex
     formId?: string,
     originalSearch?: Record<string, string>,
   ): string {
-    if (pathData.appointmentId === NEW_APPOINTMENT_ID) {
-      return this.pathWithFormId(paths.appointments.create({ projectCode: pathData.projectCode, page }), formId)
-    }
     if (pathData.appointmentId) {
       return pathWithQuery(
         this.pathWithFormId(

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -10,7 +10,6 @@ import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormServ
 import ChooseSupervisorPage from './chooseSupervisorPage'
 import providerTeamSummaryFactory from '../../testutils/factories/providerTeamSummaryFactory'
 import Offender from '../../models/offender'
-import { NEW_APPOINTMENT_ID } from './pathMap'
 
 jest.mock('../../models/offender')
 
@@ -200,25 +199,6 @@ describe('ChooseSupervisorPage', () => {
         projectCode: appointment.projectCode,
         page: 'choose-supervisor',
       })
-    })
-
-    it('should return an exit link back link when appointmentId is the new appointment id', () => {
-      jest.spyOn(paths.appointments, 'create')
-      jest.spyOn(paths.projects, 'show')
-
-      const result = page.commonViewData({
-        pathData: {
-          appointmentId: NEW_APPOINTMENT_ID,
-          projectCode: appointment.projectCode,
-          date: '2026-01-20',
-        },
-        appointmentOrSession: { appointment },
-        form,
-        formId: 'formId',
-      })
-
-      expect(result.backLink).toBe(pathWithQuery)
-      expect(paths.appointments.create).toHaveBeenCalledWith({ projectCode: appointment.projectCode, page: 'date' })
     })
 
     it('should use session paths when appointmentOrSession is a session', () => {

--- a/server/pages/appointments/chooseSupervisorPage.test.ts
+++ b/server/pages/appointments/chooseSupervisorPage.test.ts
@@ -246,6 +246,24 @@ describe('ChooseSupervisorPage', () => {
     })
   })
 
+  describe('createPaths()', () => {
+    it('should return the date page as the create-mode back link', () => {
+      const page = new ChooseSupervisorPage()
+      const form = appointmentOutcomeFormFactory.build()
+
+      jest.spyOn(paths.projects.create, 'formSteps')
+
+      const result = page.createPaths({
+        pathData: { projectCode: 'P123' },
+        form,
+        formId: 'formId',
+      })
+
+      expect(result.backLink).toBe(pathWithQuery)
+      expect(paths.projects.create.formSteps).toHaveBeenCalledWith({ projectCode: 'P123', page: 'date' })
+    })
+  })
+
   describe('validate', () => {
     it('has no errors if team has value and supervisor has value', () => {
       const query = { team: 'X123', supervisor: 'Jane' }

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -90,6 +90,10 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<Supe
     return 'select-people'
   }
 
+  protected backPageForCreate(): AppointmentPage {
+    return 'date'
+  }
+
   protected nextPage(): AppointmentPage {
     return 'choose-project'
   }

--- a/server/pages/appointments/chooseSupervisorPage.ts
+++ b/server/pages/appointments/chooseSupervisorPage.ts
@@ -8,7 +8,7 @@ import {
 import { AppointmentOutcomeForm } from '../../services/forms/appointmentFormService'
 import GovUkSelectInput from '../../forms/GovUkSelectInput'
 import BaseAppointmentUpdatePage from './baseAppointmentUpdatePage'
-import { AppointmentPage, NEW_APPOINTMENT_ID } from './pathMap'
+import { AppointmentPage } from './pathMap'
 
 interface ViewData {
   teamItems: GovUkSelectOption[]
@@ -80,10 +80,6 @@ export default class ChooseSupervisorPage extends BaseAppointmentUpdatePage<Supe
   }
 
   protected backPage(params: AppointmentOrSessionParams): AppointmentPage {
-    if (params.appointmentId === NEW_APPOINTMENT_ID) {
-      return 'date'
-    }
-
     if (params.appointmentId) {
       return 'appointment-details'
     }

--- a/server/pages/appointments/confirmPage.test.ts
+++ b/server/pages/appointments/confirmPage.test.ts
@@ -655,38 +655,23 @@ describe('ConfirmPage', () => {
       offenderMock.mockImplementation(() => ({ details: { description: 'John Smith (X123456)' } }))
     })
 
-    it('returns only a person item when unpaidWorkDetails is an empty array', () => {
+    it('does not include a Requirement item when unpaidWorkDetails is an empty array', () => {
       const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
       const offender = offenderFullFactory.build()
+      const pathData = { projectCode: 'XY', appointmentId: '1' }
 
       const result = page.createFormItems({
         form,
-        pathData: { projectCode: 'XY', appointmentId: '1' },
+        pathData,
         formId: 'formId',
         offenderSummary: caseDetailsSummaryFactory.build({ offender, unpaidWorkDetails: [] }),
         projectType: 'INDIVIDUAL',
       })
 
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
-                  form: 'formId',
-                }),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
-        },
-      ])
+      expect(result).not.toContainEqual(expect.objectContaining({ key: { text: 'Requirement' } }))
     })
 
-    it('returns only a person item when unpaidWorkDetails has fewer than 2 items', () => {
+    it('does not include a Requirement item when unpaidWorkDetails has fewer than 2 items', () => {
       const form = { ...appointmentOutcomeFormFactory.build(), crn: 'X123456', deliusEventNumber: '1' }
       const requirement = unpaidWorkDetailsFactory.build({ eventNumber: 1 })
       const offender = offenderFullFactory.build({ forename: 'John', surname: 'Smith', crn: 'X123456' })
@@ -699,23 +684,7 @@ describe('ConfirmPage', () => {
         projectType: 'INDIVIDUAL',
       })
 
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
-                  form: 'formId',
-                }),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
-        },
-      ])
+      expect(result).not.toContainEqual(expect.objectContaining({ key: { text: 'Requirement' } }))
     })
 
     it('returns a person item using the sessions find a person path when projectType is GROUP', () => {
@@ -735,24 +704,21 @@ describe('ConfirmPage', () => {
         projectType: 'GROUP',
       })
 
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(
-                  paths.sessions.create.findAPerson({ projectCode: 'XY', date: '2026-01-20' }),
-                  { form: 'formId' },
-                ),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
+      expect(result).toContainEqual({
+        key: { text: 'Person' },
+        value: { text: 'John Smith (X123456)' },
+        actions: {
+          items: [
+            {
+              href: Utils.pathWithQuery(paths.sessions.create.findAPerson({ projectCode: 'XY', date: '2026-01-20' }), {
+                form: 'formId',
+              }),
+              text: 'Change',
+              visuallyHiddenText: 'person',
+            },
+          ],
         },
-      ])
+      })
     })
 
     it('returns an unpaid work summary item using the projects requirement path when projectType is INDIVIDUAL', () => {
@@ -792,24 +758,7 @@ describe('ConfirmPage', () => {
           form: 'formId',
         }),
       )
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
-                  form: 'formId',
-                }),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
-        },
-        unpaidWorkItem,
-      ])
+      expect(result).toContainEqual(unpaidWorkItem)
     })
 
     it('returns an unpaid work summary item using the sessions requirement path when projectType is GROUP', () => {
@@ -852,25 +801,7 @@ describe('ConfirmPage', () => {
           },
         ),
       )
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(
-                  paths.sessions.create.findAPerson({ projectCode: 'XY', date: '2026-01-20' }),
-                  { form: 'formId' },
-                ),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
-        },
-        unpaidWorkItem,
-      ])
+      expect(result).toContainEqual(unpaidWorkItem)
     })
 
     it('passes an undefined requirement when no unpaidWorkDetails match the deliusEventNumber', () => {
@@ -910,24 +841,7 @@ describe('ConfirmPage', () => {
           form: 'formId',
         }),
       )
-      expect(result).toEqual([
-        {
-          key: { text: 'Person' },
-          value: { text: 'John Smith (X123456)' },
-          actions: {
-            items: [
-              {
-                href: Utils.pathWithQuery(paths.projects.create.findAPerson({ projectCode: 'XY' }), {
-                  form: 'formId',
-                }),
-                text: 'Change',
-                visuallyHiddenText: 'person',
-              },
-            ],
-          },
-        },
-        unpaidWorkItem,
-      ])
+      expect(result).toContainEqual(unpaidWorkItem)
     })
   })
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -38,6 +38,7 @@ interface Query {
 
 type ItemsOptions = { includeDateItem: boolean }
 type ValidationContext = { form: AppointmentOutcomeForm; outcomeShouldBeAttended?: boolean }
+type PathBuilder = (pathData: AppointmentOrSessionParams, page: AppointmentPage, formId?: string) => string
 
 export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, ValidationContext> {
   protected page: AppointmentPage = 'confirm-details'
@@ -165,12 +166,13 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
     appointmentOrSession: AppointmentOrSession | undefined,
     formId?: string,
     options?: ItemsOptions,
+    buildPath: PathBuilder = this.buildPath.bind(this),
   ): GovUkSummaryListItem[] {
     const { appointment, session } = appointmentOrSession ?? {}
     const items: GovUkSummaryListItem[] = []
 
     if (session) {
-      items.push(...this.buildOffenderItem(form, session.appointmentSummaries, pathData, formId))
+      items.push(...this.buildOffenderItem(form, session.appointmentSummaries, pathData, formId, buildPath))
     }
 
     if (options?.includeDateItem) {
@@ -184,7 +186,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
         actions: {
           items: [
             {
-              href: this.buildPath(pathData, 'date', formId),
+              href: buildPath(pathData, 'date', formId),
               text: 'Change',
               visuallyHiddenText: 'date',
             },
@@ -205,7 +207,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
           actions: {
             items: [
               {
-                href: this.buildPath(pathData, 'choose-supervisor', formId),
+                href: buildPath(pathData, 'choose-supervisor', formId),
                 text: 'Change',
                 visuallyHiddenText: 'supervising officer',
               },
@@ -222,7 +224,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
           actions: {
             items: [
               {
-                href: this.buildPath(pathData, 'choose-project', formId),
+                href: buildPath(pathData, 'choose-project', formId),
                 text: 'Change',
                 visuallyHiddenText: 'project team',
               },
@@ -239,7 +241,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
           actions: {
             items: [
               {
-                href: this.buildPath(pathData, 'choose-project', formId),
+                href: buildPath(pathData, 'choose-project', formId),
                 text: 'Change',
                 visuallyHiddenText: 'project',
               },
@@ -254,7 +256,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
           actions: {
             items: [
               {
-                href: this.buildPath(pathData, 'attendance-outcome', formId),
+                href: buildPath(pathData, 'attendance-outcome', formId),
                 text: 'Change',
                 visuallyHiddenText: 'attendance outcome',
                 attributes: { id: 'outcome' },
@@ -278,7 +280,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
             actions: {
               items: [
                 {
-                  href: this.buildPath(pathData, 'log-hours', formId),
+                  href: buildPath(pathData, 'log-hours', formId),
                   text: 'Change',
                   visuallyHiddenText: 'start and end time',
                 },
@@ -295,7 +297,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
             actions: {
               items: [
                 {
-                  href: this.buildPath(pathData, 'log-compliance', formId),
+                  href: buildPath(pathData, 'log-compliance', formId),
                   text: 'Change',
                   visuallyHiddenText: 'compliance',
                 },
@@ -311,7 +313,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
     items.push(
       ...NotesUtils.checkYourAnswersRows(
         form,
-        this.buildPath(pathData, 'attendance-outcome', formId),
+        buildPath(pathData, 'attendance-outcome', formId),
         appointment,
         !isSession,
       ),
@@ -360,6 +362,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
     appointmentSummaries: Array<AppointmentSummaryDto>,
     pathData: AppointmentOrSessionParams,
     formId: string,
+    buildPath: PathBuilder,
   ): Array<GovUkSummaryListItem> {
     const offenderDescriptions = form.appointments
       ?.map(appointment => {
@@ -384,7 +387,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
         actions: {
           items: [
             {
-              href: this.buildPath(pathData, 'select-people', formId),
+              href: buildPath(pathData, 'select-people', formId),
               text: 'Change',
               visuallyHiddenText: 'people',
             },

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -134,7 +134,7 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
     return [
       personItem,
       ...this.requirementItems({ form, pathData, formId, offenderSummary, pathNamespace }),
-      ...this.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+      ...this.formItems(form, pathData, undefined, formId, { includeDateItem: true }, this.buildCreatePath.bind(this)),
     ]
   }
 

--- a/server/pages/appointments/confirmPage.ts
+++ b/server/pages/appointments/confirmPage.ts
@@ -131,7 +131,11 @@ export default class ConfirmPage extends BaseAppointmentUpdatePage<Query, Valida
       },
     }
 
-    return [personItem, ...this.requirementItems({ form, pathData, formId, offenderSummary, pathNamespace })]
+    return [
+      personItem,
+      ...this.requirementItems({ form, pathData, formId, offenderSummary, pathNamespace }),
+      ...this.formItems(form, pathData, undefined, formId, { includeDateItem: true }),
+    ]
   }
 
   private requirementItems({

--- a/server/pages/appointments/pathMap.ts
+++ b/server/pages/appointments/pathMap.ts
@@ -1,8 +1,6 @@
 import { FormPageHandlerMethod } from '../../@types/user-defined'
 import { Page } from '../../services/auditService'
 
-export const NEW_APPOINTMENT_ID = 'create'
-
 export type AppointmentFormPage =
   | 'choose-supervisor'
   | 'attendance-outcome'

--- a/server/paths/createAppointmentPaths.ts
+++ b/server/paths/createAppointmentPaths.ts
@@ -6,5 +6,6 @@ export default function createAppointmentPaths<Pattern extends `/${string}`>(bas
     createAppointment: createPath.path(':crn/:deliusEventNumber'),
     findAPerson: createPath.path('/find-a-person'),
     requirement: createPath.path('/:crn/requirement'),
+    formSteps: createPath.path(':page'),
   }
 }

--- a/server/paths/index.ts
+++ b/server/paths/index.ts
@@ -43,7 +43,6 @@ const paths = {
     unableToCreditTime: courseCompletionsShowPath.path('unable-to-credit-time'),
   },
   appointments: {
-    create: projectAppointmentsPath.path('create/:page'),
     update: appointmentPath.path(':page'),
     travelTime: {
       index: appointmentsPath.path('attended'),

--- a/server/routes/appointment.ts
+++ b/server/routes/appointment.ts
@@ -4,7 +4,6 @@ import type { Controllers } from '../controllers'
 import { Page } from '../services/auditService'
 import actions from './actions'
 import { APPOINTMENT_FORM_PAGES_AUDIT_MAP, AppointmentFormPage } from '../pages/appointments/pathMap'
-import featureFlagMiddleware from './featureFlagMiddleware'
 
 const singleAppointmentFormPages: Array<AppointmentFormPage> = [
   'choose-supervisor',
@@ -47,15 +46,6 @@ export default function appointmentRoutes(controllers: Controllers, router: Rout
 
   singleAppointmentFormPages.forEach((page: AppointmentFormPage) => {
     const controller = updateControllers[page]
-
-    const createRoute = paths.appointments.create.pattern.replace(':page', page)
-
-    get(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.create()], {
-      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].create,
-    })
-    post(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.submitCreate()], {
-      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].submitCreate,
-    })
 
     const updateRoute = paths.appointments.update.pattern.replace(':page', page)
 

--- a/server/routes/project.ts
+++ b/server/routes/project.ts
@@ -7,6 +7,17 @@ import featureFlagMiddleware from './featureFlagMiddleware'
 import { Controllers } from '../controllers'
 import requirementMiddleware from './requirementMiddleware'
 import buildRequirementPagePaths from '../paths/requirementPagePaths'
+import { APPOINTMENT_FORM_PAGES_AUDIT_MAP, AppointmentFormPage } from '../pages/appointments/pathMap'
+
+const createAppointmentFormPages: Array<AppointmentFormPage> = [
+  'choose-supervisor',
+  'choose-project',
+  'attendance-outcome',
+  'log-hours',
+  'log-compliance',
+  'confirm-details',
+  'date',
+]
 
 export default function projectRoutes(controllers: Controllers, router: Router, services: Services): Router {
   const { get, post } = actions(router)
@@ -77,6 +88,18 @@ export default function projectRoutes(controllers: Controllers, router: Router, 
   )
 
   get(paths.projects.create.createAppointment.pattern, appointments.appointmentsController.create())
+
+  createAppointmentFormPages.forEach((page: AppointmentFormPage) => {
+    const controller = appointments.updateControllers[page]
+    const createRoute = paths.projects.create.formSteps.pattern.replace(':page', page)
+
+    get(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.create()], {
+      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].create,
+    })
+    post(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.submitCreate()], {
+      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].submitCreate,
+    })
+  })
 
   return router
 }

--- a/server/routes/session.ts
+++ b/server/routes/session.ts
@@ -18,6 +18,16 @@ const bulkUpdateAppointmentFormPages: Array<AppointmentFormPage> = [
   'confirm-details',
 ]
 
+const createAppointmentFormPages: Array<AppointmentFormPage> = [
+  'choose-supervisor',
+  'choose-project',
+  'attendance-outcome',
+  'log-hours',
+  'log-compliance',
+  'confirm-details',
+  'date',
+]
+
 export default function sessionRoutes(controllers: Controllers, router: Router, services: Services): Router {
   const selectPeopleRoute = paths.sessions.update.pattern.replace(':page', 'select-people')
 
@@ -110,6 +120,18 @@ export default function sessionRoutes(controllers: Controllers, router: Router, 
   })
 
   get(paths.sessions.create.createAppointment.pattern, appointments.appointmentsController.create())
+
+  createAppointmentFormPages.forEach((page: AppointmentFormPage) => {
+    const controller = appointments.updateControllers[page]
+    const createRoute = paths.sessions.create.formSteps.pattern.replace(':page', page)
+
+    get(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.create()], {
+      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].create,
+    })
+    post(createRoute, [featureFlagMiddleware('createAppointmentEnabled'), controller.submitCreate()], {
+      auditEvent: APPOINTMENT_FORM_PAGES_AUDIT_MAP[page].submitCreate,
+    })
+  })
 
   return router
 }


### PR DESCRIPTION
## Context

This introduces the concept of entirely separate paths for creating an appointment for a session or for a project.
The underlying form behaviour/implementation is the same, this just changes navigation.

- Can navigate to the original session or project using the presence or absence of a date, rather than the project type 
- Can ensure we navigate to and from the original session using the date in the params (as relying the the date in the form navigates to a different session)
- Can move towards removing dependency on fetching a project using the project code in the path params for navigation (needed for creating an appointment for a person page).
- Keeps the paths the same structure moving forwards from the requirement page - rather than jumping into a different URL structure.


### Screenshots of UI changes

## Pre merge

- [ ] Consider running the [test script](https://github.com/ministryofjustice/hmpps-community-payback-supervisors-ui?tab=readme-ov-file#run-tests) against local changes.

<!-- ```
$ ./script/test
``` -->
